### PR TITLE
Display the correct license on generated image pages

### DIFF
--- a/static-sitegen/scripts/generate_image_page.py
+++ b/static-sitegen/scripts/generate_image_page.py
@@ -14,6 +14,11 @@ from utils import format_for_html
 logger = logging.getLogger(os.path.basename(__file__))
 
 
+LICENSE_URI_LOOKUP = {
+    "CC0": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "CC BY 4.0": "https://creativecommons.org/licenses/by/4.0/"
+}
+
 env = Environment(
     loader = FileSystemLoader("templates"),
     autoescape=select_autoescape()
@@ -141,8 +146,13 @@ def generate_image_page_html(accession_id, image_id):
     neuroglancer_uri = generate_neuroglancer_link(zarr_uri)
 
     bia_image.attributes = sort_dict(bia_image.attributes)
+
+
+    license_uri = LICENSE_URI_LOOKUP.get(bia_study.license, "Unknown")
+
     rendered = template.render(
         study=bia_study,
+        license_uri=license_uri,
         image=bia_image,
         image_alias=image_alias,
         zarr_uri=zarr_uri,

--- a/static-sitegen/templates/image-landing.html.j2
+++ b/static-sitegen/templates/image-landing.html.j2
@@ -30,7 +30,7 @@
                     <p>Study Title: {{ study.title }}</p>
                     <p>By: {{ authors }}</p>
                     <p>Organism: {{ study.organism }}</p>
-                    <p>License: <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a></p>
+                    <p>License: <a href={{ license_uri }}>{{ study.license }}</a></p>
                     <figure class="vf-figure vf-figure--align vf-figure--align-centered">
                         <img class="vf-figure__image" src="{{ image_uri }}">
                     </figure>  

--- a/tools/scripts/assign_images_from_yaml.py
+++ b/tools/scripts/assign_images_from_yaml.py
@@ -1,0 +1,160 @@
+import uuid
+import hashlib
+import logging
+
+import parse
+import typer
+from ruamel.yaml import YAML
+
+from bia_integrator_core.models import BIAImage, BIAImageRepresentation
+from bia_integrator_core.integrator import load_and_annotate_study
+from bia_integrator_core.interface import persist_image
+
+from bia_integrator_tools.representations import StructuredFileset
+
+
+app = typer.Typer()
+
+
+logger = logging.getLogger(__file__)
+
+
+def find_fileref_structure_mapping(bia_study, parse_template):
+    """Generate the mapping betweeen image structure (e.g. Z plane and channel)
+    and file reference. Example for channels:
+    
+    "structure": {
+        "C_0000": "d93c4a37-a3b4-460d-a335-ab51d6808e5f",
+        "C_0001": "4270be60-51e5-44f6-9607-bfe9172344fe",
+        "C_0002": "a7f24a56-9c91-4125-b633-752329af6e99",
+        "C_0003": "12980c81-1075-449c-880b-37e1beb6f4da"
+    },
+    "pattern": "C_<0000-0003>.tif"
+    """
+
+    structure = {}
+    for fid, fileref in bia_study.file_references.items():
+        result = parse.parse(parse_template, fileref.name)
+        if result:
+            k = "Z_{z:04d}".format(z=result.named['z'])
+            structure[k] = fid
+
+    pattern = "Z_<0001-0059>.tif"
+
+    return structure, pattern
+
+
+def find_fileref_structure_mapping_complex(bia_study, parse_template):
+    """Generate the mapping betweeen image structure (e.g. Z plane and channel)
+    and file reference. Example for channels:
+    
+    "structure": {
+        "C_0000": "d93c4a37-a3b4-460d-a335-ab51d6808e5f",
+        "C_0001": "4270be60-51e5-44f6-9607-bfe9172344fe",
+        "C_0002": "a7f24a56-9c91-4125-b633-752329af6e99",
+        "C_0003": "12980c81-1075-449c-880b-37e1beb6f4da"
+    },
+    "pattern": "C_<0000-0003>.tif"
+    """
+
+    component_map = {
+        "Axon": "C_0000",
+        "Oligodendrocyte": "C_0001",
+        "Nucleus": "C_0002"
+    }
+
+    fileref_ids = []
+    structure = {}
+    for fid, fileref in bia_study.file_references.items():
+        result = parse.parse(parse_template, fileref.name)
+        if result:
+            component = result.named["component"]
+            if component in component_map:
+                structure_key = component_map[component]
+                structure[structure_key] = fid
+                fileref_ids.append(fid)
+
+    pattern = "C_<0000-0002>.tif"
+
+    image_id = identifier_from_fileref_ids(fileref_ids)
+
+
+    return structure, pattern, image_id
+
+
+# FIXME - library code
+def identifier_from_fileref_ids(fileref_ids):
+    hash_input = ''.join(fileref_ids)
+    hexdigest = hashlib.md5(hash_input.encode("utf-8")).hexdigest()
+    image_id_as_uuid = uuid.UUID(version=4, hex=hexdigest)
+    image_id = str(image_id_as_uuid)    
+
+    return image_id
+
+
+
+
+@app.command()
+def assign_images_from_yaml(yaml_fpath):
+    logging.basicConfig(level=logging.INFO)
+
+    yaml = YAML()
+    with open(yaml_fpath) as fh:
+        raw_config = yaml.load(fh)
+
+    accession_id = raw_config['accession_id']
+    bia_study = load_and_annotate_study(accession_id)
+
+    # by_plane = {}
+    fileref_map = {}
+    for name, image_description in raw_config['images'].items():
+        parse_template = image_description['parse_template']
+
+        for fid, fileref in bia_study.file_references.items():
+            result = parse.parse(parse_template, fileref.name)
+            if result:
+                z = result.named['z']
+                # map_key = (0, 0, z)
+                # fileref_map[map_key] = fid
+                # by_plane[z] = fid
+                fileref_map[fid] = (0, 0, z)
+
+
+        # fileref_ids = list(by_plane.values())
+        fileref_ids = list(fileref_map.keys())
+        filerefs = [bia_study.file_references[fid] for fid in fileref_ids]
+
+        image_id = identifier_from_fileref_ids(fileref_ids)
+
+        sf = StructuredFileset(
+            # by_plane=by_plane,
+            fileref_map=fileref_map,
+            attributes=image_description['attributes']
+        )
+
+        image_rep = BIAImageRepresentation(
+            accession_id=accession_id,
+            image_id=image_id,
+            size=sum(fileref.size_in_bytes for fileref in filerefs),
+            uri=[fileref.uri for fileref in filerefs],
+            attributes={
+                "structured_fileset": sf.dict()
+            },
+            type="structured_fileset",
+            dimensions=None,
+            rendering=None
+        )       
+
+        image = BIAImage(
+            id=image_id,
+            accession_id=accession_id,
+            original_relpath=name,
+            name=name,
+            representations=[image_rep]
+        )
+
+        persist_image(image)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/scripts/convert_from_structured_fileset.py
+++ b/tools/scripts/convert_from_structured_fileset.py
@@ -1,0 +1,85 @@
+"""Convert an image from a structured fileref representation (i.e. multiple input
+files together with information on how they relate, such as channel or timepoint
+numbers) into OME-Zarr."""
+
+import logging
+import tempfile
+from pathlib import Path
+
+import typer
+
+from bia_integrator_core.integrator import load_and_annotate_study
+from bia_integrator_tools.utils import get_image_rep_by_type
+from bia_integrator_tools.io import stage_fileref_and_get_fpath
+from bia_integrator_tools.conversion import run_zarr_conversion
+from bia_integrator_tools.representations import StructuredFileset
+
+logger = logging.getLogger(__file__)
+
+
+app = typer.Typer()
+
+
+def fileref_map_to_pattern(fileref_map):
+    """Determine the pattern needed to enable bioformats to load the components
+    of a structured fileset, e.g. for conversion."""
+
+    all_positions = list(fileref_map.values())
+    tvals, cvals, zvals = zip(*all_positions)
+
+    zmin = min(zvals)
+    zmax = max(zvals)
+    cmin = min(cvals)
+    cmax = max(cvals)
+    tmin = min(tvals)
+    tmax = max(tvals)
+
+    pattern = f"T<{tmin:04d}-{tmax:04d}>_C<{cmin:04d}-{cmax:04d}>_Z<{zmin:04d}-{zmax:04d}>.tif"
+
+    return pattern
+
+
+@app.command('structured-fileset-to-local')
+def convert_structured_fileset(accession_id: str, image_id: str,  dst_dir_basepath: str):
+    logging.basicConfig(level=logging.INFO)
+
+    bia_study = load_and_annotate_study(accession_id)
+    image_rep = get_image_rep_by_type(accession_id, image_id, 'structured_fileset')
+
+    assert image_rep, "Can't find image representation"
+    sf = StructuredFileset.parse_obj(image_rep.attributes['structured_fileset'])
+
+    # n_items = len(image_rep.attributes['structure'])
+    dst_dir_basepath = Path(dst_dir_basepath)
+
+    tmpdir_obj = tempfile.TemporaryDirectory()
+    tmpdir_path = Path(tmpdir_obj.name)
+
+    for fileref_id, position in sf.fileref_map.items():
+        # print(z, fileref_id)
+        t, c, z = position
+        label = "T{t:04d}_C{c:04d}_Z{z:04d}".format(z=z, c=c, t=t)
+
+        fileref = bia_study.file_references[fileref_id]
+        input_fpath = stage_fileref_and_get_fpath(accession_id, fileref)
+
+        suffix = input_fpath.suffix
+
+        logger.info(f"Linking {input_fpath}")
+        target_path = tmpdir_path/(label+suffix)
+        target_path.symlink_to(input_fpath)
+
+
+    pattern = fileref_map_to_pattern(sf.fileref_map)
+    pattern_fpath = tmpdir_path / "conversion.pattern"
+    logger.info(f"Using pattern {pattern}")
+    pattern_fpath.write_text(pattern)
+
+    zarr_fpath = dst_dir_basepath/f"{image_id}.zarr"
+    logger.info(f"Destination fpath: {zarr_fpath}")
+    if not zarr_fpath.exists():
+        run_zarr_conversion(pattern_fpath, zarr_fpath)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
Currently we read the license from the original BioStudies entry on ingest, which is part of our data model. However, when we render the license on generated image pages, we always show CC0, which is incorrect. This PR fixes this for the two licenses we allow for web submission.