### PR TITLE
Dev

### DIFF
--- a/tools/snakemake/Snakefile
+++ b/tools/snakemake/Snakefile
@@ -151,6 +151,7 @@ rule convert_to_zarr_and_upload:
         im_ref = work_dir + "/im_reps/{i,[a-z|\d|-]+}"
     output:
         im_ref = work_dir + "/im_reps_output/{i}"
+        flag = work_ + "im_reps_output/{i}.done"
     singularity:
         singularity_container_path
     shell:
@@ -162,14 +163,15 @@ rule convert_to_zarr_and_upload:
 # but putting it here to make the steps involved clearer
 rule generate_thumbnails:
     input:
-        work_dir + "/im_reps_output/{i,[a-z|\d|-]+}"
+        zarr_folder = work_dir + "/im_reps_output/{i,[a-z|\d|-]+}"
+        flag = work_dir + "/im_reps_output/{i,[a-z|\d|-]+}"
     output:
         work_dir + "/gen_thumb_output/{i}"
     singularity:
         singularity_container_path
     shell:
         """
-            IM_REF=$(basename {input})
+            IM_REF=$(basename {input.zarr_folder})
             {command_prefix} python {script_dir}/generate_thumbnail.py $ACCNO $IM_REF > {output}
         """
 def aggregate_converted_im_reps(wildcards):

--- a/tools/snakemake/Snakefile
+++ b/tools/snakemake/Snakefile
@@ -151,7 +151,7 @@ rule convert_to_zarr_and_upload:
         im_ref = work_dir + "/im_reps/{i,[a-z|\d|-]+}"
     output:
         im_ref = work_dir + "/im_reps_output/{i}"
-        flag = work_ + "im_reps_output/{i}.done"
+        flag = touch(work_ + "im_reps_output/{i}.done")
     singularity:
         singularity_container_path
     shell:


### PR DESCRIPTION
@kbab 

Here is an attempt at helping with your snakemake "resumability" problem. 

You add a touch(file) flag output that snakemake will generate when the script doesn't crash, you then use that as an input to the next rule

https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#flag-files

P.s. I've not tested this feel free to commit to this branch