### PR TITLE
Fix issues due to deletion of preview.py

### DIFF
--- a/tools/scripts/generate_representative_image_and_set_to_default.py
+++ b/tools/scripts/generate_representative_image_and_set_to_default.py
@@ -6,7 +6,9 @@ from bia_integrator_core.models import BIAImageRepresentation, StudyAnnotation, 
 from bia_integrator_core.interface import persist_image_representation, persist_study_annotation
 from bia_integrator_tools.utils import get_ome_ngff_rep_by_accession_and_image, get_example_image_uri
 from bia_integrator_tools.io import copy_local_to_s3
-from bia_integrator_tools.rendering import NGFFProxyImage, render_proxy_image
+from bia_integrator_tools.rendering import (
+    NGFFProxyImage, render_proxy_image, generate_padded_thumbnail_from_ngff_uri
+)
 
 logger = logging.getLogger(__file__)
 
@@ -24,9 +26,9 @@ def main(accession_id, image_id):
         return
     
     ome_ngff_rep = get_ome_ngff_rep_by_accession_and_image(accession_id, image_id)
-    proxy_im = NGFFProxyImage(ome_ngff_rep.uri)
-    im = render_proxy_image(proxy_im)
-    w, h = im.size
+    w = 512
+    h = 512
+    im = generate_padded_thumbnail_from_ngff_uri(ome_ngff_rep.uri, dims=(w,h))
     dst_key = f"{accession_id}/{image_id}/{image_id}-representative-{w}-{h}.png"
 
     with tempfile.NamedTemporaryFile(suffix=".png") as fh:

--- a/tools/scripts/generate_representative_image_and_set_to_default.py
+++ b/tools/scripts/generate_representative_image_and_set_to_default.py
@@ -6,12 +6,7 @@ from bia_integrator_core.models import BIAImageRepresentation, StudyAnnotation, 
 from bia_integrator_core.interface import persist_image_representation, persist_study_annotation
 from bia_integrator_tools.utils import get_ome_ngff_rep_by_accession_and_image, get_example_image_uri
 from bia_integrator_tools.io import copy_local_to_s3
-
-from preview import (
-    min_dim_array_from_zarr_uri, get_single_channel_image_arrays,
-    channel_arrays_and_chrenders_to_thumbnail,
-    scale_channel_arrays
-)
+from bia_integrator_tools.rendering import NGFFProxyImage, render_proxy_image
 
 logger = logging.getLogger(__file__)
 
@@ -28,36 +23,10 @@ def main(accession_id, image_id):
         logging.info(f"There is a representative image already. Terminating the script")
         return
     
-    dimensions = 512, 512
-
     ome_ngff_rep = get_ome_ngff_rep_by_accession_and_image(accession_id, image_id)
-    rendering = ome_ngff_rep.rendering
-
-    if not rendering:
-        logging.info(f"No rendering information set, will default to grayscale")
-        render = ChannelRendering(
-            colormap_start=[0., 0., 0.],
-            colormap_end=[1., 1., 1.],
-            scale_factor=1
-        )
-        rendering=RenderingInfo(
-            channel_renders=[render],
-            default_t=None,
-            default_z=None
-        )
-    else:
-        logging.info(f"Read channel renders for {len(rendering.channel_renders)} channels")
-
-    channel_renders = rendering.channel_renders
-    imarray = min_dim_array_from_zarr_uri(ome_ngff_rep.uri, dimensions)
-    channel_arrays = get_single_channel_image_arrays(imarray, rendering.default_z, rendering.default_t)
-    scaled_arrays = scale_channel_arrays(channel_arrays, channel_renders)
-
-    im = channel_arrays_and_chrenders_to_thumbnail(scaled_arrays, channel_renders, dimensions)
-
-    w, h = dimensions
-
-    # im = thumbnail_from_image(accession_id, image_id, dimensions=dimensions)
+    proxy_im = NGFFProxyImage(ome_ngff_rep.uri)
+    im = render_proxy_image(proxy_im)
+    w, h = im.size
     dst_key = f"{accession_id}/{image_id}/{image_id}-representative-{w}-{h}.png"
 
     with tempfile.NamedTemporaryFile(suffix=".png") as fh:
@@ -71,7 +40,7 @@ def main(accession_id, image_id):
         size=0,
         uri=uri,
         type="representative",
-        dimensions=str(dimensions),
+        dimensions=str((w, h)),
         attributes=None,
         rendering=None
     )

--- a/tools/scripts/generate_thumbnail.py
+++ b/tools/scripts/generate_thumbnail.py
@@ -5,7 +5,6 @@ import click
 from bia_integrator_core.models import BIAImageRepresentation
 from bia_integrator_core.interface import persist_image_representation
 from bia_integrator_tools.utils import ( get_ome_ngff_rep_by_accession_and_image, 
-                                        get_unconverted_rep_by_accession_and_image
 )
 from bia_integrator_tools.io import copy_local_to_s3
 
@@ -22,34 +21,6 @@ def generate_and_persist_thumbnail_from_ngff_rep(ome_ngff_rep, dimensions):
     image_id = ome_ngff_rep.image_id
 
     im = generate_padded_thumbnail_from_ngff_uri(ome_ngff_rep.uri)
-    w, h = dimensions
-
-    dst_key = f"{accession_id}/{image_id}/{image_id}-thumbnail-{w}-{h}.png"
-
-    with tempfile.NamedTemporaryFile(suffix=".png") as fh:
-        im.save(fh)
-        thumbnail_uri = copy_local_to_s3(fh.name, dst_key)
-        logger.info(f"Wrote thumbnail to {thumbnail_uri}")
-
-    rep = BIAImageRepresentation(
-        accession_id=accession_id,
-        image_id=image_id,
-        size=0,
-        uri=thumbnail_uri,
-        type="thumbnail",
-        dimensions=str(dimensions),
-        attributes=None,
-        rendering=None
-    )
-
-    persist_image_representation(rep)
-
-def generate_and_persist_thumbnail_from_im_rep(im_rep, dimensions):
-    accession_id = im_rep.accession_id
-    image_id = im_rep.image_id
-
-    im = thumbnail_from_unconverted_image(accession_id, image_id, dimensions)
-
     w, h = dimensions
 
     dst_key = f"{accession_id}/{image_id}/{image_id}-thumbnail-{w}-{h}.png"


### PR DESCRIPTION
On deletion of preview.py there was a stray import in scripts/generate_thumbnail.py and scripts/generate_representative_image_and_set_to_default.py was broken. This PR is an attempt to fix the issues. However, it is best @matthewh-ebi reviews to ensure changes fit in with intended use of new rendering scheme.