### PR TITLE
Bia ninja2 template

### DIFF
--- a/static-sitegen/scripts/generate_dataset_page.py
+++ b/static-sitegen/scripts/generate_dataset_page.py
@@ -27,10 +27,16 @@ DEFAULT_TEMPLATE = "dataset-landing.html.j2"
 # Attributes to display in study content section
 # Use list for backward compatibility with different annotation names
 # Most recent names come first in list
-STUDY_CONTENT_ANNOTATIONS = {
+STUDY_WITH_ZIP_CONTENT_ANNOTATIONS = {
     "Study size:": ["study_size_human_readable", "study_size"],
     "N files (exc zip contents):": ["n_files_excluding_zip_contents", "n_files_in_study",],
     "N files (inc zip contents):": ["n_files_including_zip_contents",],
+    "Filetype breakdown:": ["filetype_breakdown_html",],
+}
+
+STUDY_NO_ZIP_CONTENT_ANNOTATIONS = {
+    "Study size:": ["study_size_human_readable", "study_size"],
+    "N files:": ["n_files_including_zip_contents", "n_files_in_study",],
     "Filetype breakdown:": ["filetype_breakdown_html",],
 }
 
@@ -90,6 +96,15 @@ def generate_dataset_page_html(accession_id, template_fname: str):
     template = env.get_template(template_fname)
 
     # Get the keys to use for rendering study contents section
+    try:
+        if bia_study.attributes["n_files_including_zip_contents"] != bia_study.attributes["n_files_excluding_zip_contents"]:
+            STUDY_CONTENT_ANNOTATIONS = STUDY_WITH_ZIP_CONTENT_ANNOTATIONS
+        else:
+            STUDY_CONTENT_ANNOTATIONS = STUDY_NO_ZIP_CONTENT_ANNOTATIONS
+    except KeyError:
+        STUDY_CONTENT_ANNOTATIONS = STUDY_NO_ZIP_CONTENT_ANNOTATIONS
+        
+            
     study_content_annotations = {}
     for label, keys in STUDY_CONTENT_ANNOTATIONS.items():
         for key in keys:

--- a/static-sitegen/templates/base.html.j2
+++ b/static-sitegen/templates/base.html.j2
@@ -1,5 +1,14 @@
 <html lang="en" class="vf-no-js">
     <head>
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-NH1CCYVM6V"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+        
+          gtag('config', 'G-NH1CCYVM6V');
+        </script>
         <title>
             {% block title %}{% endblock %} &lt;BioImageArchive&gt; 
         </title>

--- a/static-sitegen/templates/base.html.j2
+++ b/static-sitegen/templates/base.html.j2
@@ -3,17 +3,17 @@
         <!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-NH1CCYVM6V"></script>
         <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-        
-          gtag('config', 'G-NH1CCYVM6V');
+            window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-NH1CCYVM6V');
         </script>
         <title>
-            {% block title %}{% endblock %} &lt;BioImageArchive&gt; 
+            {% block title %}{% endblock %} &lt;BioImage Archive&gt; 
         </title>
         {% block header_extras %}
-            <!-- EXTRA ENTRIES FOR HEADER -->
+        <!-- EXTRA ENTRIES FOR HEADER -->
         {% endblock %}
 
         <meta charset="UTF-8">
@@ -31,145 +31,271 @@
         <meta name="theme-color" content="#75C8EC" /> <!-- Android Chrome mobile browser tab color -->
         <meta http-equiv="pragma" content="no-cache" />
 
-        <!-- shared variables -->
-        <script>
-            var contextPath = '/biostudies';
-            var collection = 'BioImages';
-            if (collection==='undefined') collection = undefined;
-        </script>
-
         <!-- If you link to any other sites frequently, consider optimising performance with a DNS prefetch -->
         <link rel="dns-prefetch" href="//embl.de" />
 
         <!-- If you have custom icon, replace these as appropriate.
-             You can generate them at realfavicongenerator.net -->
-        <link rel="icon" type="image/x-icon" href="https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/favicon.ico" />
-        <link rel="icon" type="image/png" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="192×192" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/android-chrome-192x192.png" /> <!-- Android (192px) -->
-        <link rel="apple-touch-icon-precomposed" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/apple-touch-icon.png" /> <!-- Apple? -->
-        <link rel="mask-icon" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/safari-pinned-tab.svg" color="#ffffff" /> <!-- Safari icon for pinned tab -->
-        <meta name="msapplication-TileColor" content="#2b5797"> <!-- MS Icons -->
-        <meta name="msapplication-TileImage" content=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/mstile-150x150.png" />
+            You can generate them at realfavicongenerator.net -->
+            <link rel="icon" type="image/x-icon" href="https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/favicon.ico" />
+            <link rel="icon" type="image/png" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/favicon-32x32.png" />
+            <link rel="icon" type="image/png" sizes="192×192" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/android-chrome-192x192.png" /> <!-- Android (192px) -->
+            <link rel="apple-touch-icon-precomposed" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/apple-touch-icon.png" /> <!-- Apple? -->
+            <link rel="mask-icon" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/safari-pinned-tab.svg" color="#ffffff" /> <!-- Safari icon for pinned tab -->
+            <meta name="msapplication-TileColor" content="#2b5797"> <!-- MS Icons -->
+            <meta name="msapplication-TileImage" content=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/mstile-150x150.png" />
 
-        <!-- CSS: implied media=all -->
-        <!-- CSS concatenated and minified via ant build script-->
-        <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/css/ebi-global.css" type="text/css" media="all" />
-        <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Icon-fonts/v1.2/fonts.css" type="text/css" media="all" />
+            <!-- CSS: implied media=all -->
+            <!-- CSS concatenated and minified via ant build script-->
+            <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/css/ebi-global.css" type="text/css" media="all" />
+            <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Icon-fonts/v1.2/fonts.css" type="text/css" media="all" />
 
 
-        <!-- Use this CSS file for any custom styling -->
-        <!--
-          <link rel="stylesheet" href="css/custom.css" type="text/css" media="all">
-        -->
+            <!-- Use this CSS file for any custom styling -->
+            <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/css/theme-embl-petrol.css" type="text/css" media="all">
 
-        <!-- If you have a custom header image or colour -->
-        <!--
-        <meta name="ebi:localmasthead-color" content="#000">
-        <meta name="ebi:localmasthead-image" content="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/images/backgrounds/embl-ebi-background.jpg">
-        -->
+            <!-- If you have a custom header image or colour -->
+            <!--
+                <meta name="ebi:localmasthead-color" content="#000">
+                <meta name="ebi:localmasthead-image" content="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/images/backgrounds/embl-ebi-background.jpg">
+                            -->
 
-        <!-- you can replace this with theme-[projectname].css. See http://www.ebi.ac.uk/web/style/colour for details of how to do this -->
-        <!-- also inform ES so we can host your colour palette file -->
-        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/theme-biostudies.css" type="text/css" media="all" />
-        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/common.css" type="text/css" media="all" />
+                            <!-- you can replace this with theme-[projectname].css. See http://www.ebi.ac.uk/web/style/colour for details of how to do this -->
+                            <!-- also inform ES so we can host your colour palette file -->
+                            <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/theme-biostudies.css" type="text/css" media="all" />
+                            <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/common.css" type="text/css" media="all" />
 
-        <!-- for production the above can be replaced with -->
-        <!--
-        <link rel="stylesheet" href="//www.ebi.ac.uk/web_guidelines/css/compliance/mini/ebi-fluid-embl.css">
-        -->
+                            <!-- for production the above can be replaced with -->
+                            <!--
+                                <link rel="stylesheet" href="//www.ebi.ac.uk/web_guidelines/css/compliance/mini/ebi-fluid-embl.css">
+                                           -->
 
-        <!-- end CSS-->
+                                           <!-- end CSS-->
 
-        <meta class="foundation-mq" />
-        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/jquery.dataTables.css">
-        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/detail.css" type="text/css">
-        <!--script type="text/javascript" src="https://www.ebi.ac.uk/biostudies/gzip_N1305990095/js/common.min.js" ></script>
+                                           <meta class="foundation-mq" />
+                                           <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/jquery.dataTables.css">
+                                           <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/detail.css" type="text/css">
+                                           <!--script type="text/javascript" src="https://www.ebi.ac.uk/biostudies/gzip_N1305990095/js/common.min.js" ></script>
         <script type="text/javascript" src="https://www.ebi.ac.uk/biostudies/gzip_342799686/js/detail.min.js" ></script-->
     </head>
 
-    <body>
+    <body class="level2 ebi-black-bar-loaded no-global-search" style="">
+
+        <div id="skip-to">
+            <ul>
+                <li><a href="https://www.ebi.ac.uk/bioimage-archive/#content">Skip to main content</a></li>
+                <li><a href="https://www.ebi.ac.uk/bioimage-archive/#local-nav">Skip to local navigation</a></li>
+                <li><a href="https://www.ebi.ac.uk/bioimage-archive/#global-nav">Skip to EBI global navigation menu</a></li>
+                <li><a href="https://www.ebi.ac.uk/bioimage-archive/#global-nav-expanded">Skip to expanded EBI global navigation menu (includes all sub-sections)</a></li>
+            </ul>
+        </div>
+
+        <header id="masthead-black-bar" class="clearfix masthead-black-bar"><div></div><div><nav class="row"><ul id="global-nav" class="menu global-nav text-right" data-vf-google-analytics-region="Black bar"><li class="float-right show-for-medium embl-selector embl-ebi"><a class="button float-right custom-ebi-logo-bg custom-ebi-logo-bg-transparent-text" style="color: transparent;" href="https://www.ebi.ac.uk/">EMBL-EBI</a></li><li class="float-right search"><a href="https://www.ebi.ac.uk/bioimage-archive/#" class="inline-block collpased float-left search-toggle"><span class="show-for-small-only">Search</span></a></li><li class="what about"><a href="https://www.ebi.ac.uk/about">About us</a></li><li class="what training"><a href="https://www.ebi.ac.uk/training">Training</a></li><li class="what research"><a href="https://www.ebi.ac.uk/research">Research</a></li><li class="what services"><a href="https://www.ebi.ac.uk/services">Services</a></li><li class="where ebi"><a href="https://www.ebi.ac.uk/">EMBL-EBI home</a></li></ul></nav></div></header>
 
 
-<div id="skip-to">
-    <a href="#content">Skip to main content</a>
-</div>
-<header id="masthead-black-bar" class="clearfix masthead-black-bar"></header>
-<div id="content">
-    <div data-sticky-container>
-    <header id="masthead" class="masthead" style="background-image: url(&quot;https://www.ebi.ac.uk/biostudies/images/collections/bioimages/background.jpg&quot;); background-color: rgb(0, 124, 130);">
-            <div class="masthead-inner row">
+        <div id="content" role="main">
+            <div data-sticky-container>
+                <header id="masthead" class="masthead" style="background-image: url(&quot;https://www.ebi.ac.uk/biostudies/images/collections/bioimages/background.jpg&quot;); background-color: rgb(0, 124, 130);">
+                    <div class="masthead-inner row">
 
-                <!-- local-title -->
-                <div class="columns medium-7" id="local-title"><h1><a href="https://www.ebi.ac.uk/bioimage-archive"><img src="https://www.ebi.ac.uk/biostudies/images/collections/bioimages/logo.png"></a></h1></div>
-                <!-- Add local-title -->
-                <!-- Add local-description -->
+                        <div class="columns medium-7" id="local-title"><h1><a href="https://www.ebi.ac.uk/bioimage-archive"><img src="https://www.ebi.ac.uk/biostudies/images/collections/bioimages/logo.png"></a></h1></div>
+                    </div>
+
+                    <!-- /local-title -->
+                    <!-- local-nav -->
+                    <div class="row">
+                        <nav>
+                            <ul id="local-nav" class="dropdown menu float-left" data-description="navigational" data-dropdown-menu="inl31y-dropdown-menu" role="menubar">
+                                <li role="none"><a href="https://www.ebi.ac.uk/bioimage-archive/" role="menuitem">Home</a></li>
+                                <li role="none"><a href="https://www.ebi.ac.uk/biostudies/BioImages/studies" role="menuitem">Browse</a></li>
+                                <li role="none"><a href="https://www.ebi.ac.uk/bioimage-archive/submit/" role="menuitem">Submit</a></li>
+                                <li class="active" role="none"><a href="https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/pages/jan2023-to-may-2023.html" class="active" role="menuitem">Visual pages</a></li>
+                                <li role="none" class="is-dropdown-submenu-parent opens-right" aria-haspopup="true" aria-label="Help" data-is-click="false">
+                                    <a href="https://www.ebi.ac.uk/bioimage-archive/#" role="menuitem">Help</a>
+                                    <ul class="menu submenu is-dropdown-submenu first-sub vertical" data-submenu="" role="menubar" style="">
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/help-faq" role="menuitem">FAQs</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/help-search/" role="menuitem">Searching the archive</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/help-download/" role="menuitem">Downloading data</a></li>
+                                        <!-- <li><a href='/bioimage-archive/rembi-model-reference/'>Submission data model reference</a></li> -->
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/help-file-list/" role="menuitem">Submission File List guide</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/help-tools/" role="menuitem">Supporting Tools</a></li>
+                                    </ul>
+                                </li>
+                                <li role="none" class="is-dropdown-submenu-parent opens-right" aria-haspopup="true" aria-label="REMBI Help">
+                                    <a href="https://www.ebi.ac.uk/bioimage-archive/#" role="menuitem">REMBI Help</a>
+                                    <ul class="menu submenu is-dropdown-submenu first-sub vertical" data-submenu="" role="menubar">
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/rembi-help-overview" role="menuitem">REMBI Overview</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/rembi-help-lab/" role="menuitem">REMBI Lab Guidance</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/rembi-help-examples/" role="menuitem">Study Component Guidance</a></li>
+                                        <!-- <li><a href='/bioimage-archive/rembi-help-spreadsheets/'>REMBI Spreadsheets</a></li> -->
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/rembi-model-reference/" role="menuitem">REMBI Model Reference</a></li>
+                                    </ul>
+                                </li>
+                                <li role="none" class="is-dropdown-submenu-parent opens-right" aria-haspopup="true" aria-label="Policies">
+                                    <a href="https://www.ebi.ac.uk/bioimage-archive/#" role="menuitem">Policies</a>
+                                    <ul class="menu submenu is-dropdown-submenu first-sub vertical" data-submenu="" role="menubar">
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/help-policies/" role="menuitem">Archive policies</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/help-images-at-ebi/" role="menuitem">Depositing image data to EBI resources</a></li>
+                                    </ul>
+                                </li>
+                                <li role="none" class="is-dropdown-submenu-parent opens-right" aria-haspopup="true" aria-label="About us">
+                                    <a href="https://www.ebi.ac.uk/bioimage-archive/#" role="menuitem">About us</a>
+                                    <ul class="menu submenu is-dropdown-submenu first-sub vertical" data-submenu="" role="menubar">
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/project-developments/" role="menuitem">Project developments</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/case-studies/" role="menuitem">Case studies</a></li>
+                                        <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/contact-us/" role="menuitem">Contact us</a></li>
+                                    </ul>
+                                </li>
+                                <li class="extra-items-menu is-dropdown-submenu-parent opens-right" style="display: none;" role="none" aria-haspopup="true" aria-label="Also in this section"><a href="https://www.ebi.ac.uk/bioimage-archive/#" role="menuitem">Also in this section</a><ul class="menu submenu is-dropdown-submenu first-sub vertical" data-submenu="" role="menubar"><li class="bug-fix-placeholder is-dropdown-submenu-parent is-submenu-item is-dropdown-submenu-item opens-right" style="display:none !important;" role="none" aria-haspopup="true" aria-label="A workaround"><a href="https://www.ebi.ac.uk/bioimage-archive/#" role="menuitem">A workaround</a> <ul class="menu submenu is-dropdown-submenu vertical" data-submenu="" role="menubar"> <li role="none" class="is-submenu-item is-dropdown-submenu-item"><a href="https://www.ebi.ac.uk/bioimage-archive/#" role="menuitem">for a bug where the dropdown menu fails sometimes unless there are two submenus in the submenu</a></li></ul>  </li></ul></li></ul>
+                        </nav>
+                    </div>
+                    <!-- /local-nav -->
+                </header>
             </div>
-        </header>
-    </div>
 
 
+            <!-- Suggested layout containers -->
 
-    <div id="collection-banner"></div>
-    <script id='collection-banner-template' type='text/x-handlebars-template'>
-        <div class="collection-banner-content columns medium-12 clearfix row">
-                <span class="collection-logo">
-                    <a class="no-border" href="{{url}}" target="_blank">
-                        <img src="{{logo}}"></a>
-                </span>
-            <span class="collection-text">
-                    <span class="collection-description">{{description}}</span>
-                </span>
-        </div>
-    </script>
-    <!-- Suggested layout containers -->
+            <section id="main-content-area" class="row" role="main">
 
-        <section id="main-content-area" class="row" role="main">
-                
-    <!--START OF EBI TEMPLATE WRAPPER -->
-        <div class="medium-12 columns"> 
-        <!--CONTENT GOES HERE -->
-        {% block content %}
-        {% endblock %}
+                <!--START OF EBI TEMPLATE WRAPPER -->
+                <div class="medium-12 columns"> 
+                    <!--CONTENT GOES HERE -->
+                    {% block content %}
+                    {% endblock %}
+                </div>
+
+                <!--END OF EBI TEMPLATE WRAPPER -->
+
+            </section>
+            <!-- End suggested layout containers -->
+
         </div>
 
-    <!--END OF EBI TEMPLATE WRAPPER -->
+        <footer>
+            <div id="elixir-ribbon" class="elixir-ribbon">
+                <div class="row">
+                    <div class="column">
 
-        </section>
-    <!-- End suggested layout containers -->
+                        <div class="eubi-logo-kite"></div>
+                        <div class="elixir-logo-kite"></div>
+                        <h5>
+                            <span class="elixir-banner-name">The BioImage Archive is developed in close collaboration with <a href="http://www.eurobioimaging.eu/">Euro-BioImaging</a> and <a href="https://elixir-europe.org/">Elixir</a>.</span></h5>
+                        <div id="elixir-banner-info">
+                            <small>
+                                <!--<span class="elixir-banner-description">I am a super cool service</span>
+                                    <span class="readmore">Learn more ›</span>-->
+                            </small>
+                        </div>
 
-</div>
+                    </div>
+                </div>
+            </div>
+            <style>
+.elixir-ribbon {
+    padding: 1rem 0;
+    /*background-color: rgb(77, 77, 72); */
+    background-color: #fff;
+    border-top: 5px solid #eee;
+    ;
+}
 
+    .elixir-ribbon {
+        font-family: Helvetica, Arial, FreeSans, 'Liberation Sans', sans-serif;
+        clear: both;
+    }
 
+    .elixir-ribbon .row {
+        /*max-width: 1200px;*/
+        margin: 0 auto 1rem;
+    }
 
-          <footer>
-    <div id="elixir-banner" data-color="grey" data-name="BioStudies" data-description="BioStudies is a recommended ELIXIR Deposition Database" data-more-information-link="https://www.elixir-europe.org/platforms/data/elixir-deposition-databases" data-use-basic-styles="false"></div>
-    <script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/elixirBanner.js"></script>
-    <div id="global-footer" class="global-footer">
-        <nav id="global-nav-expanded" class="global-nav-expanded row">
-            <!-- Footer will be automatically inserted by footer.js -->
-        </nav>
-        <section id="ebi-footer-meta" class="ebi-footer-meta row">
-            <!-- Footer meta will be automatically inserted by footer.js -->
-        </section>
-    </div>
-</footer>
+    .elixir-ribbon .row::before,
+    .elixir-ribbon .row::after {
+        display: table;
+        content: ' ';
+    }
 
-<!-- JavaScript -->
-{% block post_body_scripts %} {% endblock %}
-<!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
-<!--
-<script>window.jQuery || document.write('<script src="../js/libs/jquery-1.10.2.min.js"><\/script>')</script>
--->
-<!-- Your custom JavaScript file scan go here... change names accordingly -->
-<!--
-<script defer="defer" src="//www.ebi.ac.uk/web_guidelines/js/plugins.js"></script>
-<script defer="defer" src="//www.ebi.ac.uk/web_guidelines/js/script.js"></script>
--->
-<script defer="defer" src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>
-<!-- The Foundation theme JavaScript -->
-<script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/libraries/foundation-6/js/foundation.js"></script>
-<script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/js/foundationExtendEBI.js"></script>
-<script>$(document).foundation();</script>
-<script>$(document).foundationExtendEBI();</script>
+    .elixir-ribbon h5 {
+        font-size: 1.3rem;
+        padding: 0;
+        display: inline-block;
+    }
+
+    .elixir-ribbon,
+    .elixir-ribbon h5,
+    .elixir-ribbon a,
+    .elixir-ribbon a:active,
+    .elixir-ribbon a:visited,
+    .elixir-ribbon a:hover {
+        color: rgb(77, 77, 72);
+        text-decoration: none;
+    }
+
+    .elixir-ribbon a:hover {
+        opacity: .8;
+    }
+
+    .elixir-ribbon .readmore {
+        border-bottom: 1px dotted rgb(77, 77, 72);
+    }
+
+    .elixir-ribbon h5 {
+        margin: 0;
+    }
+
+    .elixir-ribbon .eubi-logo-kite {
+        background: 80% 58% url("https://www.ebi.ac.uk/bioimage-archive/static/euro_bio_imaging_logo.jpg") no-repeat;
+        position: relative;
+        top: -5px;
+        margin: 0 1rem -.5rem 0;
+        height: 60px;
+        width: 60px;
+        display: inline-block;
+        float: left;
+        background-size: 60px;
+    }
+
+    .elixir-ribbon .elixir-logo-kite {
+        background: 80% 58% url("https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/assorted/elixir_kitemark-60px.png") no-repeat;
+        position: relative;
+        top: -5px;
+        margin: 0 1rem -.5rem 0;
+        height: 60px;
+        width: 60px;
+        display: inline-block;
+        float: left;
+        background-size: 60px;
+    }
+            </style>
+
+            <script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/elixirBanner.js"></script>
+            <div id="global-footer" class="global-footer">
+                <nav id="global-nav-expanded" class="global-nav-expanded row">
+                    <!-- Footer will be automatically inserted by footer.js -->
+                </nav>
+                <section id="ebi-footer-meta" class="ebi-footer-meta row">
+                    <!-- Footer meta will be automatically inserted by footer.js -->
+                </section>
+            </div>
+        </footer>
+
+        <!-- JavaScript -->
+        {% block post_body_scripts %} {% endblock %}
+        <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+        <!--
+            <script>window.jQuery || document.write('<script src="../js/libs/jquery-1.10.2.min.js"><\/script>')</script>
+            -->
+            <!-- Your custom JavaScript file scan go here... change names accordingly -->
+            <!--
+                <script defer="defer" src="//www.ebi.ac.uk/web_guidelines/js/plugins.js"></script>
+                <script defer="defer" src="//www.ebi.ac.uk/web_guidelines/js/script.js"></script>
+                -->
+                <script defer="defer" src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>
+                <!-- The Foundation theme JavaScript -->
+                <script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/libraries/foundation-6/js/foundation.js"></script>
+                <script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/js/foundationExtendEBI.js"></script>
+                <script>$(document).foundation();</script>
+                <script>$(document).foundationExtendEBI();</script>
+                <style id="dynamic-stuck-height" type="text/css"> .masthead.sticky.is-stuck{ margin-top: -132px !important;} </style>
     </body>
 </html>

--- a/static-sitegen/templates/base.html.j2
+++ b/static-sitegen/templates/base.html.j2
@@ -1,0 +1,165 @@
+<html lang="en" class="vf-no-js">
+    <head>
+        <title>
+            {% block title %}{% endblock %} &lt;BioImageArchive&gt; 
+        </title>
+        {% block header_extras %}
+            <!-- EXTRA ENTRIES FOR HEADER -->
+        {% endblock %}
+
+        <meta charset="UTF-8">
+        <link rel="stylesheet" href="https://assets.emblstatic.net/vf/v2.5.8/css/styles.css">
+        <meta charset="UTF-8">
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="BioImageArchive &lt; The European Bioinformatics Institute &lt; EMBL-EBI" />
+        <meta property="og:description" content="The BioImageArchive – a free, publicly available online resource which stores and distributes biological images" />
+        <meta name="description" content="The BioImageArchive – a free, publicly available online resource which stores and distributes biological images" />
+        <meta name="keywords" content="bioinformatics, europe, institute, biostudies, images" />
+        <meta name="author" content="BioImageArchive" />
+        <meta name="HandheldFriendly" content="true" />
+        <meta name="MobileOptimized" content="width" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="theme-color" content="#75C8EC" /> <!-- Android Chrome mobile browser tab color -->
+        <meta http-equiv="pragma" content="no-cache" />
+
+        <!-- shared variables -->
+        <script>
+            var contextPath = '/biostudies';
+            var collection = 'BioImages';
+            if (collection==='undefined') collection = undefined;
+        </script>
+
+        <!-- If you link to any other sites frequently, consider optimising performance with a DNS prefetch -->
+        <link rel="dns-prefetch" href="//embl.de" />
+
+        <!-- If you have custom icon, replace these as appropriate.
+             You can generate them at realfavicongenerator.net -->
+        <link rel="icon" type="image/x-icon" href="https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/favicon.ico" />
+        <link rel="icon" type="image/png" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="192×192" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/android-chrome-192x192.png" /> <!-- Android (192px) -->
+        <link rel="apple-touch-icon-precomposed" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/apple-touch-icon.png" /> <!-- Apple? -->
+        <link rel="mask-icon" href=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/safari-pinned-tab.svg" color="#ffffff" /> <!-- Safari icon for pinned tab -->
+        <meta name="msapplication-TileColor" content="#2b5797"> <!-- MS Icons -->
+        <meta name="msapplication-TileImage" content=""https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/logos/bioimage-archive/favicons/mstile-150x150.png" />
+
+        <!-- CSS: implied media=all -->
+        <!-- CSS concatenated and minified via ant build script-->
+        <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/css/ebi-global.css" type="text/css" media="all" />
+        <link rel="stylesheet" href="https://www.ebi.ac.uk/web_guidelines/EBI-Icon-fonts/v1.2/fonts.css" type="text/css" media="all" />
+
+
+        <!-- Use this CSS file for any custom styling -->
+        <!--
+          <link rel="stylesheet" href="css/custom.css" type="text/css" media="all">
+        -->
+
+        <!-- If you have a custom header image or colour -->
+        <!--
+        <meta name="ebi:localmasthead-color" content="#000">
+        <meta name="ebi:localmasthead-image" content="https://www.ebi.ac.uk/web_guidelines/EBI-Framework/images/backgrounds/embl-ebi-background.jpg">
+        -->
+
+        <!-- you can replace this with theme-[projectname].css. See http://www.ebi.ac.uk/web/style/colour for details of how to do this -->
+        <!-- also inform ES so we can host your colour palette file -->
+        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/theme-biostudies.css" type="text/css" media="all" />
+        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/common.css" type="text/css" media="all" />
+
+        <!-- for production the above can be replaced with -->
+        <!--
+        <link rel="stylesheet" href="//www.ebi.ac.uk/web_guidelines/css/compliance/mini/ebi-fluid-embl.css">
+        -->
+
+        <!-- end CSS-->
+
+        <meta class="foundation-mq" />
+        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/jquery.dataTables.css">
+        <link rel="stylesheet" href="https://www.ebi.ac.uk/biostudies/css/detail.css" type="text/css">
+        <!--script type="text/javascript" src="https://www.ebi.ac.uk/biostudies/gzip_N1305990095/js/common.min.js" ></script>
+        <script type="text/javascript" src="https://www.ebi.ac.uk/biostudies/gzip_342799686/js/detail.min.js" ></script-->
+    </head>
+
+    <body>
+
+
+<div id="skip-to">
+    <a href="#content">Skip to main content</a>
+</div>
+<header id="masthead-black-bar" class="clearfix masthead-black-bar"></header>
+<div id="content">
+    <div data-sticky-container>
+    <header id="masthead" class="masthead" style="background-image: url(&quot;https://www.ebi.ac.uk/biostudies/images/collections/bioimages/background.jpg&quot;); background-color: rgb(0, 124, 130);">
+            <div class="masthead-inner row">
+
+                <!-- local-title -->
+                <div class="columns medium-7" id="local-title"><h1><a href="https://www.ebi.ac.uk/bioimage-archive"><img src="https://www.ebi.ac.uk/biostudies/images/collections/bioimages/logo.png"></a></h1></div>
+                <!-- Add local-title -->
+                <!-- Add local-description -->
+            </div>
+        </header>
+    </div>
+
+
+
+    <div id="collection-banner"></div>
+    <script id='collection-banner-template' type='text/x-handlebars-template'>
+        <div class="collection-banner-content columns medium-12 clearfix row">
+                <span class="collection-logo">
+                    <a class="no-border" href="{{url}}" target="_blank">
+                        <img src="{{logo}}"></a>
+                </span>
+            <span class="collection-text">
+                    <span class="collection-description">{{description}}</span>
+                </span>
+        </div>
+    </script>
+    <!-- Suggested layout containers -->
+
+        <section id="main-content-area" class="row" role="main">
+                
+    <!--START OF EBI TEMPLATE WRAPPER -->
+    
+        <!--CONTENT GOES HERE -->
+        {% block content %}
+        {% endblock %}
+
+    <!--END OF EBI TEMPLATE WRAPPER -->
+
+        </section>
+    <!-- End suggested layout containers -->
+
+</div>
+
+
+
+          <footer>
+    <div id="elixir-banner" data-color="grey" data-name="BioStudies" data-description="BioStudies is a recommended ELIXIR Deposition Database" data-more-information-link="https://www.elixir-europe.org/platforms/data/elixir-deposition-databases" data-use-basic-styles="false"></div>
+    <script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/elixirBanner.js"></script>
+    <div id="global-footer" class="global-footer">
+        <nav id="global-nav-expanded" class="global-nav-expanded row">
+            <!-- Footer will be automatically inserted by footer.js -->
+        </nav>
+        <section id="ebi-footer-meta" class="ebi-footer-meta row">
+            <!-- Footer meta will be automatically inserted by footer.js -->
+        </section>
+    </div>
+</footer>
+
+<!-- JavaScript -->
+{% block post_body_scripts %} {% endblock %}
+<!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+<!--
+<script>window.jQuery || document.write('<script src="../js/libs/jquery-1.10.2.min.js"><\/script>')</script>
+-->
+<!-- Your custom JavaScript file scan go here... change names accordingly -->
+<!--
+<script defer="defer" src="//www.ebi.ac.uk/web_guidelines/js/plugins.js"></script>
+<script defer="defer" src="//www.ebi.ac.uk/web_guidelines/js/script.js"></script>
+-->
+<script defer="defer" src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>
+<!-- The Foundation theme JavaScript -->
+<script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/libraries/foundation-6/js/foundation.js"></script>
+<script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.4/js/foundationExtendEBI.js"></script>
+<script>$(document).foundation();</script>
+<script>$(document).foundationExtendEBI();</script>
+    </body>
+</html>

--- a/static-sitegen/templates/base.html.j2
+++ b/static-sitegen/templates/base.html.j2
@@ -126,10 +126,11 @@
         <section id="main-content-area" class="row" role="main">
                 
     <!--START OF EBI TEMPLATE WRAPPER -->
-    
+        <div class="medium-12 columns"> 
         <!--CONTENT GOES HERE -->
         {% block content %}
         {% endblock %}
+        </div>
 
     <!--END OF EBI TEMPLATE WRAPPER -->
 

--- a/static-sitegen/templates/collection-landing.html.j2
+++ b/static-sitegen/templates/collection-landing.html.j2
@@ -1,29 +1,8 @@
-<html lang="en" class="vf-no-js">
-    <head>
-        <meta charset="UTF-8">
-        <link rel="stylesheet" href="https://assets.emblstatic.net/vf/v2.5.8/css/styles.css">
-        <meta charset="UTF-8">
-        <title>Collection landing</title>
-    </head>
+{% extends "base.html.j2" %}
 
-    <body>
-        <!-- Header -->
-        <header class="vf-global-header">
+{% block title %} Collection landing {% endblock %}
 
-            <header class="vf-global-header">
-
-                <div class="vf-global-header__inner">
-          
-                  <a href="https://www.ebi.ac.uk/bioimage-archive" class="vf-logo">
-                    <img class="vf-logo__image" src="/bia-integrator-data/pages/assets/BIA-Logo.png" alt="BioImage Archive">
-                    <span class="vf-logo__text">   BioImage Archive</span>
-                  </a>
-          
-                </div>
-          
-            </header>
-        </header>
-
+{% block content %}
         <!-- Collection summary -->
         <div class="vf-stack vf-stack--500">
             <section class="vf-intro | embl-grid embl-grid--has-centered-content">
@@ -95,5 +74,4 @@
             </section>
 
           </div>
-    </body>
-</html>
+{% endblock %}

--- a/static-sitegen/templates/collection-landing.html.j2
+++ b/static-sitegen/templates/collection-landing.html.j2
@@ -1,6 +1,13 @@
 {% extends "base.html.j2" %}
 
-{% block title %} Collection landing {% endblock %}
+{% block header_extras %}
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
+{% endblock %}
+
+{% block title %} {{ collection.title }} {% endblock %}
 
 {% block content %}
         <!-- Collection summary -->
@@ -16,27 +23,26 @@
             </section>
  
             <!-- Images -->
-            <section class="vf-content | embl-grid embl-grid--has-centered-content">
-                <div>
-
-                </div>
-                <div>
-
-                    <section>
-                        
-                    <table class="vf-table--striped">
+            <!--section class="vf-content | embl-grid embl-grid--has-centered-content"-->
+            <section class="vf-content">
+                    <table class="vf-table--striped" id="collectionItems">
                         <colgroup>
-                              <col span="1" style="width: 20%;">
-                              <col span="1" style="width: 35%;">
-                              <col span="1" style="width: 10%;">
-                              <col span="1" style="width: 35%;">
+                              <col span="1" style="width: 12%;">
+                              <col span="1" style="width: 33%;">
+                              <col span="1" style="width: 12%;">
+                              <col span="1" style="width: 28%;">
+                              <col span="1" style="width: 15%;">
                         </colgroup>
+                        <thead>
                             <tr class="vf-table__row">
                                 <th class="vf-table__heading">Summary</th>
                                 <th class="vf-table__heading">Study title</th>
+                                <th class="vf-table__heading">Release date</th>
                                 <th class="vf-table__heading">Imaging method / organism</th>
                                 <th class="vf-table__heading">Example</th>
                             </tr>
+                        </thead>
+                        <tbody>
                             {% for study in studies %}
                             <tr class="vf-table__row">
                               <td class="vf-table__cell">
@@ -54,6 +60,7 @@
                                   <a href="{{ study.accession_id }}{{ page_suffix }}"><button class="vf-button vf-button--sm">view</button></a>
                               </td>
                               <td class="vf-table__cell">{{ study.title }}</td>
+                              <td class="vf-table__cell">{{ study.release_date }}</td>
 
                               <td class="vf-table__cell">
                                 {{ study.imaging_type }}
@@ -66,12 +73,19 @@
                                   </figure>  
                               </td>                              
                             </tr>
- 
                             {% endfor %}
+                        </tbody>
                       </table>
                       </section>
-                </div>
-            </section>
-
           </div>
+          <script>
+        $(document).ready( function () {
+            $('#collectionItems').DataTable( {
+                columnDefs: [
+                    { type: 'natural', targets: 0 },
+                    { orderable: false, targets: 4}
+                ]
+            });
+        } );
+    </script>
 {% endblock %}

--- a/static-sitegen/templates/collection-landing.html.j2
+++ b/static-sitegen/templates/collection-landing.html.j2
@@ -1,91 +1,91 @@
 {% extends "base.html.j2" %}
 
 {% block header_extras %}
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
+<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
 {% endblock %}
 
 {% block title %} {{ collection.title }} {% endblock %}
 
 {% block content %}
-        <!-- Collection summary -->
-        <div class="vf-stack vf-stack--500">
-            <section class="vf-intro | embl-grid embl-grid--has-centered-content">
-                <div></div>
-                <div>
-                    <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ collection.title }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
-                    <h2 class="vf-intro__subheading">{{ collection.subtitle }}</h2>
-                    {{ collection.description }}
-                </div>
-                <div></div>
-            </section>
- 
-            <!-- Images -->
-            <!--section class="vf-content | embl-grid embl-grid--has-centered-content"-->
-            <section class="vf-content">
-                    <table class="vf-table--striped" id="collectionItems">
-                        <colgroup>
-                              <col span="1" style="width: 12%;">
-                              <col span="1" style="width: 33%;">
-                              <col span="1" style="width: 12%;">
-                              <col span="1" style="width: 28%;">
-                              <col span="1" style="width: 15%;">
-                        </colgroup>
-                        <thead>
-                            <tr class="vf-table__row">
-                                <th class="vf-table__heading">Summary</th>
-                                <th class="vf-table__heading">Study title</th>
-                                <th class="vf-table__heading">Release date</th>
-                                <th class="vf-table__heading">Imaging method / organism</th>
-                                <th class="vf-table__heading">Example</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for study in studies %}
-                            <tr class="vf-table__row">
-                              <td class="vf-table__cell">
-                                  <b>{{ study.accession_id }}</b>
-                                  <br><br>
-                                  {{ study.images|length }} images
-                                  <br><br>
-                                  <!-- <b>Tags: </b>{{ study.tags|join(", ") }} -->
-                                    {% for value in study.tags %}
-                                    {% if not value.startswith('AI') %}
-                                    {{ value }},
-                                    {% endif %}
-                                    {% endfor %}
-                                  <br><br>
-                                  <a href="{{ study.accession_id }}{{ page_suffix }}"><button class="vf-button vf-button--sm">view</button></a>
-                              </td>
-                              <td class="vf-table__cell">{{ study.title }}</td>
-                              <td class="vf-table__cell">{{ study.release_date }}</td>
+<!-- Collection summary -->
+<div class="vf-stack vf-stack--500">
+    <section class="vf-intro | embl-grid embl-grid--has-centered-content">
+        <div></div>
+        <div>
+            <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ collection.title }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+            <h2 class="vf-intro__subheading">{{ collection.subtitle }}</h2>
+            {{ collection.description }}
+        </div>
+        <div></div>
+    </section>
 
-                              <td class="vf-table__cell">
-                                {{ study.imaging_type }}
-                                <br><hr>
-                                {{ study.organism }}
-                              </td>
-                              <td class="vf-table__cell">
-                                  <figure class="vf-figure vf-figure--align vf-figure--align-centered">
-                                    <img class="vf-figure__image" src="{{ study.example_image_uri }}">
-                                  </figure>  
-                              </td>                              
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                      </table>
-                      </section>
-          </div>
-          <script>
-        $(document).ready( function () {
-            $('#collectionItems').DataTable( {
-                columnDefs: [
-                    { type: 'natural', targets: 0 },
-                    { orderable: false, targets: 4}
-                ]
-            });
-        } );
-    </script>
+    <!-- Images -->
+    <!--section class="vf-content | embl-grid embl-grid--has-centered-content"-->
+    <section class="vf-content">
+        <table class="vf-table--striped" id="collectionItems">
+            <colgroup>
+                <col span="1" style="width: 12%;">
+                <col span="1" style="width: 33%;">
+                <col span="1" style="width: 12%;">
+                <col span="1" style="width: 28%;">
+                <col span="1" style="width: 15%;">
+            </colgroup>
+            <thead>
+                <tr class="vf-table__row">
+                    <th class="vf-table__heading">Summary</th>
+                    <th class="vf-table__heading">Study title</th>
+                    <th class="vf-table__heading">Release date</th>
+                    <th class="vf-table__heading">Imaging method / organism</th>
+                    <th class="vf-table__heading">Example</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for study in studies %}
+                <tr class="vf-table__row">
+                    <td class="vf-table__cell">
+                        <b>{{ study.accession_id }}</b>
+                        <br><br>
+                        {{ study.images|length }} images
+                        <br><br>
+                        <!-- <b>Tags: </b>{{ study.tags|join(", ") }} -->
+                        {% for value in study.tags %}
+                        {% if not value.startswith('AI') %}
+                        {{ value }},
+                        {% endif %}
+                        {% endfor %}
+                        <br><br>
+                        <a href="{{ study.accession_id }}{{ page_suffix }}"><button class="vf-button vf-button--sm">view</button></a>
+                    </td>
+                    <td class="vf-table__cell">{{ study.title }}</td>
+                    <td class="vf-table__cell">{{ study.release_date }}</td>
+
+                    <td class="vf-table__cell">
+                        {{ study.imaging_type }}
+                        <br><hr>
+                        {{ study.organism }}
+                    </td>
+                    <td class="vf-table__cell">
+                        <figure class="vf-figure vf-figure--align vf-figure--align-centered">
+                            <img class="vf-figure__image" src="{{ study.example_image_uri }}">
+                        </figure>  
+                    </td>                              
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+</div>
+<script>
+    $(document).ready( function () {
+        $('#collectionItems').DataTable( {
+            columnDefs: [
+                { type: 'natural', targets: 0 },
+                { orderable: false, targets: 4}
+            ]
+        });
+    } );
+</script>
 {% endblock %}

--- a/static-sitegen/templates/dataset-landing.html.j2
+++ b/static-sitegen/templates/dataset-landing.html.j2
@@ -1,202 +1,185 @@
-<html lang="en" class="vf-no-js">
-    <head>
-        <meta charset="UTF-8">
-        <link rel="stylesheet" href="https://assets.emblstatic.net/vf/v2.5.8/css/styles.css">
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
-        <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
-        <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
-        <meta charset="UTF-8">
-        <title>{{ accession_id }}</title>
-    </head>
+{% extends "base.html.j2" %}
 
-    <body>
-        <header class="vf-global-header">
-            <header class="vf-global-header">
+{% block header_extras %}
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
+{% endblock %}
 
-                <div class="vf-global-header__inner">
-          
-                  <a href="http://www.embl.de" class="vf-logo">
-                    <img class="vf-logo__image" src="/bia-integrator-data/pages/assets/BIA-Logo.png" alt="BioImage Archive">
-                    <span class="vf-logo__text">   BioImage Archive</span>
-                  </a>
-          
+{% block title %} {{ study.accession_id }} {% endblock %}
+
+{% block content %}
+    <div class="vf-stack vf-stack--500">
+        <section class="vf-intro | embl-grid embl-grid--has-centered-content">
+            <div></div>
+            <div>
+                <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ study.accession_id }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+                <h2 class="vf-intro__subheading">{{ study.title }}</h2>
+                Released {{ study.release_date }}<br>
+                {{ authors }}
+            </div>
+            <div></div>
+        </section>
+        <section  class="vf-content | embl-grid embl-grid--has-centered-content">
+            <div>
+                <h2 class="vf-section-header__heading">Content</h2>
+                <ul class="vf-list">
+                    <li>{{ study.images|length }} images</li>
+                    {% if study.archive_files|length > 0 %}
+                    <li>{{ study.archive_files|length }} archive files</li>
+                    {% endif %}
+                    {% if study.other_files|length > 0 %}
+                    <li>{{ study.other_files|length }} other files</li>
+                    {% endif %}
+
+                    {% for label, key in study_content_annotations.items() %}
+                        <li>{{ label }} {{ study.attributes[key] }}</li>
+                    {% endfor %}
+                </ul>
+            {% if 'bia_binder_url' in study.attributes %}
+                <a href={{ study.attributes['bia_binder_url'] }}><button class="vf-button vf-button--primary vf-button--sm">Explore in BIA Binder</button></a>
+            {% endif %}
+            </div>
+            <div>                  
+                <figure class="vf-figure vf-figure--align vf-figure--align-centered">
+                    <img class="vf-figure__image" src="{{ study.example_image_uri }}">
+                </figure>  
+                {{ study.description }}
+            </div>
+            <div></div>
+        </section>
+        <!-- Study information -->
+        <section class="vf-content | embl-grid embl-grid--has-centered-content">
+            <div>
+                <h2 class="vf-section-header__heading">Study information</h2>
+            </div>
+            <div>
+                <div class="vf-content">
+                    <div class="vf-grid vf-grid__col-2">
+                        <div><b>Organism</b></div>
+                        <div>{{ study.organism }}</div>
+                        <div><b>Study type</b></div>
+                        <div>{{ study.attributes["study_type"] }}</div>
+                        <div><b>Imaging type</b></div>
+                        <div>{{ study.imaging_type }}</div>
+                    </div>
                 </div>
-          
-            </header>
-        </header>
+            </div>
+            <div></div>
+        </section>
+        <!-- Images -->
+        <section class="vf-content | embl-grid embl-grid--has-centered-content">
+            <div>
+                <h2 class="vf-section-header__heading">Viewable images</h2>
 
-        <div class="vf-stack vf-stack--500">
-            <section class="vf-intro | embl-grid embl-grid--has-centered-content">
-                <div></div>
-                <div>
-                    <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ study.accession_id }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
-                    <h2 class="vf-intro__subheading">{{ study.title }}</h2>
-                    Released {{ study.release_date }}<br>
-                    {{ authors }}
-                </div>
-                <div></div>
-            </section>
-            <section  class="vf-content | embl-grid embl-grid--has-centered-content">
-                <div>
-                    <h2 class="vf-section-header__heading">Content</h2>
-                    <ul class="vf-list">
-                        <li>{{ study.images|length }} images</li>
-                        {% if study.archive_files|length > 0 %}
-                        <li>{{ study.archive_files|length }} archive files</li>
-                        {% endif %}
-                        {% if study.other_files|length > 0 %}
-                        <li>{{ study.other_files|length }} other files</li>
-                        {% endif %}
+            </div>
+            <div>
 
-                        {% for label, key in study_content_annotations.items() %}
-                            <li>{{ label }} {{ study.attributes[key] }}</li>
+                {# <section> #}
+                    
+                <table id="viewable">
+                    {# <caption class="vf-table__caption">Images with OME-NGFF representations</caption> #}
+                    {# <colgroup>
+                          <col span="1" style="width: 20%;">
+                          <col span="1" style="width: 40%;">
+                          <col span="1" style="width: 30%;">
+                          <col span="1" style="width: 10%;">
+                    </colgroup> #}
+                    <thead>
+                        <tr>
+                            <th>Image ID</th>
+                            <th>Preview</th>
+                            <th>Filename</th>
+                            <th>Dimensions<br>(T, C, Z, Y, X)</th>
+                            <th>Download Size</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for image in images %}
+                        <tr>
+                            <td>{{ image_names[image.id] }}</td>
+                            <td>
+                                <img class="vf-figure__image" src={{ image_thumbnails[image.id] }}>
+                            </td>
+                            <td>{{ image.original_relpath }}</td>
+                            {% if image.dimensions %}
+                                <td>{{ image.dimensions }}</td>
+                            {% elif image.attributes.get('SizeX') %}
+                                <td> ({{ image.attributes['SizeT'] }}, {{ image.attributes['SizeC'] }}, {{ image.attributes['SizeZ'] }}, {{ image.attributes['SizeY'] }}, {{ image.attributes['SizeX'] }})</td>
+                            {% else %}
+                                <td> None </td>
+                            {% endif %}
+                            {% if "download_size" in image.attributes %}
+                                <td>{{ image.attributes["download_size"] }}</td>
+                            {% else %}
+                                <td>Unavailable</td>
+                            {% endif %}
+                            <td>
+                                <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
+                                <a href={{ image_download_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">download</button></a>
+                            </td>                            
+                        </tr>
                         {% endfor %}
-                    </ul>
-                {% if 'bia_binder_url' in study.attributes %}
-                    <a href={{ study.attributes['bia_binder_url'] }}><button class="vf-button vf-button--primary vf-button--sm">Explore in BIA Binder</button></a>
-                {% endif %}
-                </div>
-                <div>                  
-                    <figure class="vf-figure vf-figure--align vf-figure--align-centered">
-                        <img class="vf-figure__image" src="{{ study.example_image_uri }}">
-                    </figure>  
-                    {{ study.description }}
+                    </tbody>
+                  </table>
+                  {# </section> #}
                 </div>
                 <div></div>
-            </section>
-            <!-- Study information -->
-            <section class="vf-content | embl-grid embl-grid--has-centered-content">
                 <div>
-                    <h2 class="vf-section-header__heading">Study information</h2>
+                    <h2 class="vf-section-header__heading">All images</h2>
                 </div>
                 <div>
-                    <div class="vf-content">
-                        <div class="vf-grid vf-grid__col-2">
-                            <div><b>Organism</b></div>
-                            <div>{{ study.organism }}</div>
-                            <div><b>Study type</b></div>
-                            <div>{{ study.attributes["study_type"] }}</div>
-                            <div><b>Imaging type</b></div>
-                            <div>{{ study.imaging_type }}</div>
-                        </div>
-                    </div>
-                </div>
-                <div></div>
-            </section>
-            <!-- Images -->
-            <section class="vf-content | embl-grid embl-grid--has-centered-content">
-                <div>
-                    <h2 class="vf-section-header__heading">Viewable images</h2>
+                  <table class="display table" id="table">
+                    <thead>
+                        <tr>
+                            <th>Image ID</th>
+                            <th>Filename</th>
+                            <th>Download Size</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for image in study.images.values() %}
+                            <td>{{ image_names[image.id] }}</td>
+                            <td>{{ image.original_relpath }}</td>
+                            {% if "download_size" in image.attributes %}
+                                <td>{{ image.attributes["download_size"] }}</td>
+                            {% else %}
+                                <td>Unavailable</td>
+                            {% endif %}
+                            <td><a href={{ image_download_uris[image.id] }}>Download</a></td>
+                        </tr>
+                        {# <tr class="vf-table__row">
+                            <td class="vf-table__cell">{{ image.id }}</td>
+                            <td class="vf-table__cell">{{ image.original_relpath }}</td>
+                            <td class="vf-table__cell--actions">
+                                <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
+                                <button class="vf-button vf-button--sm vf-button--icon">download</button>
+                            </td>                            
+                        </tr> #}
+                        {% endfor %}
+                    </tbody>
+                  </table>                      
+                  </div>
+        </section>
 
-                </div>
-                <div>
-
-                    {# <section> #}
-                        
-                    <table id="viewable">
-                        {# <caption class="vf-table__caption">Images with OME-NGFF representations</caption> #}
-                        {# <colgroup>
-                              <col span="1" style="width: 20%;">
-                              <col span="1" style="width: 40%;">
-                              <col span="1" style="width: 30%;">
-                              <col span="1" style="width: 10%;">
-                        </colgroup> #}
-                        <thead>
-                            <tr>
-                                <th>Image ID</th>
-                                <th>Preview</th>
-                                <th>Filename</th>
-                                <th>Dimensions<br>(T, C, Z, Y, X)</th>
-                                <th>Download Size</th>
-                                <th>Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for image in images %}
-                            <tr>
-                                <td>{{ image_names[image.id] }}</td>
-                                <td>
-                                    <img class="vf-figure__image" src={{ image_thumbnails[image.id] }}>
-                                </td>
-                                <td>{{ image.original_relpath }}</td>
-                                {% if image.dimensions %}
-                                    <td>{{ image.dimensions }}</td>
-                                {% elif image.attributes.get('SizeX') %}
-                                    <td> ({{ image.attributes['SizeT'] }}, {{ image.attributes['SizeC'] }}, {{ image.attributes['SizeZ'] }}, {{ image.attributes['SizeY'] }}, {{ image.attributes['SizeX'] }})</td>
-                                {% else %}
-                                    <td> None </td>
-                                {% endif %}
-                                {% if "download_size" in image.attributes %}
-                                    <td>{{ image.attributes["download_size"] }}</td>
-                                {% else %}
-                                    <td>Unavailable</td>
-                                {% endif %}
-                                <td>
-                                    <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
-                                    <a href={{ image_download_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">download</button></a>
-                                </td>                            
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                      </table>
-                      {# </section> #}
-                    </div>
-                    <div></div>
-                    <div>
-                        <h2 class="vf-section-header__heading">All images</h2>
-                    </div>
-                    <div>
-                      <table class="display table" id="table">
-                        <thead>
-                            <tr>
-                                <th>Image ID</th>
-                                <th>Filename</th>
-                                <th>Download Size</th>
-                                <th>Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for image in study.images.values() %}
-                                <td>{{ image_names[image.id] }}</td>
-                                <td>{{ image.original_relpath }}</td>
-                                {% if "download_size" in image.attributes %}
-                                    <td>{{ image.attributes["download_size"] }}</td>
-                                {% else %}
-                                    <td>Unavailable</td>
-                                {% endif %}
-                                <td><a href={{ image_download_uris[image.id] }}>Download</a></td>
-                            </tr>
-                            {# <tr class="vf-table__row">
-                                <td class="vf-table__cell">{{ image.id }}</td>
-                                <td class="vf-table__cell">{{ image.original_relpath }}</td>
-                                <td class="vf-table__cell--actions">
-                                    <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
-                                    <button class="vf-button vf-button--sm vf-button--icon">download</button>
-                                </td>                            
-                            </tr> #}
-                            {% endfor %}
-                        </tbody>
-                      </table>                      
-                      </div>
-            </section>
-
-        </div>
-        <script>
-            $(document).ready( function () {
-                $('#table').DataTable( {
-                    columnDefs: [
-                        { type: 'natural', targets: 0 }
-                    ]
-                });
-            } );
-            $(document).ready( function () {
-                $('#viewable').DataTable( {
-                    columnDefs: [
-                        { type: 'natural', targets: 0 }
-                    ]
-                });
-            } );
-        </script>
-    </body>
-</html>
+    </div>
+    <script>
+        $(document).ready( function () {
+            $('#table').DataTable( {
+                columnDefs: [
+                    { type: 'natural', targets: 0 }
+                ]
+            });
+        } );
+        $(document).ready( function () {
+            $('#viewable').DataTable( {
+                columnDefs: [
+                    { type: 'natural', targets: 0 }
+                ]
+            });
+        } );
+    </script>
+{% endblock %}

--- a/static-sitegen/templates/dataset-landing.html.j2
+++ b/static-sitegen/templates/dataset-landing.html.j2
@@ -53,16 +53,18 @@
         <section class="vf-content | embl-grid embl-grid--has-centered-content">
             <div>
                 <h2 class="vf-section-header__heading">Study information</h2>
+                <p></p>
+                <a class="vf-card__link" href="https://www.ebi.ac.uk/biostudies/BioImages/studies/{{ study.accession_id }}" target=”_blank”><button class="vf-button vf-button--primary vf-button--sm">Original submission page</button></a>
             </div>
             <div>
                 <div class="vf-content">
                     <div class="vf-grid vf-grid__col-2">
                         <div><b>Organism</b></div>
                         <div>{{ study.organism }}</div>
-                        <div><b>Study type</b></div>
-                        <div>{{ study.attributes["study_type"] }}</div>
                         <div><b>Imaging type</b></div>
                         <div>{{ study.imaging_type }}</div>
+                        <div><b>License</b></div>
+                        <div>{{ study.license }}</div>
                     </div>
                 </div>
             </div>

--- a/static-sitegen/templates/dataset-landing.html.j2
+++ b/static-sitegen/templates/dataset-landing.html.j2
@@ -1,92 +1,92 @@
 {% extends "base.html.j2" %}
 
 {% block header_extras %}
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
+<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
 {% endblock %}
 
 {% block title %} {{ study.accession_id }} {% endblock %}
 
 {% block content %}
-    <div class="vf-stack vf-stack--500">
-        <section class="vf-intro | embl-grid embl-grid--has-centered-content">
-            <div></div>
-            <div>
-                <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ study.accession_id }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
-                <h2 class="vf-intro__subheading">{{ study.title }}</h2>
-                Released {{ study.release_date }}<br>
-                {{ authors }}
-            </div>
-            <div></div>
-        </section>
-        <section  class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
-                <h2 class="vf-section-header__heading">Content</h2>
-                <ul class="vf-list">
-                    <li>{{ study.images|length }} images</li>
-                    {% if study.archive_files|length > 0 %}
-                    <li>{{ study.archive_files|length }} archive files</li>
-                    {% endif %}
-                    {% if study.other_files|length > 0 %}
-                    <li>{{ study.other_files|length }} other files</li>
-                    {% endif %}
+<div class="vf-stack vf-stack--500">
+    <section class="vf-intro | embl-grid embl-grid--has-centered-content">
+        <div></div>
+        <div>
+            <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ study.accession_id }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+            <h2 class="vf-intro__subheading">{{ study.title }}</h2>
+            Released {{ study.release_date }}<br>
+            {{ authors }}
+        </div>
+        <div></div>
+    </section>
+    <section  class="vf-content | embl-grid embl-grid--has-centered-content">
+        <div>
+            <h2 class="vf-section-header__heading">Content</h2>
+            <ul class="vf-list">
+                <li>{{ study.images|length }} images</li>
+                {% if study.archive_files|length > 0 %}
+                <li>{{ study.archive_files|length }} archive files</li>
+                {% endif %}
+                {% if study.other_files|length > 0 %}
+                <li>{{ study.other_files|length }} other files</li>
+                {% endif %}
 
-                    {% for label, key in study_content_annotations.items() %}
-                        <li>{{ label }} {{ study.attributes[key] }}</li>
-                    {% endfor %}
-                </ul>
+                {% for label, key in study_content_annotations.items() %}
+                <li>{{ label }} {{ study.attributes[key] }}</li>
+                {% endfor %}
+            </ul>
             {% if 'bia_binder_url' in study.attributes %}
-                <a href={{ study.attributes['bia_binder_url'] }}><button class="vf-button vf-button--primary vf-button--sm">Explore in BIA Binder</button></a>
+            <a href={{ study.attributes['bia_binder_url'] }}><button class="vf-button vf-button--primary vf-button--sm">Explore in BIA Binder</button></a>
             {% endif %}
-            </div>
-            <div>                  
-                <figure class="vf-figure vf-figure--align vf-figure--align-centered">
-                    <img class="vf-figure__image" src="{{ study.example_image_uri }}">
-                </figure>  
-                {{ study.description }}
-            </div>
-            <div></div>
-        </section>
-        <!-- Study information -->
-        <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
-                <h2 class="vf-section-header__heading">Study information</h2>
-                <p></p>
-                <a class="vf-card__link" href="https://www.ebi.ac.uk/biostudies/BioImages/studies/{{ study.accession_id }}" target=”_blank”><button class="vf-button vf-button--primary vf-button--sm">Original submission page</button></a>
-            </div>
-            <div>
-                <div class="vf-content">
-                    <div class="vf-grid vf-grid__col-2">
-                        <div><b>Organism</b></div>
-                        <div>{{ study.organism }}</div>
-                        <div><b>Imaging type</b></div>
-                        <div>{{ study.imaging_type }}</div>
-                        <div><b>License</b></div>
-                        <div>{{ study.license }}</div>
-                    </div>
+        </div>
+        <div>                  
+            <figure class="vf-figure vf-figure--align vf-figure--align-centered">
+                <img class="vf-figure__image" src="{{ study.example_image_uri }}">
+            </figure>  
+            {{ study.description }}
+        </div>
+        <div></div>
+    </section>
+    <!-- Study information -->
+    <section class="vf-content | embl-grid embl-grid--has-centered-content">
+        <div>
+            <h2 class="vf-section-header__heading">Study information</h2>
+            <p></p>
+            <a class="vf-card__link" href="https://www.ebi.ac.uk/biostudies/BioImages/studies/{{ study.accession_id }}" target=”_blank”><button class="vf-button vf-button--primary vf-button--sm">Original submission page</button></a>
+        </div>
+        <div>
+            <div class="vf-content">
+                <div class="vf-grid vf-grid__col-2">
+                    <div><b>Organism</b></div>
+                    <div>{{ study.organism }}</div>
+                    <div><b>Imaging type</b></div>
+                    <div>{{ study.imaging_type }}</div>
+                    <div><b>License</b></div>
+                    <div>{{ study.license }}</div>
                 </div>
             </div>
-            <div></div>
-        </section>
-        <!-- Images -->
-        <section class="vf-content | embl-grid embl-grid--has-centered-content">
-            <div>
-                <h2 class="vf-section-header__heading">Viewable images</h2>
+        </div>
+        <div></div>
+    </section>
+    <!-- Images -->
+    <section class="vf-content | embl-grid embl-grid--has-centered-content">
+        <div>
+            <h2 class="vf-section-header__heading">Viewable images</h2>
 
-            </div>
-            <div>
+        </div>
+        <div>
 
-                {# <section> #}
-                    
+            {# <section> #}
+
                 <table id="viewable">
                     {# <caption class="vf-table__caption">Images with OME-NGFF representations</caption> #}
                     {# <colgroup>
-                          <col span="1" style="width: 20%;">
-                          <col span="1" style="width: 40%;">
-                          <col span="1" style="width: 30%;">
-                          <col span="1" style="width: 10%;">
+                        <col span="1" style="width: 20%;">
+                        <col span="1" style="width: 40%;">
+                        <col span="1" style="width: 30%;">
+                        <col span="1" style="width: 10%;">
                     </colgroup> #}
                     <thead>
                         <tr>
@@ -107,81 +107,81 @@
                             </td>
                             <td>{{ image.original_relpath }}</td>
                             {% if image.dimensions %}
-                                <td>{{ image.dimensions }}</td>
+                            <td>{{ image.dimensions }}</td>
                             {% elif image.attributes.get('SizeX') %}
-                                <td> ({{ image.attributes['SizeT'] }}, {{ image.attributes['SizeC'] }}, {{ image.attributes['SizeZ'] }}, {{ image.attributes['SizeY'] }}, {{ image.attributes['SizeX'] }})</td>
+                            <td> ({{ image.attributes['SizeT'] }}, {{ image.attributes['SizeC'] }}, {{ image.attributes['SizeZ'] }}, {{ image.attributes['SizeY'] }}, {{ image.attributes['SizeX'] }})</td>
                             {% else %}
-                                <td> None </td>
+                            <td> None </td>
                             {% endif %}
                             {% if "download_size" in image.attributes %}
-                                <td>{{ image.attributes["download_size"] }}</td>
+                            <td>{{ image.attributes["download_size"] }}</td>
                             {% else %}
-                                <td>Unavailable</td>
+                            <td>Unavailable</td>
                             {% endif %}
                             <td>
                                 <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
-                                <a href={{ image_download_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">download</button></a>
+                                        <a href={{ image_download_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">download</button></a>
                             </td>                            
                         </tr>
                         {% endfor %}
                     </tbody>
-                  </table>
-                  {# </section> #}
-                </div>
-                <div></div>
-                <div>
-                    <h2 class="vf-section-header__heading">All images</h2>
-                </div>
-                <div>
-                  <table class="display table" id="table">
-                    <thead>
-                        <tr>
-                            <th>Image ID</th>
-                            <th>Filename</th>
-                            <th>Download Size</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for image in study.images.values() %}
-                            <td>{{ image_names[image.id] }}</td>
-                            <td>{{ image.original_relpath }}</td>
-                            {% if "download_size" in image.attributes %}
-                                <td>{{ image.attributes["download_size"] }}</td>
-                            {% else %}
-                                <td>Unavailable</td>
-                            {% endif %}
-                            <td><a href={{ image_download_uris[image.id] }}>Download</a></td>
-                        </tr>
-                        {# <tr class="vf-table__row">
-                            <td class="vf-table__cell">{{ image.id }}</td>
-                            <td class="vf-table__cell">{{ image.original_relpath }}</td>
-                            <td class="vf-table__cell--actions">
-                                <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
-                                <button class="vf-button vf-button--sm vf-button--icon">download</button>
-                            </td>                            
-                        </tr> #}
-                        {% endfor %}
-                    </tbody>
-                  </table>                      
-                  </div>
-        </section>
+                </table>
+                {# </section> #}
+        </div>
+        <div></div>
+        <div>
+            <h2 class="vf-section-header__heading">All images</h2>
+        </div>
+        <div>
+            <table class="display table" id="table">
+                <thead>
+                    <tr>
+                        <th>Image ID</th>
+                        <th>Filename</th>
+                        <th>Download Size</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for image in study.images.values() %}
+                    <td>{{ image_names[image.id] }}</td>
+                    <td>{{ image.original_relpath }}</td>
+                    {% if "download_size" in image.attributes %}
+                    <td>{{ image.attributes["download_size"] }}</td>
+                    {% else %}
+                    <td>Unavailable</td>
+                    {% endif %}
+                    <td><a href={{ image_download_uris[image.id] }}>Download</a></td>
+                    </tr>
+                    {# <tr class="vf-table__row">
+                        <td class="vf-table__cell">{{ image.id }}</td>
+                        <td class="vf-table__cell">{{ image.original_relpath }}</td>
+                        <td class="vf-table__cell--actions">
+                            <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
+                                    <button class="vf-button vf-button--sm vf-button--icon">download</button>
+                        </td>                            
+                    </tr> #}
+                    {% endfor %}
+                </tbody>
+            </table>                      
+        </div>
+    </section>
 
-    </div>
-    <script>
-        $(document).ready( function () {
-            $('#table').DataTable( {
-                columnDefs: [
-                    { type: 'natural', targets: 0 }
-                ]
-            });
-        } );
-        $(document).ready( function () {
-            $('#viewable').DataTable( {
-                columnDefs: [
-                    { type: 'natural', targets: 0 }
-                ]
-            });
-        } );
-    </script>
+</div>
+<script>
+    $(document).ready( function () {
+        $('#table').DataTable( {
+            columnDefs: [
+                { type: 'natural', targets: 0 }
+            ]
+        });
+    } );
+$(document).ready( function () {
+    $('#viewable').DataTable( {
+        columnDefs: [
+            { type: 'natural', targets: 0 }
+        ]
+    });
+} );
+</script>
 {% endblock %}

--- a/static-sitegen/templates/image-landing.html.j2
+++ b/static-sitegen/templates/image-landing.html.j2
@@ -1,6 +1,6 @@
 {% extends "base.html.j2" %}
 
-{% block title %} {{ image_alias }} {% endblock %}
+{% block title %} {{ study.accession_id }}:{{ image_alias }} {% endblock %}
 
 {% block content %}
 <div class="vf-stack vf-stack--500">
@@ -24,9 +24,10 @@
     <section class="vf-content | embl-grid embl-grid--has-centered-content">
         <div>
             <button class="vf-button vf-button--primary vf-button--sm" onclick="copyTextToClipboard('{{ zarr_uri }}')">Copy S3 URI to clipboard</button>
-            <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad={{ zarr_uri }}';">Open in ITK viewer</button>
-            <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='https://hms-dbmi.github.io/vizarr/?source={{ zarr_uri }}';">Open fullscreen in Vizarr</button>
-            <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='{{ neuroglancer_uri }}';">Open in Neuroglancer</button>
+
+            <a href='https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad={{ zarr_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open in ITK viewer</button></a>
+            <a href='https://hms-dbmi.github.io/vizarr/?source={{ zarr_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open fullscreen in Vizarr</button></a>
+            <a href='{{ neuroglancer_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open in Neuroglancer</button></a>
 
             <a href={{ download_uri }}><button class="vf-button vf-button--primary vf-button--sm">Download original ({{ download_size }})</button></a>
         </div>

--- a/static-sitegen/templates/image-landing.html.j2
+++ b/static-sitegen/templates/image-landing.html.j2
@@ -1,95 +1,80 @@
-<html lang="en" class="vf-no-js">
-    <head>
-        <meta charset="UTF-8">
-        <link rel="stylesheet" href="https://assets.emblstatic.net/vf/v2.5.8/css/styles.css">
-        <title>{{ image.id }}</title>
-    </head>
+{% extends "base.html.j2" %}
 
-    <body>
-        <header class="vf-global-header">
-            <header class="vf-global-header">
+{% block title %} {{ image_alias }} {% endblock %}
 
-                <div class="vf-global-header__inner">
-          
-                  <a href="http://www.embl.de" class="vf-logo">
-                    <img class="vf-logo__image" src="/bia-integrator-data/pages/assets/BIA-Logo.png" alt="BioImage Archive">
-                    <span class="vf-logo__text">   BioImage Archive</span>
-                  </a>
-          
-                </div>
-          
-            </header>
-        </header>
+{% block content %}
+<div class="vf-stack vf-stack--500">
+    <section class="vf-intro | embl-grid embl-grid--has-centered-content">
+        <div></div>
+        <div>
+            <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ study.accession_id }}:{{ image_alias }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+            <h2 class="vf-intro__subheading">{{ image.original_relpath }}</h2>
+            <p>Study Title: {{ study.title }}</p>
+            <p>By: {{ authors }}</p>
+            <p>Organism: {{ study.organism }}</p>
+            <p>License: <a href={{ license_uri }}>{{ study.license }}</a></p>
+            <figure class="vf-figure vf-figure--align vf-figure--align-centered">
+                <img class="vf-figure__image" src="{{ image_uri }}">
+            </figure>  
 
-        <div class="vf-stack vf-stack--500">
-            <section class="vf-intro | embl-grid embl-grid--has-centered-content">
-                <div></div>
-                <div>
-                    <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ study.accession_id }}:{{ image_alias }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
-                    <h2 class="vf-intro__subheading">{{ image.original_relpath }}</h2>
-                    <p>Study Title: {{ study.title }}</p>
-                    <p>By: {{ authors }}</p>
-                    <p>Organism: {{ study.organism }}</p>
-                    <p>License: <a href={{ license_uri }}>{{ study.license }}</a></p>
-                    <figure class="vf-figure vf-figure--align vf-figure--align-centered">
-                        <img class="vf-figure__image" src="{{ image_uri }}">
-                    </figure>  
-
-                </div>
-                <div></div>
-            </section>
-            <!-- Study information -->
-            <section class="vf-content | embl-grid embl-grid--has-centered-content">
-                <div>
-                    <button class="vf-button vf-button--primary vf-button--sm" onclick="copyTextToClipboard('{{ zarr_uri }}')">Copy S3 URI to clipboard</button>
-                    <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad={{ zarr_uri }}';">Open in ITK viewer</button>
-                    <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='https://hms-dbmi.github.io/vizarr/?source={{ zarr_uri }}';">Open fullscreen in Vizarr</button>
-                    <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='{{ neuroglancer_uri }}';">Open in Neuroglancer</button>
-
-                    <a href={{ download_uri }}><button class="vf-button vf-button--primary vf-button--sm">Download original ({{ download_size }})</button></a>
-                </div>
-                <div>
-                    <iframe style="width: 100%; height: 500px" name="vizarr" src="https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source={{ zarr_uri }}"></iframe>
-                </div>
-
-                <div>
-                    <h2 class="vf-section-header__heading">Image metadata</h2>
-                    <p></p>
-                    <b> Image Dimensions </b>: {{ dimensions }}
-                    {% if pdims != None %}
-                        <div> <b> Physical Dimensions </b>: {{ pdims }} </div>
-                    {% endif %}
-                    {% if psize != None %}
-                        <div> <b> Pixel/Voxel Size </b>: {{ psize }} </div>
-                    {% endif %}
-                    {% if image.attributes.get('SizeC') %}
-                        <div> <b> Number of Channels</b> : {{ image.attributes['SizeC'] }} </div>
-                    {% endif %}
-                    {% if image.attributes.get('SizeT') %}
-                        {% if image.attributes['SizeT'] != 1 %}
-                            <div> <b> Number of Time Points </b>: {{ image.attributes['SizeT'] }} </div>
-                        {% endif %}
-                    {% endif %}
-                    {% for key, value in image.attributes.items() %}
-                        {% if 'Size' not in key %} 
-                            {% if key not in ['DimensionOrder','md5'] %}
-                                <div> <b>{{key}}</b> : {{value}} </div>
-                            {% endif %}
-                        {% endif %}
-                    {% endfor %}
-                </div>
-                <div>
-                    <div class="vf-content">
-                        <div class="vf-grid vf-grid__col-2">
-
-                        </div>
-                    </div>
-                </div>
-                <div></div>
-            </section>
- 
         </div>
-    </body>
+        <div></div>
+    </section>
+    <!-- Study information -->
+    <section class="vf-content | embl-grid embl-grid--has-centered-content">
+        <div>
+            <button class="vf-button vf-button--primary vf-button--sm" onclick="copyTextToClipboard('{{ zarr_uri }}')">Copy S3 URI to clipboard</button>
+            <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad={{ zarr_uri }}';">Open in ITK viewer</button>
+            <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='https://hms-dbmi.github.io/vizarr/?source={{ zarr_uri }}';">Open fullscreen in Vizarr</button>
+            <button class="vf-button vf-button--primary vf-button--sm" onclick="location.href='{{ neuroglancer_uri }}';">Open in Neuroglancer</button>
+
+            <a href={{ download_uri }}><button class="vf-button vf-button--primary vf-button--sm">Download original ({{ download_size }})</button></a>
+        </div>
+        <div>
+            <iframe style="width: 100%; height: 500px" name="vizarr" src="https://uk1s3.embassy.ebi.ac.uk/bia-zarr-test/vizarr/index.html?source={{ zarr_uri }}"></iframe>
+        </div>
+
+        <div>
+            <h2 class="vf-section-header__heading">Image metadata</h2>
+            <p></p>
+            <b> Image Dimensions </b>: {{ dimensions }}
+            {% if pdims != None %}
+                <div> <b> Physical Dimensions </b>: {{ pdims }} </div>
+            {% endif %}
+            {% if psize != None %}
+                <div> <b> Pixel/Voxel Size </b>: {{ psize }} </div>
+            {% endif %}
+            {% if image.attributes.get('SizeC') %}
+                <div> <b> Number of Channels</b> : {{ image.attributes['SizeC'] }} </div>
+            {% endif %}
+            {% if image.attributes.get('SizeT') %}
+                {% if image.attributes['SizeT'] != 1 %}
+                    <div> <b> Number of Time Points </b>: {{ image.attributes['SizeT'] }} </div>
+                {% endif %}
+            {% endif %}
+            {% for key, value in image.attributes.items() %}
+                {% if 'Size' not in key %} 
+                    {% if key not in ['DimensionOrder','md5'] %}
+                        <div> <b>{{key}}</b> : {{value}} </div>
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+        </div>
+        <div>
+            <div class="vf-content">
+                <div class="vf-grid vf-grid__col-2">
+
+                </div>
+            </div>
+        </div>
+        <div></div>
+    </section>
+</div>
+{% endblock %}
+    
+
+
+{% block post_body_scripts %}
     <script>
         function copyTextToClipboard(text) {
             var textArea = document.createElement("textarea");
@@ -125,4 +110,4 @@
         }
     </script>
     <script type="text/javascript" src="https://kitware.github.io/itk-vtk-viewer/app/itkVtkViewerCDN.js"></script>
-</html>
+{% endblock %}

--- a/static-sitegen/templates/image-landing.html.j2
+++ b/static-sitegen/templates/image-landing.html.j2
@@ -1,5 +1,9 @@
 {% extends "base.html.j2" %}
 
+{% block header_extras %}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+{% endblock %}
+
 {% block title %} {{ study.accession_id }}:{{ image_alias }} {% endblock %}
 
 {% block content %}
@@ -40,25 +44,25 @@
             <p></p>
             <b> Image Dimensions </b>: {{ dimensions }}
             {% if pdims != None %}
-                <div> <b> Physical Dimensions </b>: {{ pdims }} </div>
+            <div> <b> Physical Dimensions </b>: {{ pdims }} </div>
             {% endif %}
             {% if psize != None %}
-                <div> <b> Pixel/Voxel Size </b>: {{ psize }} </div>
+            <div> <b> Pixel/Voxel Size </b>: {{ psize }} </div>
             {% endif %}
             {% if image.attributes.get('SizeC') %}
-                <div> <b> Number of Channels</b> : {{ image.attributes['SizeC'] }} </div>
+            <div> <b> Number of Channels</b> : {{ image.attributes['SizeC'] }} </div>
             {% endif %}
             {% if image.attributes.get('SizeT') %}
-                {% if image.attributes['SizeT'] != 1 %}
-                    <div> <b> Number of Time Points </b>: {{ image.attributes['SizeT'] }} </div>
-                {% endif %}
+            {% if image.attributes['SizeT'] != 1 %}
+            <div> <b> Number of Time Points </b>: {{ image.attributes['SizeT'] }} </div>
+            {% endif %}
             {% endif %}
             {% for key, value in image.attributes.items() %}
-                {% if 'Size' not in key %} 
-                    {% if key not in ['DimensionOrder','md5'] %}
-                        <div> <b>{{key}}</b> : {{value}} </div>
-                    {% endif %}
-                {% endif %}
+            {% if 'Size' not in key %} 
+            {% if key not in ['DimensionOrder','md5'] %}
+            <div> <b>{{key}}</b> : {{value}} </div>
+            {% endif %}
+            {% endif %}
             {% endfor %}
         </div>
         <div>
@@ -72,43 +76,43 @@
     </section>
 </div>
 {% endblock %}
-    
+
 
 
 {% block post_body_scripts %}
-    <script>
-        function copyTextToClipboard(text) {
-            var textArea = document.createElement("textarea");
-            // Place in the top-left corner of screen regardless of scroll position.
-            textArea.style.position = 'fixed';
+<script>
+    function copyTextToClipboard(text) {
+        var textArea = document.createElement("textarea");
+        // Place in the top-left corner of screen regardless of scroll position.
+        textArea.style.position = 'fixed';
 
-            textArea.value = text;
+        textArea.value = text;
 
-            document.body.appendChild(textArea);
-            textArea.focus();
-            textArea.select();
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
 
-            var successful;
-            try {
-                successful = document.execCommand('copy');
-            } catch (err) {
-                console.log('Oops, unable to copy');
-            }
-            document.body.removeChild(textArea);
-
-            if (successful) {
-                // show user that copying happened - update text on element (e.g. button)
-                let target = event.target;
-                let html = target.innerHTML;
-                target.classList.add("shake");
-                setTimeout(() => {
-                    // reset after 1 second
-                    target.classList.remove("shake");
-                }, 1000)
-            } else {
-                console.log("Copying failed")
-            }
+        var successful;
+        try {
+            successful = document.execCommand('copy');
+        } catch (err) {
+            console.log('Oops, unable to copy');
         }
-    </script>
-    <script type="text/javascript" src="https://kitware.github.io/itk-vtk-viewer/app/itkVtkViewerCDN.js"></script>
+        document.body.removeChild(textArea);
+
+        if (successful) {
+            // show user that copying happened - update text on element (e.g. button)
+            let target = event.target;
+            let html = target.innerHTML;
+            target.classList.add("shake");
+            setTimeout(() => {
+                // reset after 1 second
+                target.classList.remove("shake");
+            }, 1000)
+        } else {
+            console.log("Copying failed")
+        }
+    }
+</script>
+<script type="text/javascript" src="https://kitware.github.io/itk-vtk-viewer/app/itkVtkViewerCDN.js"></script>
 {% endblock %}


### PR DESCRIPTION
This branch allows giving a consistent look and feel to the visualisation pages by extension of a base template which frames contents around the current BIA website look. Google analytics were incorporated into the base template, and modifications to the collection, dataset and image pages were made:

1. If no zips in study display single line for number of files
2. Modify base template so content uses more screen real estate
3. Allow sorting of columns in collection landing page
4. Include release date in collection landing page
5. Make dataset pages more like those in AI collection
    - remove study type
    - add license
    - add link to original submission
6. Make image landing pages more web analytics friendly
    - change viewer buttons to links (so they are captured as events)
    - add accession number and image alias to title