### PR TITLE
Handle zarrs in snakemake workflow

### DIFF
--- a/tools/scripts/assign_zipped_zarr_from_filerefs.py
+++ b/tools/scripts/assign_zipped_zarr_from_filerefs.py
@@ -22,7 +22,7 @@ def main(accession_id):
     filerefs = bia_study.file_references
 
     for fileref in filerefs.values():
-        if "ome.zarr" in fileref.name:
+        if ".zarr" in fileref.name:
             name = fileref.name
 
             hash_input = fileref.id

--- a/tools/scripts/generate_image_download_size_annotations.py
+++ b/tools/scripts/generate_image_download_size_annotations.py
@@ -35,23 +35,24 @@ def get_image_download_size(accession_id: str) -> dict:
 
     for bia_image in bia_study.images.values():
         for image_representation in bia_image.representations:
-            # TODO: Revisit this when we start dealing with representations
-            # composed of more than one file reference
-            fileref_ids = image_representation.attributes["fileref_ids"]
-            n_fileref_ids = len(fileref_ids)
-            if n_fileref_ids > 1:
-                warning_str = [
-                    f"image_representation in {bia_image.accession_id} "
-                    f"with ID: {bia_image.id} has {n_fileref_ids} file "
-                    "references. However, only the first one is being "
-                    "used to compute download size"
-                ]
-                logger.warning(warning_str)
-            if image_representation.type == "fire_object" and image_representation.uri.endswith(".zip"):
-                download_size = f"In {zip_sizes[image_representation.uri]} zip"
-            else:
-                download_size = sizeof_fmt(bia_study.file_references[fileref_ids[0]].size_in_bytes)
-                
+            if image_representation.type in ["zipped_zarr", "fire_object"]:
+                # TODO: Revisit this when we start dealing with representations
+                # composed of more than one file reference
+                fileref_ids = image_representation.attributes["fileref_ids"]
+                n_fileref_ids = len(fileref_ids)
+                if n_fileref_ids > 1:
+                    warning_str = [
+                        f"image_representation in {bia_image.accession_id} "
+                        f"with ID: {bia_image.id} has {n_fileref_ids} file "
+                        "references. However, only the first one is being "
+                        "used to compute download size"
+                    ]
+                    logger.warning(warning_str)
+                if image_representation.type == "fire_object" and image_representation.uri.endswith(".zip"):
+                    download_size = f"In {zip_sizes[image_representation.uri]} zip"
+                else:
+                    download_size = sizeof_fmt(bia_study.file_references[fileref_ids[0]].size_in_bytes)
+                    
             download_sizes[bia_image.id] = download_size
                 
     return download_sizes

--- a/tools/scripts/generate_image_download_size_annotations.py
+++ b/tools/scripts/generate_image_download_size_annotations.py
@@ -35,23 +35,23 @@ def get_image_download_size(accession_id: str) -> dict:
 
     for bia_image in bia_study.images.values():
         for image_representation in bia_image.representations:
-            if image_representation.type == "fire_object":
-                # TODO: Revisit this when we start dealing with representations
-                # composed of more than one file reference
-                fileref_ids = image_representation.attributes["fileref_ids"]
-                n_fileref_ids = len(fileref_ids)
-                if n_fileref_ids > 1:
-                    warning_str = [
-                        f"image_representation in {bia_image.accession_id} "
-                        f"with ID: {bia_image.id} has {n_fileref_ids} file "
-                        "references. However, only the first one is being "
-                        "used to compute download size"
-                    ]
-                    logger.warning(warning_str)
-                if image_representation.uri.endswith(".zip"):
-                    download_size = f"In {zip_sizes[image_representation.uri]} zip"
-                else:
-                    download_size = sizeof_fmt(bia_study.file_references[fileref_ids[0]].size_in_bytes)
+            # TODO: Revisit this when we start dealing with representations
+            # composed of more than one file reference
+            fileref_ids = image_representation.attributes["fileref_ids"]
+            n_fileref_ids = len(fileref_ids)
+            if n_fileref_ids > 1:
+                warning_str = [
+                    f"image_representation in {bia_image.accession_id} "
+                    f"with ID: {bia_image.id} has {n_fileref_ids} file "
+                    "references. However, only the first one is being "
+                    "used to compute download size"
+                ]
+                logger.warning(warning_str)
+            if image_representation.type == "fire_object" and image_representation.uri.endswith(".zip"):
+                download_size = f"In {zip_sizes[image_representation.uri]} zip"
+            else:
+                download_size = sizeof_fmt(bia_study.file_references[fileref_ids[0]].size_in_bytes)
+                
             download_sizes[bia_image.id] = download_size
                 
     return download_sizes

--- a/tools/scripts/summarise_study_filetypes.py
+++ b/tools/scripts/summarise_study_filetypes.py
@@ -21,6 +21,19 @@ logger = logging.getLogger(__file__)
 def _get_extension(p):
     """Return the standardized file extension for a given file path."""
 
+    special_cases = {
+        ".ome.zarr.zip": ".ome.zarr.zip",
+        ".zarr.zip": ".zarr.zip",
+        ".ome.zarr": ".ome.zarr",
+        ".ome.tiff": ".ome.tiff",
+        ".ome.tif" : ".ome.tiff",
+        ".tar.gz": ".tar.gz",
+    }
+
+    for special_ext, mapped_value in special_cases.items():
+        if p.lower().endswith(special_ext):
+            return mapped_value
+    
     ext_map = {
         ".jpeg": ".jpg",
         ".tiff": ".tif",

--- a/tools/snakemake/Snakefile
+++ b/tools/snakemake/Snakefile
@@ -89,6 +89,9 @@ rule summarise_study_filetypes:
     shell:
         "{command_prefix} python {script_dir}/summarise_study_filetypes.py $ACCNO 2>&1 | tee {output}"
 
+# Create image representations for filerefs that can be converted to zarrs
+# in a straightforward manner by bioformats2raw 'easily convertable', then
+# for (zipped) zarr files
 rule auto_create_image_representations:
     input:
         work_dir + "/summarise_study_filetypes.log"
@@ -97,7 +100,10 @@ rule auto_create_image_representations:
     singularity:
         singularity_container_path
     shell:
-        "{command_prefix} python {script_dir}/assign_all_easily_convertible_images_from_filerefs.py $ACCNO 2>&1 | tee {output}"
+        """
+            {command_prefix} python {script_dir}/assign_all_easily_convertible_images_from_filerefs.py $ACCNO 2>&1 | tee {output} && \
+            {command_prefix} python {script_dir}/assign_zipped_zarr_from_filerefs.py $ACCNO 2>&1 | tee --append {output}
+        """
 
 # Set source image for file references which are AI annotations and has a source image.
 # This is the way to set which files are annotations in a dataset. 
@@ -185,7 +191,16 @@ rule convert_to_zarr_and_upload:
             # See https://snakemake.readthedocs.io/en/stable/project_info/faq.html#my-shell-command-fails-with-exit-code-0-from-within-a-pipe-what-s-wrong
             set +e
             IM_REF=$(basename {input.im_ref})
-            {command_prefix} python {script_dir}/convert_to_zarr_and_upload.py $ACCNO $IM_REF > {output.im_ref}
+            # If zipped_zarr use remote_zipped_zarr_to_s3
+            biaint images show $ACCNO $IM_REF | grep zipped_zarr
+            exitcode=$?
+            if [ $exitcode -eq 0 ]
+            then
+                {command_prefix} python {script_dir}/remote_zipped_zarr_to_s3.py $ACCNO $IM_REF > {output.im_ref}
+            else
+                # Otherwise convert and upload
+                {command_prefix} python {script_dir}/convert_to_zarr_and_upload.py $ACCNO $IM_REF > {output.im_ref}
+            fi
 
             exitcode=$?
             if [ $exitcode -eq 0 ]


### PR DESCRIPTION
This branch allows the current snakemake workflow to handle zarr files using the existing remote_zipped_zarr_to_s3.py script. It currently does not distinguish between OME and non-ome zarrs. It simply downloads zarrs unzips if necessary and uploads to S3.

Fixes issues #37 and #38 and allows #27 to be closed.