### PR TITLE
Fix Download URL for zipped_zarrs in dataset and image pages

### DIFF
--- a/static-sitegen/scripts/generate_dataset_page.py
+++ b/static-sitegen/scripts/generate_dataset_page.py
@@ -9,7 +9,8 @@ from bia_integrator_core.integrator import load_and_annotate_study
 from bia_integrator_core.interface import get_aliases
 from utils import ( get_annotation_files_in_study, 
                    get_non_annotation_images_in_study,
-                   add_annotation_download_size_attributes
+                   add_annotation_download_size_attributes,
+                   DOWNLOADABLE_REPRESENTATIONS,
 )
 
 logger = logging.getLogger(os.path.basename(__file__))
@@ -81,7 +82,7 @@ def generate_dataset_page_html(accession_id, template_fname: str):
                 image_landing_uris[image.id] = f"{accession_id}/{image.id}.html"
             if representation.type == "thumbnail":
                 image_thumbnails[image.id] = representation.uri
-            if representation.type in ["fire_object", "zipped_zarr"]:
+            if representation.type in DOWNLOADABLE_REPRESENTATIONS:
                 image_download_uris[image.id] = urllib.parse.quote(representation.uri, safe=":/")
 
     for annfile in annotation_files:

--- a/static-sitegen/scripts/generate_dataset_page.py
+++ b/static-sitegen/scripts/generate_dataset_page.py
@@ -81,7 +81,7 @@ def generate_dataset_page_html(accession_id, template_fname: str):
                 image_landing_uris[image.id] = f"{accession_id}/{image.id}.html"
             if representation.type == "thumbnail":
                 image_thumbnails[image.id] = representation.uri
-            if representation.type == "fire_object":
+            if representation.type in ["fire_object", "zipped_zarr"]:
                 image_download_uris[image.id] = urllib.parse.quote(representation.uri, safe=":/")
 
     for annfile in annotation_files:

--- a/static-sitegen/scripts/generate_image_page.py
+++ b/static-sitegen/scripts/generate_image_page.py
@@ -131,10 +131,12 @@ def generate_image_page_html(accession_id, image_id):
         except Exception:
             # Skip if any errors
             continue
-    try:
-        download_uri = urllib.parse.quote(reps_by_type["fire_object"].uri, safe=":/")
-    except KeyError:
-        download_uri = None
+
+    download_uri = None
+    for rep_type in ["fire_object", "zipped_zarr",]:
+        if rep_type in reps_by_type:
+            download_uri = urllib.parse.quote(reps_by_type[rep_type].uri, safe=":/")
+            break
     
     try:
         download_size = bia_study.images[image_id].attributes["download_size"]

--- a/static-sitegen/scripts/generate_image_page.py
+++ b/static-sitegen/scripts/generate_image_page.py
@@ -9,7 +9,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from bia_integrator_core.integrator import load_and_annotate_study
 from bia_integrator_core.interface import get_aliases
 
-from utils import format_for_html
+from utils import format_for_html, DOWNLOADABLE_REPRESENTATIONS
 
 logger = logging.getLogger(os.path.basename(__file__))
 
@@ -133,7 +133,7 @@ def generate_image_page_html(accession_id, image_id):
             continue
 
     download_uri = None
-    for rep_type in ["fire_object", "zipped_zarr",]:
+    for rep_type in DOWNLOADABLE_REPRESENTATIONS:
         if rep_type in reps_by_type:
             download_uri = urllib.parse.quote(reps_by_type[rep_type].uri, safe=":/")
             break

--- a/static-sitegen/scripts/utils.py
+++ b/static-sitegen/scripts/utils.py
@@ -1,6 +1,12 @@
 import ast
 import json
 
+# BIA image representation types that we add download uris for
+DOWNLOADABLE_REPRESENTATIONS = [
+    "fire_object",
+    "zipped_zarr",
+]
+
 # From https://stackoverflow.com/questions/1094841/get-human-readable-version-of-file-size
 def sizeof_fmt(num, suffix="B"):
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:


### PR DESCRIPTION
The addition of the zipped zarrs to the snakemake workflow introduced a bug where the download urls for the zipped zarr files were not being added to the dataset and image pages during static_site page generation. This PR fixes it.