### PR TITLE
Update VEM collection

### DIFF
--- a/static-sitegen/README.rst
+++ b/static-sitegen/README.rst
@@ -16,3 +16,10 @@ Use
 Build a collection site with:
 
     python scripts/build_collection_site.py visualisation
+
+Deployment
+----------
+
+Deploy to staging with:
+
+    bash deploy-pages-staging.sh

--- a/static-sitegen/deploy-pages-staging.sh
+++ b/static-sitegen/deploy-pages-staging.sh
@@ -1,0 +1,3 @@
+BUCKET_NAME=bia-pages-staging
+aws --endpoint-url https://uk1s3.embassy.ebi.ac.uk s3 sync tmp/pages/ s3://${BUCKET_NAME}/pages --acl public-read
+aws --endpoint-url https://uk1s3.embassy.ebi.ac.uk s3 cp BIA-Logo.png s3://${BUCKET_NAME}/assets/BIA-Logo.png --acl public-read

--- a/static-sitegen/scripts/generate_image_page.py
+++ b/static-sitegen/scripts/generate_image_page.py
@@ -145,10 +145,9 @@ def generate_image_page_html(accession_id, image_id):
 
     zarr_uri = reps_by_type["ome_ngff"].uri
 
-    neuroglancer_uri = generate_neuroglancer_link(zarr_uri)
+    neuroglancer_uri = bia_image.attributes.get("neuroglancer_link", None)
 
     bia_image.attributes = sort_dict(bia_image.attributes)
-
 
     license_uri = LICENSE_URI_LOOKUP.get(bia_study.license, "Unknown")
 

--- a/static-sitegen/scripts/generate_image_page.py
+++ b/static-sitegen/scripts/generate_image_page.py
@@ -145,8 +145,6 @@ def generate_image_page_html(accession_id, image_id):
 
     zarr_uri = reps_by_type["ome_ngff"].uri
 
-    neuroglancer_uri = bia_image.attributes.get("neuroglancer_link", None)
-
     bia_image.attributes = sort_dict(bia_image.attributes)
 
     license_uri = LICENSE_URI_LOOKUP.get(bia_study.license, "Unknown")
@@ -162,7 +160,6 @@ def generate_image_page_html(accession_id, image_id):
         dimensions=dims,
         authors=author_names,
         download_uri=download_uri,
-        neuroglancer_uri=neuroglancer_uri,
         download_size=download_size
     )
 

--- a/static-sitegen/templates/collection-vem-landing.html.j2
+++ b/static-sitegen/templates/collection-vem-landing.html.j2
@@ -1,0 +1,58 @@
+{% extends "base.html.j2" %}
+
+{% block header_extras %}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.css"/>
+<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.11.5/datatables.min.js"></script>
+<script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.1/sorting/natural.js"></script>
+{% endblock %}
+
+{% block title %} {{ collection.title }} {% endblock %}
+
+{% block content %}
+<!-- Collection summary -->
+    <section class="vf-intro | embl-grid embl-grid--has-centered-content">
+        <div></div>
+        <div>
+            <h1 class="vf-intro__heading vf-intro__heading--has-tag">{{ collection.title }}<a href="JavaScript:Void(0);" class="vf-badge vf-badge--primary vf-badge--phases">alpha</a></h1>
+            <h2 class="vf-intro__subheading">{{ collection.subtitle }}</h2>
+            <p class="vf-hero__text">{{ collection.description }}</p>
+        </div>
+        <div></div>
+    </section> 
+<!-- Images -->
+<section class="vf-card-container vf-card-container__col-3 | vf-u-background-color-ui--white vf-u-fullbleed" style="--vf-card__image--aspect-ratio: 16 / 9;">
+  <div class="vf-card-container__inner">
+ 
+
+        {% for study in studies %}
+
+        <article class="vf-card vf-card--brand vf-card--bordered">
+        <img src="{{ study.example_image_uri }}" alt="" class="vf-card__image" loading="lazy">
+        <div class="vf-card__content | vf-stack vf-stack--400">
+            <h3 class="vf-card__heading">
+                <a class="vf-card__link" href="{{ study.accession_id }}{{ page_suffix }}">{{ study.accession_id }}       <svg aria-hidden="true" class="vf-card__heading__icon | vf-icon vf-icon-arrow--inline-end" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg"><path d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z" fill="currentColor" fill-rule="nonzero"></path></svg>
+                </a>
+            </h3>
+            {% if study.attributes.get('one_summary') %}
+                <p class="vf-card__text">{{ study.attributes["one_summary"] }}</p>
+            {% else %}
+                {{ study.title }}
+                <p class="vf-card__text">
+                    <b>{{ study.imaging_type }}</b>
+                    <br>
+                    <i>{{ study.organism }}</i>
+                </p>
+            {% endif %}
+        <br>
+        </div>
+        </article>
+                  
+        {% endfor %}
+
+</section>        
+
+
+
+          </div>
+{% endblock %}

--- a/static-sitegen/templates/image-landing.html.j2
+++ b/static-sitegen/templates/image-landing.html.j2
@@ -31,8 +31,8 @@
 
             <a href='https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad={{ zarr_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open in ITK viewer</button></a>
             <a href='https://hms-dbmi.github.io/vizarr/?source={{ zarr_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open fullscreen in Vizarr</button></a>
-            {% if image.attributes.get("neuroglancer_link") %}
-                <a href='{{ neuroglancer_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open in Neuroglancer</button></a>
+            {% if image.attributes.get("_neuroglancer_link") %}
+                <a href='{{ image.attributes.get("_neuroglancer_link") }}'><button class="vf-button vf-button--primary vf-button--sm">Open in Neuroglancer</button></a>
             {% endif %}
             <a href={{ download_uri }}><button class="vf-button vf-button--primary vf-button--sm">Download original ({{ download_size }})</button></a>
         </div>
@@ -61,7 +61,9 @@
             {% for key, value in image.attributes.items() %}
             {% if 'Size' not in key %} 
             {% if key not in ['DimensionOrder','md5'] %}
-            <div> <b>{{key}}</b> : {{value}} </div>
+              {% if not key.startswith("_") %}
+                <div> <b>{{key}}</b> : {{value}} </div>
+              {% endif %}
             {% endif %}
             {% endif %}
             {% endfor %}

--- a/static-sitegen/templates/image-landing.html.j2
+++ b/static-sitegen/templates/image-landing.html.j2
@@ -31,8 +31,9 @@
 
             <a href='https://kitware.github.io/itk-vtk-viewer/app/?fileToLoad={{ zarr_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open in ITK viewer</button></a>
             <a href='https://hms-dbmi.github.io/vizarr/?source={{ zarr_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open fullscreen in Vizarr</button></a>
-            <a href='{{ neuroglancer_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open in Neuroglancer</button></a>
-
+            {% if image.attributes.get("neuroglancer_link") %}
+                <a href='{{ neuroglancer_uri }}'><button class="vf-button vf-button--primary vf-button--sm">Open in Neuroglancer</button></a>
+            {% endif %}
             <a href={{ download_uri }}><button class="vf-button vf-button--primary vf-button--sm">Download original ({{ download_size }})</button></a>
         </div>
         <div>


### PR DESCRIPTION
This PR:

a) Updates the VEM collection to use the AI datasets collection landing style.
b) Changes neuroglancer link handling (only display if the link exists as an attribute, since it doesn't work well for many images).
c) Adds a deploy script to push to the newly provisioned staging bucket for pages (so we can test without breaking the existing pages).

New VEM pages visible here:

https://uk1s3.embassy.ebi.ac.uk/bia-pages-staging/pages/vem.html