### PR TITLE
This makes snakemake check for env variables and warn you if they're not set

### DIFF
--- a/tools/snakemake/Snakefile
+++ b/tools/snakemake/Snakefile
@@ -42,7 +42,15 @@ import re
 import subprocess
 import os
 
-# Set directory for artefacts
+envvars:
+    "ACCNO",
+    "bioformats2raw_java_home",
+    "bioformats2raw_bin",
+    "AWS_PROFILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    
+# ToDo: use variable for work_dir
 work_dir = "work_dir/" + os.environ["ACCNO"]
 
 # Get number of images to convert to zarr format


### PR DESCRIPTION
I've specifically not added so env vars to this patch because they have sane defaults