### PR TITLE
Generate static page artefacts via api

### DIFF
--- a/static-sitegen/scripts/build_collection_site.py
+++ b/static-sitegen/scripts/build_collection_site.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import click
 
 from bia_integrator_core.collection import get_collection
+from bia_integrator_core.study import get_study
 from bia_integrator_core.integrator import load_and_annotate_study
 
 from generate_collection_page import generate_collection_page_html
@@ -42,12 +43,16 @@ def main(collection_name):
     output_base_dirpath = Path("tmp/pages")
     output_base_dirpath.mkdir(exist_ok=True, parents=True)
 
-    dataset_template_fname = collection.attributes.get(
-        "dataset_landing_template", DEFAULT_DATASET_TEMPLATE
-    )
+    dataset_template_fname = DEFAULT_DATASET_TEMPLATE 
+    #dataset_template_fname = collection.attributes.get(
+    #    "dataset_landing_template", DEFAULT_DATASET_TEMPLATE
+    #)
 
-    page_suffix = collection.attributes.get("page-suffix", ".html")
-    for accession_id in collection.accession_ids:
+    page_suffix = ".html"
+    #page_suffix = collection.attributes.get("page-suffix", ".html")
+    
+    accession_ids = [get_study(study_uuid=study_uuid).accession_id for study_uuid in collection.study_uuids]
+    for accession_id in accession_ids:
         logger.info(f"Generating dataset page for {accession_id}")
         rendered_html = generate_dataset_page_html(accession_id, dataset_template_fname)
         output_fpath = output_base_dirpath/f"{accession_id}{page_suffix}"
@@ -60,10 +65,6 @@ def main(collection_name):
     collection_page_fpath = output_base_dirpath/f"{collection.name}.html"
     with open(collection_page_fpath, "w") as fh:
         fh.write(collection_page_html)
-
-                
-
-
 
 if __name__ == "__main__":
     main()

--- a/static-sitegen/scripts/generate_collection_page.py
+++ b/static-sitegen/scripts/generate_collection_page.py
@@ -5,7 +5,8 @@ import click
 from jinja2 import Environment, FileSystemLoader, select_autoescape # type: ignore 
 
 from bia_integrator_core.collection import get_collection
-from bia_integrator_core.models import BIACollection
+from bia_integrator_core.study import get_study
+from bia_integrator_core._models import BIACollection
 from bia_integrator_core.interface import load_and_annotate_study
 from utils import ( get_annotation_files_in_study, 
                    get_non_annotation_images_in_study)
@@ -23,18 +24,21 @@ DEFAULT_TEMPLATE = "collection-landing.html.j2"
 
 def generate_collection_page_html(collection: BIACollection) -> str:
 
-    template_fname = collection.attributes.get("collection_landing_template", DEFAULT_TEMPLATE)
+    #template_fname = collection.attributes.get("collection_landing_template", DEFAULT_TEMPLATE)
+    template_fname = DEFAULT_TEMPLATE
     
-    bia_studies = [load_and_annotate_study(accession_id) for accession_id in collection.accession_ids]
+    accession_ids = [get_study(study_uuid=study_uuid).accession_id for study_uuid in collection.study_uuids]
+    bia_studies = [load_and_annotate_study(accession_id) for accession_id in accession_ids]
 
-    page_suffix = collection.attributes.get("page-suffix", ".html")
+    #page_suffix = collection.attributes.get("page-suffix", ".html")
+    page_suffix = ".html"
     logger.info(f"Loading template {template_fname}")
     logger.info(f"Using dataset page suffix: {page_suffix}")
 
     # Calculate the number of images and number of annotations in a study
     # Put it as an attribute of the study to pass it to collection template
     for bia_study in bia_studies:
-        len_images = len(bia_study.images.keys()) 
+        len_images = len(bia_study.images) 
         bia_study.attributes['no_of_images'] = len_images
         ann_files = get_annotation_files_in_study(bia_study)
         if ann_files:

--- a/static-sitegen/scripts/generate_image_page.py
+++ b/static-sitegen/scripts/generate_image_page.py
@@ -6,8 +6,9 @@ import urllib.parse
 import click
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from bia_integrator_core.integrator import load_and_annotate_study
+from bia_integrator_core.study import get_study
 from bia_integrator_core.interface import get_image, to_uuid
+from scripts.extract_ome_metadata import sanitise_image_metadata
 
 from utils import format_for_html, DOWNLOADABLE_REPRESENTATIONS
 
@@ -59,10 +60,14 @@ def generate_neuroglancer_link(uri: str):
     return neuroglancer_uri
 
 
-def generate_image_page_html(accession_id: str, image_id):
+def generate_image_page_html(accession_id: str, image_uuid):
 
-    bia_study = load_and_annotate_study(accession_id)
-    bia_image = get_image(accession_id, image_id)
+    bia_study = get_study(accession_id)
+    bia_image = get_image(image_uuid)
+    author_names = ', '.join([ 
+        author.name
+        for author in bia_study.authors
+    ])
 
     reps_by_type = {
         representation.type: representation
@@ -114,6 +119,7 @@ def generate_image_page_html(accession_id: str, image_id):
 
 
     # If an attribute is in form of json format to display indented in html
+    bia_image.attributes = sort_dict(sanitise_image_metadata(bia_image.attributes))
     for key, attribute in bia_image.attributes.items():
         try:
             if attribute.find("{") >= 0:
@@ -125,19 +131,23 @@ def generate_image_page_html(accession_id: str, image_id):
     download_uri = None
     for rep_type in DOWNLOADABLE_REPRESENTATIONS:
         if rep_type in reps_by_type:
-            download_uri = urllib.parse.quote(reps_by_type[rep_type].uri, safe=":/")
+            download_uri = urllib.parse.quote(reps_by_type[rep_type].uri[0], safe=":/")
             break
     
     try:
-        download_size = bia_study.images[image_id].attributes["download_size"]
+        download_size = bia_image.attributes["download_size"]
     except KeyError:
         download_size = "?MiB"
 
-    zarr_uri = reps_by_type["ome_ngff"].uri
+    zarr_uri = reps_by_type["ome_ngff"].uri[0]
 
-    bia_image.attributes = sort_dict(bia_image.attributes)
 
-    license_uri = LICENSE_URI_LOOKUP.get(bia_study.license, "Unknown")
+    #TODO: Discuss with LA/MH
+    try:
+        license_uri = LICENSE_URI_LOOKUP.get(bia_study.license, "Unknown")
+    except AttributeError:
+        license_uri = "Unknown"
+
 
     rendered = template.render(
         study=bia_study,
@@ -158,12 +168,10 @@ def generate_image_page_html(accession_id: str, image_id):
 
 @click.command()
 @click.argument("accession_id")
-@click.argument("image_id")
-def main(accession_id, image_id):
+@click.argument("image_uuid")
+def main(accession_id, image_uuid):
 
     logging.basicConfig(level=logging.INFO)
-
-    image_uuid = to_uuid(image_id, lambda: get_image(accession_id, image_id))
 
     rendered = generate_image_page_html(accession_id, image_uuid)
 

--- a/static-sitegen/scripts/utils.py
+++ b/static-sitegen/scripts/utils.py
@@ -20,7 +20,7 @@ def get_annotation_files_in_study(bia_study):
     """Generate list of files in study that are annotations of another image."""
     
     return [
-        fileref for fileref in bia_study.file_references.values()
+        fileref for fileref in bia_study.file_references
         if "source image" in fileref.attributes
     ]
 

--- a/static-sitegen/templates/dataset-landing.html.j2
+++ b/static-sitegen/templates/dataset-landing.html.j2
@@ -123,9 +123,9 @@
                     <tbody>
                         {% for image in images %}
                         <tr>
-                            <td>{{ image_names[image.id] }}</td>
+                            <td>{{ image_names[image.uuid] }}</td>
                             <td>
-                                <img class="vf-figure__image" src={{ image_thumbnails[image.id] }}>
+                                <img class="vf-figure__image" src={{ image_thumbnails[image.uuid] }}>
                             </td>
                             <td>{{ image.original_relpath }}</td>
                             {% if image.dimensions %}
@@ -141,8 +141,8 @@
                             <td>Unavailable</td>
                             {% endif %}
                             <td>
-                                <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
-                                        <a href={{ image_download_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">download</button></a>
+                                <a href={{ landing_uris[image.uuid] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
+                                        <a href={{ image_download_uris[image.uuid] }}><button class="vf-button vf-button--sm vf-button--icon">download</button></a>
                             </td>                            
                         </tr>
                         {% endfor %}
@@ -165,21 +165,21 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for image in study.images.values() %}
-                    <td>{{ image_names[image.id] }}</td>
+                    {% for image in study.images %}
+                    <td>{{ image_names[image.uuid] }}</td>
                     <td>{{ image.original_relpath }}</td>
                     {% if "download_size" in image.attributes %}
                     <td>{{ image.attributes["download_size"] }}</td>
                     {% else %}
                     <td>Unavailable</td>
                     {% endif %}
-                    <td><a href={{ image_download_uris[image.id] }}>Download</a></td>
+                    <td><a href={{ image_download_uris[image.uuid] }}>Download</a></td>
                     </tr>
                     {# <tr class="vf-table__row">
-                        <td class="vf-table__cell">{{ image.id }}</td>
+                        <td class="vf-table__cell">{{ image.uuid }}</td>
                         <td class="vf-table__cell">{{ image.original_relpath }}</td>
                         <td class="vf-table__cell--actions">
-                            <a href={{ landing_uris[image.id] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
+                            <a href={{ landing_uris[image.uuid] }}><button class="vf-button vf-button--sm vf-button--icon">view</button><a>
                                     <button class="vf-button vf-button--sm vf-button--icon">download</button>
                         </td>                            
                     </tr> #}

--- a/tools/scripts/extract_ome_metadata.py
+++ b/tools/scripts/extract_ome_metadata.py
@@ -2,7 +2,7 @@ import logging
 import click
 import json
 from bia_integrator_core.integrator import load_and_annotate_study
-from bia_integrator_core.models import BIAImage, ImageAnnotation
+from bia_integrator_api.models import BIAImage, ImageAnnotation
 from bia_integrator_core.interface import persist_image_annotation
 
 logger = logging.getLogger(__file__)
@@ -16,12 +16,13 @@ def sanitise_image_metadata(metadata: dict) -> dict:
 
     # Get keys and exclude those ending with '_unit' for special treatment
     # The are only included if associated with a value.
-    metadata_keys = [k for k in metadata.keys() if not k.endswith("_unit")]
+    metadata_keys = [k for k in metadata.keys() if not k.endswith("_unit") and not k.startswith("http")]
 
+    to_exclude = ("null", "None", "[]")
     sanitised = {}
     for metadata_key in metadata_keys:
         metadata_value = metadata[metadata_key]
-        if metadata_value is None or metadata_value == "null":
+        if metadata_value is None or metadata_value in to_exclude:
             continue
         elif type(metadata_value) is list:
             if len(metadata_value) == 0:

--- a/tools/scripts/list_ngff_uri_mappings.py
+++ b/tools/scripts/list_ngff_uri_mappings.py
@@ -1,7 +1,7 @@
 import typer
 
-from bia_integrator_core.integrator import load_and_annotate_study
-from bia_integrator_tools.utils import get_ome_ngff_rep
+from bia_integrator_core.image import get_images
+from bia_integrator_tools.utils import get_ome_ngff_rep, list_of_objects_to_dict
 
 app = typer.Typer()
 
@@ -9,21 +9,22 @@ app = typer.Typer()
 @app.command()
 def list_ngff_uri_mappings(accession_id: str):
 
-    bia_study = load_and_annotate_study(accession_id)
+    images = list_of_objects_to_dict(get_images(accession_id))
 
     possible_ome_ngffs = {
-        image_id: get_ome_ngff_rep(image)
-        for image_id, image in bia_study.images.items()
+        image.uuid: get_ome_ngff_rep(image)
+        for image in images.values()
     }
 
+
     ome_ngff_reps = {
-        image_id: rep
-        for image_id, rep in possible_ome_ngffs.items()
+        image_uuid: rep 
+        for image_uuid, rep in possible_ome_ngffs.items()
         if rep
     }
 
-    for image_id, rep in ome_ngff_reps.items():
-        print(f"{bia_study.images[image_id].original_relpath}, {rep.uri}")
+    for image_uuid, rep in ome_ngff_reps.items():
+        print(f"{images[image_uuid].original_relpath}, {rep.uri}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a rehash of #73 with cleaner commits. It allows generation of static pages using the API. However, it does not address the recent issue on the use of load_and_annotate_study (except in the static-sitegen/generate_image_page.py script).