### PR TITLE
Fix misc issues to allow snakemake pipeline to run with API

### DIFF
--- a/tools/bia_integrator_tools/cli.py
+++ b/tools/bia_integrator_tools/cli.py
@@ -182,13 +182,13 @@ def images_list(accession_id: str, output: OutputFormat = OutputFormat.PRETTY):
 @images_app.command("show")
 def images_show(
         image_uuid_or_alias: str,
-        accession_id: Annotated[Optional[str], typer.Argument(default=None)],
+        accession_id: Annotated[Optional[str], typer.Argument(default=None)] = None,
         apply_annotations: bool = True,
         output: OutputFormat = OutputFormat.PRETTY
     ):
     """
     Single argument: Must be the image UUID
-    Two arguments: Image alias first, then accession_id
+    If --accession_id used, then first argument must be Image alias
     """
 
     img = None

--- a/tools/bia_integrator_tools/omezarrmeta.py
+++ b/tools/bia_integrator_tools/omezarrmeta.py
@@ -46,7 +46,7 @@ class Axis(BaseModel):
 
 class MultiScaleImage(BaseModel):
     datasets: List[DataSet]
-    metadata: MSMetadata
+    metadata: Optional[MSMetadata]
     axes: Optional[List[Axis]]
     version: str
 

--- a/tools/scripts/annotate_study_from_zarr.py
+++ b/tools/scripts/annotate_study_from_zarr.py
@@ -6,6 +6,7 @@ from bia_integrator_core.interface import load_and_annotate_study, persist_image
 from bia_integrator_core.config import settings
 
 from get_dimensions_from_bia_zarr import zarr_rep_to_dimension_annotation
+from get_axis_names_from_bia_zarr import zarr_rep_to_axis_names_annotation
 
 logger = logging.getLogger(__file__)
 
@@ -35,10 +36,15 @@ def main(accession_id):
 
     for image_uuid, rep in zarr_reps:
         try:
-            annotation = zarr_rep_to_dimension_annotation(rep)
-            persist_image_annotation(image_uuid, annotation)
+            dims_annotation = zarr_rep_to_dimension_annotation(rep)
+            persist_image_annotation(image_uuid, dims_annotation)
             # FIXME - this is an ugly way to do this, should parse properly somewhere else
-            dims_tuple = literal_eval(annotation.value)
+            dims_tuple = literal_eval(dims_annotation.value)
+            
+            axis_names_annotation = zarr_rep_to_axis_names_annotation(rep)
+            persist_image_annotation(image_uuid, axis_names_annotation)
+            # FIXME - this is an ugly way to do this, should parse properly somewhere else
+            axis_names_tuple = literal_eval(axis_names_annotation.value)
 
             def make_and_persist_annotation(key, value):
                 ann = api_models.ImageAnnotation(
@@ -48,26 +54,34 @@ def main(accession_id):
                     state="active"
                 )
                 persist_image_annotation(image_uuid, ann)
+            
+            if len(dims_tuple) == len(axis_names_tuple):
+                # Try to create dims annotations using axes names
+                for name, value in zip(axis_names_tuple, dims_tuple):
+                    key = f"Size{name.upper()[0]}"
+                    make_and_persist_annotation(key, value)
+            else:
+                # Otherwise use implicit exptectation of t,c,z,y,x order
+                # Create default values for dims
+                zdim = 1
+                ydim = 1
+                xdim = 1
 
-            if len(dims_tuple) == 5:
-                tdim, cdim, zdim, ydim, xdim = dims_tuple
-                make_and_persist_annotation("SizeT", tdim)
-                make_and_persist_annotation("SizeC", cdim)
-            if len(dims_tuple) == 3:
-                zdim, ydim, xdim = dims_tuple
+                if len(dims_tuple) == 5:
+                    tdim, cdim, zdim, ydim, xdim = dims_tuple
+                    make_and_persist_annotation("SizeT", tdim)
+                    make_and_persist_annotation("SizeC", cdim)
+                if len(dims_tuple) == 3 or len(dims_tuple) == 4:
+                    zdim, ydim, xdim = dims_tuple[-3:]
+                if len(dims_tuple) == 2:
+                    ydim, xdim = dims_tuple
 
-
-            make_and_persist_annotation("SizeZ", zdim)
-            make_and_persist_annotation("SizeY", ydim)
-            make_and_persist_annotation("SizeX", xdim)
+                make_and_persist_annotation("SizeZ", zdim)
+                make_and_persist_annotation("SizeY", ydim)
+                make_and_persist_annotation("SizeX", xdim)
             
         except AttributeError:
             pass
-
-    
-
-
-
 
 if __name__ == main():
     main()

--- a/tools/scripts/fetch_ome_metadata_for_all_images_in_study.py
+++ b/tools/scripts/fetch_ome_metadata_for_all_images_in_study.py
@@ -7,6 +7,7 @@ from bia_integrator_core.interface import api_models
 
 import re
 from urllib.request import urlopen
+from urllib.error import HTTPError
 import tempfile
 
 @click.command()
@@ -44,7 +45,12 @@ def main(accession_id):
         )
         logging.info(f"Setting {ome_ngff_uri} as the ome xml of image {image.uuid}")
 
-        ome_metadata_contents = urlopen(ome_ngff_uri).read()
+        try:
+            ome_metadata_contents = urlopen(ome_ngff_uri).read()
+        except HTTPError as e:
+            error_message = f"Could not retrieve OME XML from {ome_ngff_uri} error message was {e}.\n\nImage {image.uuid} not updated with OME info."
+            logging.warn(error_message)
+            continue
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(ome_metadata_contents)
             # THIS IS MEGA-IMPORTANT!

--- a/tools/scripts/get_axis_names_from_bia_zarr.py
+++ b/tools/scripts/get_axis_names_from_bia_zarr.py
@@ -1,0 +1,56 @@
+import logging
+
+import click
+
+from ome_zarr.utils import info
+from ome_zarr.io import parse_url
+from ome_zarr.reader import Multiscales, Node, Reader
+from bia_integrator_core.interface import get_image, persist_image_annotation, api_models
+from bia_integrator_core.config import settings
+
+logger = logging.getLogger(__file__)
+
+
+def zarr_rep_to_axis_names_annotation(zarr_rep: api_models.BIAImageRepresentation) -> api_models.ImageAnnotation:
+    """For the given Zarr representation, find the axis names and order 
+    create an annotation using the string representation of these and return."""
+
+    logger.info(f"Loading from {zarr_rep.uri}")
+
+    zarr = parse_url(zarr_rep.uri[0])
+    reader = Reader(zarr)
+
+    nodes = [node for node in reader()]
+    assert len(nodes) == 1, "Zarr contains multiple images"
+
+    axis_names = [a["name"] for a in nodes[0].metadata["axes"]]
+
+    annotation = api_models.ImageAnnotation(
+        author_email=settings.bia_username,
+        key="axes",
+        value=str(axis_names),
+        state="active"
+    )
+
+    return annotation
+
+
+@click.command()
+@click.argument("accession_id")
+@click.argument("image_uuid")
+def main(accession_id, image_uuid):
+
+    logging.basicConfig(level=logging.INFO)
+
+    image = get_image(accession_id, image_uuid)
+    reps_by_type = {
+        rep.type: rep
+        for rep in image.representations
+    }
+
+    annotation = zarr_rep_to_axis_names_annotation(reps_by_type["ome_ngff"])
+    persist_image_annotation(image_uuid, annotation)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
bia_integrator_tools/cli.py
Typer does not seem to allow two command line arguments with one being optional, therefore changed accession-id to be an option to allow dual use of image show. If one argument -> image UUID,
or one argument-> image alias and --accession-id option

bia_integrator_tools/omezarrmeta.py
Make 'metadata' field in MultiScaleImage optional as .zattrs from S-BIAD852 did not have this

bia_integrator_tools/rendering.py
Modify assignment of dimension sizes for multiscale images to use info from 'axes' attr as opposed to assuming tczxy order especially when one dimension is missing. Missing dimensions are implicitly assumed to have size=1

scripts/fetch_ome_metadata_for_all_images_in_study.py Add try block to handle case where NGFF has no OME dir

scripts/annotate_study_from_zarr.py
- Created script to add annotation for axes - similar to that for getting dimensions
- Add annotation for axes, and use axes info in metadata when writing sizes of each dimension