### PR TITLE
updated UUID generation and bulk file and image generation in tests

### DIFF
--- a/api/Readme.md
+++ b/api/Readme.md
@@ -1,3 +1,18 @@
+### First time setup
+
+Run
+```
+poetry install
+```
+Will generate the following warning:
+```
+Warning: The current project could not be installed: No file/folder found for package bia-integrator-api
+If you do not want to install the current project use --no-root.
+If you want to use Poetry only for dependency management but not for packaging, you can set the operating mode to "non-package" in your pyproject.toml file.
+In a future version of Poetry this warning will become an error!
+```
+This can be ignored.
+
 ## Running the api
 
 ```sh
@@ -20,9 +35,54 @@ The response should be just `null` and there should be no errors in the api cont
 
 ## Development
 
-For test/debugger integration to work, **the api directory must be the root project directory in vscode**, not the bia-integrator directory 
+### Testing with VS CODE
 
-`.env_compose` was added for reference and 
+The instructions below assume you use VS Code for development.
+
+For test/debugger integration to work, **the api directory must be the root project directory in vscode**, not the bia-integrator directory.
+
+In order to run tests, the database needs to be up, which you can do by running the docker compose command listed above.
+
+You also need to have a `.env` file under the `/api/` folder. This configures the API that is tested to be able to access your locally running database. This .env file should not be committed to the package, as it would interact with the production service. You can copy & fill in the `.env_template` and use the `.env_compose` for reference.
+
+### Adding new tests
+
+Tests need to be created in a file starting with `test_` under the `tests` folder. They should be functions that start with `test_` e.g `def test_study_creation()` in the `test_study.py` file. This will allow vscode to identify them. 
+
+### Updating API code while testing.
+
+Can perform some on-the-fly testing by running the following commands:
+
+Build images and run contains:
+
+`docker compose --env-file ./.env_compose up --build -d`
+
+Create user:
+
+`curl -H "Content-Type: application/json" --request POST --data '{"email": "test@example.com", "password_plain": "test", "secret_token": "00123456789==" }'  http://localhost:8080/api/v1/auth/users/register`
+
+Get auth token
+
+`curl -H "Content-Type: application/x-www-form-urlencoded" --request POST --data 'username=test@example.com&password=test'  http://localhost:8080/api/v1/auth/token`
+
+Copy auth token which you can then use to make calls to the api. E.g. create a study:
+
+`curl -H "Content-Type: application/json" -H "Authorization: Bearer <auth token>" --request POST http://localhost:8080/api/v1/private/studies -d @study_input.json`
+
+You should be able to make your changes & can rebuild the api image with the command:
+
+`docker build -t api-bia-integrator-api:latest .`
+
+And then update the running container with your code.
+
+`docker-compose up -d`
+
+Alternatively, if using VS Code, you can open the code that is running in the docker container and make changes there directly.
+
+
+### Pushing to docker hub image registry
+
+To rebuild the api image and push it to the docker container registry.
 
 ```sh
 # Create a github personal access token here: https://github.com/settings/tokens

--- a/api/src/tests/test_image.py
+++ b/api/src/tests/test_image.py
@@ -333,7 +333,6 @@ def test_study_with_images_and_filerefs_fetch_images(
     images_fetched = set([img["uuid"] for img in rsp.json()])
     assert images_fetched == images_created
 
-
 def test_image_pagination(api_client: TestClient, existing_study: dict):
     images = make_images(api_client, existing_study, 5)
     images.sort(key=lambda img: UUID(img["uuid"]).hex)
@@ -345,7 +344,7 @@ def test_image_pagination(api_client: TestClient, existing_study: dict):
     images_fetched = rsp.json()
     assert len(images_fetched) == chunk_size
     images_chunk = images[:2]
-    assert images_chunk[0] == images_fetched[0]
+    assert images_chunk == images_fetched
 
     # 3,4
     rsp = api_client.get(

--- a/api/src/tests/util.py
+++ b/api/src/tests/util.py
@@ -324,10 +324,11 @@ def make_images(
         image_template = get_template_image(existing_study)
 
     images = []
-    for _ in range(n):
+    for i in range(n):
         img = image_template.copy()
         if not img["uuid"]:
             img["uuid"] = get_uuid()
+            img["name"] += str(i)
 
         images.append(img)
 
@@ -348,6 +349,7 @@ def make_file_references(
         file_ref = file_reference_template.copy()
         if not file_ref["uuid"]:
             file_ref["uuid"] = get_uuid()
+            file_ref["name"] += str(i)
 
         file_references.append(file_ref)
 
@@ -404,10 +406,12 @@ def get_client(**kwargs) -> TestClient:
 
     return TestClient(app.app, base_url=TEST_SERVER_BASE_URL, **kwargs)
 
-
+uuid_seed_current = int(time.time() * 1e9)
 def get_uuid() -> str:
     # @TODO: make this constant and require mongo to always be clean?
-    generated = uuid_lib.UUID(int=int(time.time() * 1000000))
+    global uuid_seed_current
+    uuid_seed_current += 1
+    generated = uuid_lib.UUID(int=int(uuid_seed_current))
 
     return str(generated)
 


### PR DESCRIPTION
Issue: the tests were more likely to accidentally generate duplicate UUIDs on Macs that linux when batch creating images or files. This was due to the less fine-grained time resolution. Coupled with the api returning 201s when the exact same study is attempted to be created (considered okay, but the behaviour should probably have control flags for it), tests would sometimes not add the expected number of images/files to the DB and fail.

This PR changes how groups of images/files are created in order to 1. make sure they have different UUIDs (by incrementing the input to the generate UUID), and 2. also varies the contents of the metadata, so that a more obvious error will be hit if 2 UUIDs were the same.

Also updates to the readme about setting up VSCode tests, expected poetry errors when setting up the package, and some commands i found useful for testing.