### PR TITLE
made tests independent of order of results when not relevant

### DIFF
--- a/api/src/tests/test_file_reference.py
+++ b/api/src/tests/test_file_reference.py
@@ -3,7 +3,6 @@ from .util import *
 import itertools
 from uuid import UUID
 
-
 def test_create_file_references(api_client: TestClient, existing_study: dict):
     uuids = [get_uuid() for _ in range(2)]
 
@@ -465,7 +464,7 @@ class TestSearchFilerefExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [fileref_fixtures[0], fileref_fixtures[2]]
+        assert unorderd_lists_equality([fileref_fixtures[0], fileref_fixtures[2]], rsp.json())
 
         rsp = api_client.post(
             "search/file_references/exact_match",
@@ -478,7 +477,7 @@ class TestSearchFilerefExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [fileref_fixtures[0]]
+        assert unorderd_lists_equality([fileref_fixtures[0]], rsp.json())
 
         rsp = api_client.post(
             "search/file_references/exact_match",
@@ -490,7 +489,7 @@ class TestSearchFilerefExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == fileref_fixtures
+        assert unorderd_lists_equality(fileref_fixtures, rsp.json())
 
         rsp = api_client.post(
             "search/file_references/exact_match",
@@ -502,7 +501,7 @@ class TestSearchFilerefExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == fileref_fixtures
+        assert unorderd_lists_equality(fileref_fixtures, rsp.json())
 
     def test_search_name(
         self, api_client: TestClient, fileref_fixtures: List[dict], existing_study: dict
@@ -517,7 +516,7 @@ class TestSearchFilerefExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [fileref_fixtures[0]]
+        assert unorderd_lists_equality([fileref_fixtures[0]], rsp.json())
 
     def test_search_uri_prefix(
         self, api_client: TestClient, fileref_fixtures: List[dict], existing_study: dict
@@ -532,7 +531,7 @@ class TestSearchFilerefExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [fileref_fixtures[0], fileref_fixtures[1]]
+        assert unorderd_lists_equality(fileref_fixtures[:2], rsp.json())
 
     def test_search_uri_prefix_not_substring(
         self, api_client: TestClient, fileref_fixtures: List[dict], existing_study: dict
@@ -562,7 +561,7 @@ class TestSearchFilerefExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [fileref_fixtures[1]]
+        assert unorderd_lists_equality([fileref_fixtures[1]], rsp.json())
 
     def test_search_pagination(self, api_client: TestClient):
         rsp = api_client.post(

--- a/api/src/tests/test_image.py
+++ b/api/src/tests/test_image.py
@@ -625,8 +625,7 @@ class TestSearchImagesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        img_fetched = rsp.json()
-        assert img_fetched == [img_fixtures[0]]
+        assert unorderd_lists_equality([img_fixtures[0]], rsp.json())
 
         rsp = api_client.post(
             "search/images/exact_match",
@@ -641,7 +640,7 @@ class TestSearchImagesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [img_fixtures[0]]
+        assert unorderd_lists_equality([img_fixtures[0]], rsp.json())
 
         rsp = api_client.post(
             "search/images/exact_match",
@@ -655,7 +654,7 @@ class TestSearchImagesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [img_fixtures[0], img_fixtures[1]]
+        assert unorderd_lists_equality(img_fixtures[:2], rsp.json())
 
         rsp = api_client.post(
             "search/images/exact_match",
@@ -669,7 +668,7 @@ class TestSearchImagesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [img_fixtures[0], img_fixtures[1]]
+        assert unorderd_lists_equality(img_fixtures[:2], rsp.json())
 
     def test_search_uri_prefix(
         self, api_client: TestClient, img_fixtures: List[dict], existing_study: dict
@@ -686,8 +685,8 @@ class TestSearchImagesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [img_fixtures[0], img_fixtures[1]]
-
+        assert unorderd_lists_equality(img_fixtures[:2], rsp.json())
+        
     def test_search_uri_prefix_not_substring(
         self, api_client: TestClient, img_fixtures: List[dict], existing_study: dict
     ):
@@ -720,6 +719,7 @@ class TestSearchImagesExactMatch:
             },
         )
         assert rsp.status_code == 200
+        assert unorderd_lists_equality([img_fixtures[1]], rsp.json())
         assert rsp.json() == [img_fixtures[1]]
 
     def test_search_pagination(self, api_client: TestClient):

--- a/api/src/tests/test_study.py
+++ b/api/src/tests/test_study.py
@@ -327,7 +327,7 @@ class TestSearchStudiesExactMatch:
         )
         assert rsp.status_code == 200
         assert len(rsp.json()) == 1
-        assert rsp.json()[0] == study_fixtures[0]
+        assert study_fixtures[0] in rsp.json()
 
         rsp = api_client.post(
             "search/studies/exact_match",
@@ -340,7 +340,7 @@ class TestSearchStudiesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [study_fixtures[1]]
+        assert unorderd_lists_equality([study_fixtures[1]], rsp.json())
 
         rsp = api_client.post(
             "search/studies/exact_match",
@@ -353,8 +353,7 @@ class TestSearchStudiesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json()[2] == study_fixtures[2]
-        assert rsp.json() == study_fixtures
+        assert unorderd_lists_equality(study_fixtures, rsp.json())
 
     def test_search_author(self, api_client: TestClient, study_fixtures: List[dict]):
         rsp = api_client.post(
@@ -367,7 +366,7 @@ class TestSearchStudiesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == study_fixtures[:-1]
+        assert unorderd_lists_equality(study_fixtures[:-1], rsp.json())
 
         rsp = api_client.post(
             "search/studies/exact_match",
@@ -379,7 +378,7 @@ class TestSearchStudiesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [study_fixtures[0]]
+        assert unorderd_lists_equality([study_fixtures[0]], rsp.json())
 
         rsp = api_client.post(
             "search/studies/exact_match",
@@ -416,7 +415,7 @@ class TestSearchStudiesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [study_fixtures[1]]
+        assert unorderd_lists_equality([study_fixtures[1]], rsp.json())
 
         rsp = api_client.post(
             "search/studies/exact_match",
@@ -428,7 +427,7 @@ class TestSearchStudiesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == study_fixtures[:-1]
+        assert unorderd_lists_equality(study_fixtures[:-1], rsp.json())
 
     def test_search_accession(self, api_client: TestClient, study_fixtures: List[dict]):
         rsp = api_client.post(
@@ -453,4 +452,5 @@ class TestSearchStudiesExactMatch:
             },
         )
         assert rsp.status_code == 200
-        assert rsp.json() == [study_fixtures[0]]
+        assert len(rsp.json()) == 1
+        assert study_fixtures[0] in rsp.json()

--- a/api/src/tests/util.py
+++ b/api/src/tests/util.py
@@ -10,6 +10,7 @@ import pytest_asyncio
 from ..models.repository import repository_create, Repository
 from ..api.auth import create_user, get_user
 import asyncio
+from collections import Counter 
 
 # @pytest.fixture
 # def api_client_private() -> TestClient:
@@ -345,7 +346,7 @@ def make_file_references(
         file_reference_template = get_template_file_reference(existing_study)
 
     file_references = []
-    for _ in range(n):
+    for i in range(n):
         file_ref = file_reference_template.copy()
         if not file_ref["uuid"]:
             file_ref["uuid"] = get_uuid()
@@ -406,15 +407,20 @@ def get_client(**kwargs) -> TestClient:
 
     return TestClient(app.app, base_url=TEST_SERVER_BASE_URL, **kwargs)
 
-uuid_seed_current = int(time.time() * 1e9)
 def get_uuid() -> str:
     # @TODO: make this constant and require mongo to always be clean?
-    global uuid_seed_current
-    uuid_seed_current += 1
-    generated = uuid_lib.UUID(int=int(uuid_seed_current))
+    generated = uuid_lib.uuid4()
 
     return str(generated)
 
+
+def unorderd_lists_equality(list1, list2) -> bool:
+    if len(list1) == len(list2):
+        for elem1 in list1:
+            if list1.count(elem1) != list2.count(elem1):
+                return False
+        return True
+    return False
 
 def assert_bulk_response_items_correct(
     api_client: TestClient,


### PR DESCRIPTION
Updated tests to use uuid4 (random uuid generation) & avoid incrementing global variables as Craig suggested. 

A number of tests were relying on generated documents having incrementally increasing uuids when created. This allowed them to compare results since the api returns them sorted by UUID by default. Therefore the tests had to be updated to cope with the documents being returned in a different order to their creation.

Also, a little fix in one of the tests where i failed to save & commit a variable name change.