### PR TITLE
added json-ld contexts to api response

### DIFF
--- a/api/.env_template
+++ b/api/.env_template
@@ -1,7 +1,9 @@
-MONGO_CONNSTRING="mongodb://user_name:user_password@mongo_host:27018/"
+# note user_name and user_password should be consitent in the next 3 rows
+MONGO_CONNSTRING="mongodb://user_name:user_password@mongo_host:27017/"
 MONGO_INITDB_ROOT_USERNAME=should_match_connstring
 MONGO_INITDB_ROOT_PASSWORD=should_match_connstring
 DB_NAME=bia_integrator
-#openssl rand -hex 32
-JWT_SECRET_KEY=long_key
-USER_CREATE_SECRET_TOKEN=some_long_secret_token
+# run: 'openssl rand -hex 32' to generate a secret key for testing
+JWT_SECRET_KEY="long_key"
+# token needs to end in ==
+USER_CREATE_SECRET_TOKEN="some_long_secret_token"

--- a/api/Readme.md
+++ b/api/Readme.md
@@ -13,6 +13,7 @@ In a future version of Poetry this warning will become an error!
 ```
 This can be ignored.
 
+
 ## Running the api
 
 ```sh

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -29,6 +29,7 @@ pyyaml = "^6.0.1"
 pytest = "^7"
 pytest-asyncio = "^0.21.1"
 black = "^23.12.1"
+rdflib = "^7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/api/src/api/public.py
+++ b/api/src/api/public.py
@@ -65,7 +65,7 @@ async def get_study(
 ) -> db_models.BIAStudy:
     study = await db.find_study_by_uuid(study_uuid)
     annotator.annotate_if_needed(study)
-
+    
     return study
 
 

--- a/api/src/models/jsonld/1.0/BiosampleContext.jsonld
+++ b/api/src/models/jsonld/1.0/BiosampleContext.jsonld
@@ -1,0 +1,9 @@
+{
+    "@vocab": "https://www.ebi.ac.uk/bioimage-archive/undefined.schema/",
+    "uuid": "@id",
+    "title": "http://purl.org/dc/terms/title",
+    "description": "http://purl.org/dc/terms/description",
+    "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/biosamples/",
+    "organism_scientific_name": "https://www.wikidata.org/wiki/Q10753560",
+    "organism_common_name": "https://www.wikidata.org/wiki/Q502895"
+}

--- a/api/src/models/jsonld/1.0/CollectionContext.jsonld
+++ b/api/src/models/jsonld/1.0/CollectionContext.jsonld
@@ -1,0 +1,14 @@
+{
+    "@vocab": "https://www.ebi.ac.uk/bioimage-archive/undefined.schema/",
+    "uuid": "@id",
+    "title": "http://purl.org/dc/terms/title",
+    "description": "http://purl.org/dc/terms/description",
+    "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/collections/",
+    "study_uuids": {
+        "@id": "http://purl.org/dc/terms/hasPart",
+        "@context": {
+            "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/studies/"
+        },
+        "@type": "@id"
+    }
+}

--- a/api/src/models/jsonld/1.0/ImageAcquisitionContext.jsonld
+++ b/api/src/models/jsonld/1.0/ImageAcquisitionContext.jsonld
@@ -1,0 +1,13 @@
+{
+    "@vocab": "https://www.ebi.ac.uk/bioimage-archive/undefined.schema/",
+    "uuid": "@id",
+    "title": "http://purl.org/dc/terms/title",
+    "description": "http://purl.org/dc/terms/description",
+    "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/image_acquisitions/",
+    "specimen_uuid": {
+        "@context": {
+            "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/specimens/"
+        },
+        "@type": "@id"
+    }
+}

--- a/api/src/models/jsonld/1.0/ImageContext.jsonld
+++ b/api/src/models/jsonld/1.0/ImageContext.jsonld
@@ -1,0 +1,21 @@
+{
+    "@vocab": "https://www.ebi.ac.uk/bioimage-archive/undefined.schema/",
+    "uuid": "@id",
+    "title": "http://purl.org/dc/terms/title",
+    "description": "http://purl.org/dc/terms/description",
+    "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/images/",
+    "study_uuid": {
+        "@id": "http://purl.org/dc/terms/isPartOf",
+        "@context": {
+            "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/biosamples/"
+        },
+        "@type": "@id"
+    },
+    "dimensions": "https://schema.org/size",
+    "image_acquisition_methods_uuid": {
+        "@context": {
+            "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/image_acquisitions/"
+        },
+        "@type": "@id"
+    }
+}

--- a/api/src/models/jsonld/1.0/SpecimenContext.jsonld
+++ b/api/src/models/jsonld/1.0/SpecimenContext.jsonld
@@ -1,0 +1,13 @@
+{
+    "@vocab": "https://www.ebi.ac.uk/bioimage-archive/undefined.schema/",
+    "uuid": "@id",
+    "title": "http://purl.org/dc/terms/title",
+    "description": "http://purl.org/dc/terms/description",
+    "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/specimens/",
+    "biosample_uuid": {
+        "@context": {
+            "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/biosamples/"
+        },
+        "@type": "@id"
+    }
+}

--- a/api/src/models/jsonld/1.0/StudyContext.jsonld
+++ b/api/src/models/jsonld/1.0/StudyContext.jsonld
@@ -1,0 +1,13 @@
+{
+    "@vocab": "https://www.ebi.ac.uk/bioimage-archive/undefined.schema/",
+    "uuid": "@id",
+    "title": "http://purl.org/dc/terms/title",
+    "description": "http://purl.org/dc/terms/description",
+    "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/studies/",
+    "authors": {
+        "@id": "http://purl.org/dc/terms/creator"
+    },
+    "organism": "https://schema.org/about",
+    "release_date": "https://schema.org/datePublished",
+    "tags": "https://schema.org/keywords"
+}

--- a/api/src/models/jsonld/1.0/StudyFileReferenceContext.jsonld
+++ b/api/src/models/jsonld/1.0/StudyFileReferenceContext.jsonld
@@ -1,0 +1,14 @@
+{
+    "@vocab": "https://www.ebi.ac.uk/bioimage-archive/undefined.schema/",
+    "uuid": "@id",
+    "title": "http://purl.org/dc/terms/title",
+    "description": "http://purl.org/dc/terms/description",
+    "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/file_references/",
+    "study_uuid": {
+        "@id": "http://purl.org/dc/terms/isPartOf",
+        "@context": {
+            "@base": "https://www.ebi.ac.uk/bioimage-archive/api/v1/studies"
+        },
+        "@type": "@id"
+    }
+}

--- a/api/src/models/persistence.py
+++ b/api/src/models/persistence.py
@@ -148,6 +148,8 @@ class BIAStudy(BIABaseModel, DocumentMixin, AnnotatedMixin[StudyAnnotation]):
     file_references_count: int = Field(default=0)
     images_count: int = Field(default=0)
 
+    context: str = Field(alias='@context', default="https://github.com/BioImage-Archive/bia-integrator/tree/main/api/src/models/jsonld/1.0/StudyContext.json")
+
     model_config = ConfigDict(model_version_latest=1)
 
 
@@ -217,6 +219,7 @@ class Biosample(BIABaseModel, DocumentMixin):
     intrinsic_variables: List[str] = Field(
         description="Intrinsic (e.g. genetic) alteration.", default=[]
     )
+    context: str = Field(alias='@context', default="https://github.com/BioImage-Archive/bia-integrator/tree/main/api/src/models/jsonld/1.0/SpecimenContext.json")
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -229,6 +232,7 @@ class Specimen(BIABaseModel, DocumentMixin):
     )  # is this a ST-only concern, or does it make sense for it to be in the models?
     sample_preparation_protocol: str = Field()
     growth_protocol: str = Field()
+    context: str = Field(alias='@context', default="https://github.com/BioImage-Archive/bia-integrator/tree/main/api/src/models/jsonld/1.0/SpecimenContext.json")
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -248,6 +252,7 @@ class ImageAcquisition(BIABaseModel, DocumentMixin):
     imaging_method: str = (
         Field()
     )  # make this an Enum / restrict some other way? Distinguishing between "somewhat close to a controlled vocabulary" vs "completely free text" might be useful
+    context: str = Field(alias='@context', default="https://github.com/BioImage-Archive/bia-integrator/tree/main/api/src/models/jsonld/1.0/ImageAcquisitionContext.json")
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -278,6 +283,7 @@ class BIAImage(BIABaseModel, DocumentMixin, AnnotatedMixin[ImageAnnotation]):
         description="Context in which the image was acquired. This list often has one item, but it can occasionally have more (e.g. for multimodal imaging)",
         default=[],
     )
+    context: str = Field(alias='@context', default="https://github.com/BioImage-Archive/bia-integrator/tree/main/api/src/models/jsonld/1.0/ImageContext.json")
 
     model_config = ConfigDict(model_version_latest=2)
 
@@ -291,6 +297,7 @@ class BIACollection(BIABaseModel, DocumentMixin, AnnotatedMixin[CollectionAnnota
     subtitle: str = Field()
     description: Optional[str] = Field(default=None)
     study_uuids: List[str] = Field(default=[])
+    context: str = Field(alias='@context', default="https://github.com/BioImage-Archive/bia-integrator/tree/main/api/src/models/jsonld/1.0/CollectionContext.json")
 
     model_config = ConfigDict(model_version_latest=1)
 

--- a/api/src/tests/test_annotations.py
+++ b/api/src/tests/test_annotations.py
@@ -7,7 +7,16 @@ Final invariants about the object (annotations not applied when they shouldn't b
 
 import pytest
 from fastapi.testclient import TestClient
-from .util import *
+from .util import (
+    get_template_image,
+    get_template_study,
+    get_template_file_reference,
+    get_template_collection,
+    DBTestMixin,
+    api_client,
+    uuid,
+    existing_study
+    )
 from ..models.repository import Repository
 import uuid as uuid_lib
 

--- a/api/src/tests/test_biosample_specimen_image_acquisition.py
+++ b/api/src/tests/test_biosample_specimen_image_acquisition.py
@@ -7,8 +7,15 @@ So they were grouped in the same test file
 """
 
 from fastapi.testclient import TestClient
-from .util import *
-
+from .util import (
+    api_client,
+    uuid,
+    existing_biosample,
+    existing_specimen,
+    existing_image_acquisition,
+    existing_study,
+    existing_image
+    )
 
 def test_biosample_create_retrieve_update(api_client: TestClient, uuid: str):
     # Note that this actually doesn't depend on any study
@@ -24,6 +31,7 @@ def test_biosample_create_retrieve_update(api_client: TestClient, uuid: str):
         "experimental_variables": ["placeholder_experimental_variable"],
         "extrinsic_variables": ["placeholder_extrinsic_variable"],
         "intrinsic_variables": ["placeholder_intrinsic_variable"],
+        "@context": "placeholder_context"
     }
     rsp = api_client.post(f"private/biosamples", json=biosample)
     assert rsp.status_code == 201, rsp.json()
@@ -54,6 +62,7 @@ def test_specimen_create_retrieve_update(
         "title": "placeholder_title",
         "sample_preparation_protocol": "placeholder_sample_preparation_protocol",
         "growth_protocol": "placeholder_growth_protocol",
+        "@context": "placeholder_context"
     }
     rsp = api_client.post(f"private/specimens", json=specimen)
     assert rsp.status_code == 201, rsp.json()
@@ -85,6 +94,7 @@ def test_image_acquisition_create_retrieve_update(
         "imaging_instrument": "placeholder_imaging_instrument",
         "image_acquisition_parameters": "placeholder_image_acquisition_parameters",
         "imaging_method": "placeholder_imaging_method",
+        "@context": "placeholder_context"
     }
     rsp = api_client.post(f"private/image_acquisitions", json=image_acquisition)
     assert rsp.status_code == 201, rsp.json()

--- a/api/src/tests/test_file_reference.py
+++ b/api/src/tests/test_file_reference.py
@@ -1,5 +1,16 @@
 from fastapi.testclient import TestClient
-from .util import *
+import pytest
+from typing import List
+from .util import (
+    get_uuid, 
+    get_template_file_reference, 
+    make_file_references, 
+    unorderd_lists_equality, 
+    assert_bulk_response_items_correct,
+    api_client,
+    existing_study,
+    existing_file_reference,
+    uuid)
 import itertools
 from uuid import UUID
 

--- a/api/src/tests/test_image.py
+++ b/api/src/tests/test_image.py
@@ -1,5 +1,18 @@
 from fastapi.testclient import TestClient
-from .util import *
+import pytest
+from typing import List
+from .util import (
+    get_uuid, 
+    make_file_references, 
+    make_images, 
+    make_study, 
+    get_study, 
+    get_template_image,
+    unorderd_lists_equality, 
+    assert_bulk_response_items_correct,
+    api_client,
+    existing_study,
+    existing_image)
 import itertools
 from uuid import UUID
 import os
@@ -17,7 +30,7 @@ def test_create_images(api_client: TestClient, existing_study: dict):
             "original_relpath": f"/home/test/{uuid}",
             "attributes": {
                 "image_uuid": uuid,
-            },
+            }
         }
         for uuid in uuids
     ]
@@ -41,7 +54,7 @@ def test_create_images_multiple_errors(api_client: TestClient, existing_study: d
             "original_relpath": f"/home/test/{uuid}",
             "attributes": {
                 "image_uuid": uuid,
-            },
+            }
         }
         for uuid in uuids
     ]

--- a/api/src/tests/test_misc.py
+++ b/api/src/tests/test_misc.py
@@ -1,5 +1,13 @@
 from fastapi.testclient import TestClient
-from .util import *
+from typing import List
+from .util import (
+    make_images, 
+    make_study,
+    api_client,
+    uuid,
+    existing_study,
+    existing_collection,
+    existing_image)
 
 
 def test_create_collection(api_client: TestClient, uuid: str):

--- a/api/src/tests/test_rdf.py
+++ b/api/src/tests/test_rdf.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+import pytest
+import rdflib
+import pathlib
+import json
+import uuid
+from typing import List
+from .util import (
+    get_template_study, 
+    get_template_biosample,
+    get_template_image,
+    get_template_file_reference,
+    get_template_collection,
+    get_template_specimen,
+    get_template_image_acquisition
+)
+
+@pytest.fixture(scope="function")
+def rdf_graph():
+    return rdflib.Graph()
+
+
+@pytest.mark.parametrize(
+    "context_file_name, json_object_dict",
+    [
+        ( 'CollectionContext.jsonld', get_template_collection(add_uuid=True) ),
+        ( 'StudyContext.jsonld', get_template_study(add_uuid=True) ),
+        ( 'ImageContext.jsonld', get_template_image({"uuid": uuid.uuid4()}, add_uuid=True) ),
+        ( 'StudyFileReferenceContext.jsonld', get_template_file_reference({"uuid": uuid.uuid4()}, add_uuid=True) ),
+        ( 'BiosampleContext.jsonld', get_template_biosample(add_uuid=True) ),
+        ( 'SpecimenContext.jsonld', get_template_specimen({"uuid": uuid.uuid4()}, add_uuid=True) ),
+        ( 'ImageAcquisitionContext.jsonld', get_template_image_acquisition({"uuid": uuid.uuid4()}, add_uuid=True) ),
+    ]
+)
+def test_context_creates_parseable_jsonld(rdf_graph: rdflib.Graph, context_file_name: str, json_object_dict: dict):
+
+    context_path = pathlib.Path(pathlib.Path.cwd() / 'src/models/jsonld/1.0' / context_file_name )
+    context = {}
+
+    isParseable = False
+    try:
+        with open(context_path) as context_file:
+            context = json.load(context_file)
+        json_object_dict["@context"] = context
+        rdf_graph.parse(data=json_object_dict, format="json-ld")
+        isParseable = True
+    except:
+        isParseable = False
+
+    assert isParseable
+    assert len(rdf_graph)>0

--- a/api/src/tests/test_study.py
+++ b/api/src/tests/test_study.py
@@ -1,5 +1,17 @@
 from fastapi.testclient import TestClient
-from .util import *
+import pytest
+from typing import List
+from .util import (
+    get_uuid, 
+    make_file_references, 
+    make_images, 
+    make_study, 
+    get_study,
+    get_template_study, 
+    unorderd_lists_equality,
+    api_client,
+    uuid,
+    existing_study)
 
 
 def test_create_study(api_client: TestClient, uuid: str):
@@ -19,7 +31,7 @@ def test_create_study(api_client: TestClient, uuid: str):
         ],
         "organism": "test",
         "release_date": "test",
-        "annotations_applied": False,
+        "annotations_applied": False
     }
     rsp = api_client.post("private/studies", json=study)
     assert rsp.status_code == 201, str(rsp)
@@ -35,6 +47,7 @@ def test_create_study(api_client: TestClient, uuid: str):
         "file_references_count": 0,
         "images_count": 0,
         "model": {"type_name": "BIAStudy", "version": 1},
+        "@context": "https://github.com/BioImage-Archive/bia-integrator/tree/main/api/src/models/jsonld/1.0/StudyContext.json"
     }
 
     study_created = get_study(api_client, uuid)
@@ -153,7 +166,7 @@ def test_update_study_not_created(api_client: TestClient, uuid: str):
                 },
             ],
             "organism": "test",
-            "release_date": "test",
+            "release_date": "test"
         }
         rsp = api_client.patch("private/studies", json=study)
         assert rsp.status_code == 404, str(rsp)

--- a/api/src/tests/util.py
+++ b/api/src/tests/util.py
@@ -3,14 +3,12 @@ from fastapi.testclient import TestClient
 from .. import app
 import uuid as uuid_lib
 from typing import List
-import time
 
 import pytest
 import pytest_asyncio
 from ..models.repository import repository_create, Repository
 from ..api.auth import create_user, get_user
 import asyncio
-from collections import Counter 
 
 # @pytest.fixture
 # def api_client_private() -> TestClient:
@@ -20,7 +18,7 @@ from collections import Counter
 #    return client
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def api_client() -> TestClient:
     client = get_client(raise_server_exceptions=False)
     authenticate_client(client)  # @TODO: DELETEME
@@ -141,6 +139,7 @@ def make_collection(api_client: TestClient, collection_attributes_override={}):
         "subtitle": "test_collection_subtitle",
         "description": "test_collection_description",
         "study_uuids": [],
+        "@context": "placeholder_context"
     }
     collection |= collection_attributes_override
 
@@ -171,6 +170,7 @@ def get_template_study(add_uuid=False):
         "images_count": 0,
         "annotations_applied": False,
         "annotations": [],
+        "@context": "placeholder_context"
     }
 
 
@@ -188,6 +188,7 @@ def get_template_biosample(add_uuid=False):
         "experimental_variables": ["placeholder_experimental_variable"],
         "extrinsic_variables": ["placeholder_extrinsic_variable"],
         "intrinsic_variables": ["placeholder_intrinsic_variable"],
+        "@context": "placeholder_context"
     }
 
 
@@ -200,6 +201,7 @@ def get_template_specimen(existing_biosample, add_uuid=False):
         "title": "placeholder_title",
         "sample_preparation_protocol": "placeholder_sample_preparation_protocol",
         "growth_protocol": "placeholder_growth_protocol",
+        "@context": "placeholder_context"
     }
 
 
@@ -213,6 +215,7 @@ def get_template_image_acquisition(existing_specimen, add_uuid=False):
         "imaging_instrument": "placeholder_imaging_instrument",
         "image_acquisition_parameters": "placeholder_image_acquisition_parameters",
         "imaging_method": "placeholder_imaging_method",
+        "@context": "placeholder_context"
     }
 
 
@@ -274,7 +277,7 @@ def get_template_file_reference(existing_study: dict, add_uuid=False):
         "attributes": {},
         "annotations": [],
         "annotations_applied": False,
-        "type": "file",
+        "type": "file"
     }
 
 
@@ -291,6 +294,7 @@ def get_template_collection(add_uuid=False):
         "attributes": {},
         "annotations": [],
         "annotations_applied": False,
+        "@context": "placeholder_context"
     }
 
 
@@ -311,6 +315,7 @@ def get_template_image(existing_study: dict, add_uuid=False):
         "alias": None,
         "representations": [],
         "image_acquisition_methods_uuid": [],
+        "@context": "placeholder_context"
     }
 
 
@@ -414,7 +419,8 @@ def get_uuid() -> str:
     return str(generated)
 
 
-def unorderd_lists_equality(list1, list2) -> bool:
+def unorderd_lists_equality(list1: list[dict], list2: list[dict]) -> bool:
+    # verbose equality check to compare lists of dictionaries created from json objects
     if len(list1) == len(list2):
         for elem1 in list1:
             if list1.count(elem1) != list2.count(elem1):


### PR DESCRIPTION
After this change requesting any of the following objects:
- Biosample
- Collection
- ImageAcquisition
- Image
- Specimen
- Study
- StudyFileReference
will return json with an @context field with a URL that points to a file in this github repo. The content type will still be 'application/json', regardless of what gets passed in.

List of changes:

1. Created JSON LD context objects, with some mapping to defined concepts in external ontologies where relevant. Includes ID mappings for objects that should point back to the appropriate BIA api endpoints. Included a generic vocabulary for all undefined terms.

2. Updated models to automatically add in a context object with a link to the github repository path where these files will exist

3. Added test that attempts to parse the json-ld using the contexts, in a similar manner to how i would expect users to parse the json. There is a slight difference, in that they should not need to manually insert the jsonld context (the link should just work), but you can't test changes while pointing to the link. 

4. changed tests that rely on the models to have some placeholder value for the context

5. changed the imports in the tests to avoid `from X import *`

6. Added some type checking & comment to the util method i created for checking unordered lists of dicts were equivalent.