### PR TITLE
Add readonly client builder

### DIFF
--- a/clients/python/bia_integrator_api/util.py
+++ b/clients/python/bia_integrator_api/util.py
@@ -8,6 +8,8 @@ import json
 import hashlib
 import uuid
 
+PUBLIC_API_URI = "https://45.88.81.209:8080"
+
 def get_access_token(api_config: Configuration, username: str, password: str) -> str:
     api_client = ApiClient(configuration=api_config)
     default_api = PrivateApi(api_client=api_client)
@@ -67,7 +69,7 @@ def simple_client(
     return client
 
 def get_client(
-    api_base_url: str = "https://45.88.81.209:8080"
+    api_base_url: str = PUBLIC_API_URI
 ) -> PublicApi:
     api_config = Configuration(
         host = api_base_url

--- a/clients/python/bia_integrator_api/util.py
+++ b/clients/python/bia_integrator_api/util.py
@@ -1,5 +1,5 @@
 from bia_integrator_api import Configuration, ApiClient
-from bia_integrator_api.api import PrivateApi
+from bia_integrator_api.api import PrivateApi, PublicApi
 from base64 import b64decode
 from typing import Optional
 import time
@@ -65,6 +65,18 @@ def simple_client(
     client = PrivateApi(api_client=api_client)
 
     return client
+
+def get_client(
+    api_base_url: str = "https://45.88.81.209:8080"
+) -> PublicApi:
+    api_config = Configuration(
+        host = api_base_url
+    )
+    api_config.verify_ssl = False
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    api_client = ApiClient(configuration=api_config)
+    return PublicApi(api_client=api_client)
 
 def uuid_from_str(doc_stable_string: str) -> str:
     hexdigest = hashlib.md5(doc_stable_string.encode("utf-8")).hexdigest()

--- a/clients/python/example/readonly_start_here.py
+++ b/clients/python/example/readonly_start_here.py
@@ -1,0 +1,8 @@
+from bia_integrator_api.util import get_client
+
+client = get_client()
+
+for study in client.search_studies(limit=10):
+    print(study.uuid)
+
+


### PR DESCRIPTION
Add readonly client builder, needed for nice explorer code (wip).

Some things ignored, to decide next wek
* do we keep simple_client (the private version) named as it is? get_client and simple_client in the same file might be confusing, but this means a rename everywhere we use a client
* do we add the api server as-is in the LB so we can get rid of the hardcoded ip and no host checking (get_client assumes yes, for tidyness)