### PR TITLE
Add howto & config to publish tags on pypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ static-sitegen/.DS_Store
 tools/.DS_Store
 .DS_Store
 **/__pycache__
+**/dist

--- a/clients/Readme.md
+++ b/clients/Readme.md
@@ -1,4 +1,6 @@
-## Generating clients
+# Python client
+
+## Generate
 
 ```sh
 # pull openapi.json
@@ -11,21 +13,28 @@ docker run -it --rm \
     -w /mnt/share \
     openapitools/openapi-generator-cli:v7.0.0 \
     generate --config openapi_config_python.yml -i openapi.json -g python -o python
+
+# helpers:
+#   config-help -g python
+#   author template -g python -o python_template
 ```
 
+## Publish
+
+Setup to publish builds on pypi:
+* Docs to get a new PyPi api token [here](https://pypi.org/help/#apitoken).
+* Docs to configure poetry to use those tokens [here](https://python-poetry.org/docs/repositories/#configuring-credentials)
+* `poetry config pypi-token.pypi <YOUR_TOKEN>`
+* `poetry self add poetry-version-plugin`
+
+Update released client:
 ```sh
-docker run -it --rm \
-    -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --user $(id -u) \
-    -v ${PWD}:/mnt/share \
-    -w /mnt/share \
-    openapitools/openapi-generator-cli:v7.0.0 \
-    config-help -g python
+# only release main
+git checkout main
+git pull
+
+git tag N.N.N
+git push origin N.N.N
+poetry build
+poetry publish
 ```
-
-
-docker run -it --rm \
-    -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --user $(id -u) \
-    -v ${PWD}:/mnt/share \
-    -w /mnt/share \
-    openapitools/openapi-generator-cli:v7.0.0 \
-    author template -g python -o python_template

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,8 +1,9 @@
 [tool.poetry]
 name = "bia-integrator-api"
-version = "0.1.0"
 description = ""
-authors = ["Your Name <you@example.com>"]
+# managed by poetry-version-plugin
+version = "000"
+authors = []
 readme = "Readme.md"
 packages = [{include = "bia_integrator_api"}]
 
@@ -16,3 +17,6 @@ aenum = ">=3.1.11"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry-version-plugin]
+source = "git-tag"


### PR DESCRIPTION
Publish api client to pypi, needed to add as a nice dependency in explorer.

Only publish tags for uniformity.