### PR TITLE
Fix race condition when db gets reused

### DIFF
--- a/api/src/api/annotator.py
+++ b/api/src/api/annotator.py
@@ -37,11 +37,10 @@ class Annotator:
             db_models.AnnotatedMixin | List[db_models.AnnotatedMixin]
         ) = False,
     ):
-        self.db.close()
-
         if not self.apply_annotations:
             return
 
+        self.db.close()
         if isinstance(response_object, list):
             for rsp_item in response_object:
                 self._apply_annotations(rsp_item)

--- a/api/src/api/annotator.py
+++ b/api/src/api/annotator.py
@@ -19,7 +19,7 @@ class Annotator:
 
     async def __call__(
         self,
-        db: Repository = Depends(),
+        db: Repository = Depends(use_cache=True),
         apply_annotations: Annotated[bool, Query()] = False,
     ):
         """
@@ -33,8 +33,9 @@ class Annotator:
 
     def annotate_if_needed(
         self,
-        response_object: db_models.AnnotatedMixin
-        | List[db_models.AnnotatedMixin] = False,
+        response_object: (
+            db_models.AnnotatedMixin | List[db_models.AnnotatedMixin]
+        ) = False,
     ):
         self.db.close()
 

--- a/api/src/api/annotator.py
+++ b/api/src/api/annotator.py
@@ -19,7 +19,7 @@ class Annotator:
 
     async def __call__(
         self,
-        db: Repository = Depends(use_cache=True),
+        db: Repository = Depends(),
         apply_annotations: Annotated[bool, Query()] = False,
     ):
         """

--- a/api/src/api/private.py
+++ b/api/src/api/private.py
@@ -22,7 +22,7 @@ router = APIRouter(
 @router.post("/studies", status_code=status.HTTP_201_CREATED)
 async def create_study(
     study: db_models.BIAStudy,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating study {study.accession_id}")
@@ -37,9 +37,7 @@ async def create_study(
 
 
 @router.patch("/studies", status_code=status.HTTP_200_OK)
-async def update_study(
-    study: db_models.BIAStudy, db: Repository = Depends(use_cache=True)
-) -> None:
+async def update_study(study: db_models.BIAStudy, db: Repository = Depends()) -> None:
     logging.info(f"Updating study {study.accession_id}. New version: {study.version}")
     await db.update_doc(study)
 
@@ -49,9 +47,7 @@ async def update_study(
 @router.post(
     "/studies/{study_uuid}/refresh_counts", status_code=status.HTTP_201_CREATED
 )
-async def study_refresh_counts(
-    study_uuid: str, db: Repository = Depends(use_cache=True)
-) -> None:
+async def study_refresh_counts(study_uuid: str, db: Repository = Depends()) -> None:
     """Recalculate and persist counts for other objects pointing to this study."""
 
     logging.info(f"Recalculating reference counts for study {study_uuid}")
@@ -64,7 +60,7 @@ async def study_refresh_counts(
 async def create_images(
     study_images: List[db_models.BIAImage],
     response: Response,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> api_models.BulkOperationResponse:
     logging.info(
@@ -101,7 +97,7 @@ async def create_images(
 
 @router.patch("/images/single", status_code=status.HTTP_200_OK)
 async def update_image(
-    study_image: db_models.BIAImage, db: Repository = Depends(use_cache=True)
+    study_image: db_models.BIAImage, db: Repository = Depends()
 ) -> None:
     """Bulk update not available - update_many only has one filter for the entire update
     @TODO: Find common bulk update usecases and map them to mongo operations"""
@@ -134,7 +130,7 @@ async def create_images_bulk() -> None:
 async def create_image_representation(
     image_uuid: str,
     representation: db_models.BIAImageRepresentation,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> None:
     logging.info(f"Adding an image representation to image {image_uuid}")
     await db.list_item_push(image_uuid, "representations", representation)
@@ -146,7 +142,7 @@ async def create_image_representation(
 async def create_file_references(
     file_references: List[db_models.FileReference],
     response: Response,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> api_models.BulkOperationResponse:
     logging.info(
@@ -182,7 +178,7 @@ async def create_file_references(
 
 @router.patch("/file_references/single", status_code=status.HTTP_200_OK)
 async def update_file_reference(
-    file_reference: db_models.FileReference, db: Repository = Depends(use_cache=True)
+    file_reference: db_models.FileReference, db: Repository = Depends()
 ) -> None:
     logging.info(
         f"Updating file reference {file_reference.uuid}. New version: {file_reference.version}"
@@ -202,7 +198,7 @@ async def update_file_reference(
 @router.post("/collections", status_code=status.HTTP_201_CREATED)
 async def create_collection(
     collection: db_models.BIACollection,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating collection {collection.uuid}")
@@ -221,7 +217,7 @@ async def create_collection(
 @router.post("/image_acquisitions", status_code=status.HTTP_201_CREATED)
 async def create_image_acquisition(
     image_acquisition: db_models.ImageAcquisition,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating Image Acquisition {image_acquisition.uuid}")
@@ -241,7 +237,7 @@ async def create_image_acquisition(
 @router.patch("/image_acquisitions", status_code=status.HTTP_200_OK)
 async def update_image_acquisition(
     image_acquisition: db_models.ImageAcquisition,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> None:
     logging.info(
         f"Updating Image acquisition {image_acquisition.uuid}. New version: {image_acquisition.version}"
@@ -280,7 +276,7 @@ async def create_specimen(
 
 @router.patch("/specimens", status_code=status.HTTP_200_OK)
 async def update_specimen(
-    specimen: db_models.Specimen, db: Repository = Depends(use_cache=True)
+    specimen: db_models.Specimen, db: Repository = Depends()
 ) -> None:
     logging.info(f"Updating Specimen {specimen.uuid}. New version: {specimen.version}")
     # await db.validate_uuid_type(specimen.biosample_uuid, db_models.Biosample)
@@ -298,7 +294,7 @@ async def update_specimen(
 @router.post("/biosamples", status_code=status.HTTP_201_CREATED)
 async def create_biosample(
     biosample: db_models.Biosample,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating Biosample {biosample.uuid}")
@@ -310,7 +306,7 @@ async def create_biosample(
 
 @router.patch("/biosamples", status_code=status.HTTP_200_OK)
 async def update_biosample(
-    biosample: db_models.Biosample, db: Repository = Depends(use_cache=True)
+    biosample: db_models.Biosample, db: Repository = Depends()
 ) -> None:
     logging.info(
         f"Updating Biosample {biosample.uuid}. New version: {biosample.version}"
@@ -324,7 +320,7 @@ async def update_biosample(
 async def set_image_ome_metadata(
     image_uuid: UUID,
     ome_metadata_file: UploadFile,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.BIAImageOmeMetadata:
     if not ome_metadata_file.size:
         raise exceptions.InvalidRequestException("File has size 0")

--- a/api/src/api/private.py
+++ b/api/src/api/private.py
@@ -22,7 +22,7 @@ router = APIRouter(
 @router.post("/studies", status_code=status.HTTP_201_CREATED)
 async def create_study(
     study: db_models.BIAStudy,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating study {study.accession_id}")
@@ -38,7 +38,7 @@ async def create_study(
 
 @router.patch("/studies", status_code=status.HTTP_200_OK)
 async def update_study(
-    study: db_models.BIAStudy, db: Repository = Depends(use_cache=False)
+    study: db_models.BIAStudy, db: Repository = Depends(use_cache=True)
 ) -> None:
     logging.info(f"Updating study {study.accession_id}. New version: {study.version}")
     await db.update_doc(study)
@@ -50,7 +50,7 @@ async def update_study(
     "/studies/{study_uuid}/refresh_counts", status_code=status.HTTP_201_CREATED
 )
 async def study_refresh_counts(
-    study_uuid: str, db: Repository = Depends(use_cache=False)
+    study_uuid: str, db: Repository = Depends(use_cache=True)
 ) -> None:
     """Recalculate and persist counts for other objects pointing to this study."""
 
@@ -64,7 +64,7 @@ async def study_refresh_counts(
 async def create_images(
     study_images: List[db_models.BIAImage],
     response: Response,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> api_models.BulkOperationResponse:
     logging.info(
@@ -101,7 +101,7 @@ async def create_images(
 
 @router.patch("/images/single", status_code=status.HTTP_200_OK)
 async def update_image(
-    study_image: db_models.BIAImage, db: Repository = Depends(use_cache=False)
+    study_image: db_models.BIAImage, db: Repository = Depends(use_cache=True)
 ) -> None:
     """Bulk update not available - update_many only has one filter for the entire update
     @TODO: Find common bulk update usecases and map them to mongo operations"""
@@ -134,7 +134,7 @@ async def create_images_bulk() -> None:
 async def create_image_representation(
     image_uuid: str,
     representation: db_models.BIAImageRepresentation,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> None:
     logging.info(f"Adding an image representation to image {image_uuid}")
     await db.list_item_push(image_uuid, "representations", representation)
@@ -146,7 +146,7 @@ async def create_image_representation(
 async def create_file_references(
     file_references: List[db_models.FileReference],
     response: Response,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> api_models.BulkOperationResponse:
     logging.info(
@@ -182,7 +182,7 @@ async def create_file_references(
 
 @router.patch("/file_references/single", status_code=status.HTTP_200_OK)
 async def update_file_reference(
-    file_reference: db_models.FileReference, db: Repository = Depends(use_cache=False)
+    file_reference: db_models.FileReference, db: Repository = Depends(use_cache=True)
 ) -> None:
     logging.info(
         f"Updating file reference {file_reference.uuid}. New version: {file_reference.version}"
@@ -202,7 +202,7 @@ async def update_file_reference(
 @router.post("/collections", status_code=status.HTTP_201_CREATED)
 async def create_collection(
     collection: db_models.BIACollection,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating collection {collection.uuid}")
@@ -221,7 +221,7 @@ async def create_collection(
 @router.post("/image_acquisitions", status_code=status.HTTP_201_CREATED)
 async def create_image_acquisition(
     image_acquisition: db_models.ImageAcquisition,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating Image Acquisition {image_acquisition.uuid}")
@@ -241,7 +241,7 @@ async def create_image_acquisition(
 @router.patch("/image_acquisitions", status_code=status.HTTP_200_OK)
 async def update_image_acquisition(
     image_acquisition: db_models.ImageAcquisition,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> None:
     logging.info(
         f"Updating Image acquisition {image_acquisition.uuid}. New version: {image_acquisition.version}"
@@ -280,7 +280,7 @@ async def create_specimen(
 
 @router.patch("/specimens", status_code=status.HTTP_200_OK)
 async def update_specimen(
-    specimen: db_models.Specimen, db: Repository = Depends(use_cache=False)
+    specimen: db_models.Specimen, db: Repository = Depends(use_cache=True)
 ) -> None:
     logging.info(f"Updating Specimen {specimen.uuid}. New version: {specimen.version}")
     # await db.validate_uuid_type(specimen.biosample_uuid, db_models.Biosample)
@@ -298,7 +298,7 @@ async def update_specimen(
 @router.post("/biosamples", status_code=status.HTTP_201_CREATED)
 async def create_biosample(
     biosample: db_models.Biosample,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating Biosample {biosample.uuid}")
@@ -310,7 +310,7 @@ async def create_biosample(
 
 @router.patch("/biosamples", status_code=status.HTTP_200_OK)
 async def update_biosample(
-    biosample: db_models.Biosample, db: Repository = Depends(use_cache=False)
+    biosample: db_models.Biosample, db: Repository = Depends(use_cache=True)
 ) -> None:
     logging.info(
         f"Updating Biosample {biosample.uuid}. New version: {biosample.version}"
@@ -324,7 +324,7 @@ async def update_biosample(
 async def set_image_ome_metadata(
     image_uuid: UUID,
     ome_metadata_file: UploadFile,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.BIAImageOmeMetadata:
     if not ome_metadata_file.size:
         raise exceptions.InvalidRequestException("File has size 0")

--- a/api/src/api/private.py
+++ b/api/src/api/private.py
@@ -22,7 +22,7 @@ router = APIRouter(
 @router.post("/studies", status_code=status.HTTP_201_CREATED)
 async def create_study(
     study: db_models.BIAStudy,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating study {study.accession_id}")
@@ -37,7 +37,9 @@ async def create_study(
 
 
 @router.patch("/studies", status_code=status.HTTP_200_OK)
-async def update_study(study: db_models.BIAStudy, db: Repository = Depends()) -> None:
+async def update_study(
+    study: db_models.BIAStudy, db: Repository = Depends(use_cache=False)
+) -> None:
     logging.info(f"Updating study {study.accession_id}. New version: {study.version}")
     await db.update_doc(study)
 
@@ -47,7 +49,9 @@ async def update_study(study: db_models.BIAStudy, db: Repository = Depends()) ->
 @router.post(
     "/studies/{study_uuid}/refresh_counts", status_code=status.HTTP_201_CREATED
 )
-async def study_refresh_counts(study_uuid: str, db: Repository = Depends()) -> None:
+async def study_refresh_counts(
+    study_uuid: str, db: Repository = Depends(use_cache=False)
+) -> None:
     """Recalculate and persist counts for other objects pointing to this study."""
 
     logging.info(f"Recalculating reference counts for study {study_uuid}")
@@ -60,7 +64,7 @@ async def study_refresh_counts(study_uuid: str, db: Repository = Depends()) -> N
 async def create_images(
     study_images: List[db_models.BIAImage],
     response: Response,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> api_models.BulkOperationResponse:
     logging.info(
@@ -97,7 +101,7 @@ async def create_images(
 
 @router.patch("/images/single", status_code=status.HTTP_200_OK)
 async def update_image(
-    study_image: db_models.BIAImage, db: Repository = Depends()
+    study_image: db_models.BIAImage, db: Repository = Depends(use_cache=False)
 ) -> None:
     """Bulk update not available - update_many only has one filter for the entire update
     @TODO: Find common bulk update usecases and map them to mongo operations"""
@@ -130,7 +134,7 @@ async def create_images_bulk() -> None:
 async def create_image_representation(
     image_uuid: str,
     representation: db_models.BIAImageRepresentation,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> None:
     logging.info(f"Adding an image representation to image {image_uuid}")
     await db.list_item_push(image_uuid, "representations", representation)
@@ -142,7 +146,7 @@ async def create_image_representation(
 async def create_file_references(
     file_references: List[db_models.FileReference],
     response: Response,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> api_models.BulkOperationResponse:
     logging.info(
@@ -178,7 +182,7 @@ async def create_file_references(
 
 @router.patch("/file_references/single", status_code=status.HTTP_200_OK)
 async def update_file_reference(
-    file_reference: db_models.FileReference, db: Repository = Depends()
+    file_reference: db_models.FileReference, db: Repository = Depends(use_cache=False)
 ) -> None:
     logging.info(
         f"Updating file reference {file_reference.uuid}. New version: {file_reference.version}"
@@ -198,7 +202,7 @@ async def update_file_reference(
 @router.post("/collections", status_code=status.HTTP_201_CREATED)
 async def create_collection(
     collection: db_models.BIACollection,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating collection {collection.uuid}")
@@ -217,7 +221,7 @@ async def create_collection(
 @router.post("/image_acquisitions", status_code=status.HTTP_201_CREATED)
 async def create_image_acquisition(
     image_acquisition: db_models.ImageAcquisition,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating Image Acquisition {image_acquisition.uuid}")
@@ -236,7 +240,8 @@ async def create_image_acquisition(
 
 @router.patch("/image_acquisitions", status_code=status.HTTP_200_OK)
 async def update_image_acquisition(
-    image_acquisition: db_models.ImageAcquisition, db: Repository = Depends()
+    image_acquisition: db_models.ImageAcquisition,
+    db: Repository = Depends(use_cache=False),
 ) -> None:
     logging.info(
         f"Updating Image acquisition {image_acquisition.uuid}. New version: {image_acquisition.version}"
@@ -275,7 +280,7 @@ async def create_specimen(
 
 @router.patch("/specimens", status_code=status.HTTP_200_OK)
 async def update_specimen(
-    specimen: db_models.Specimen, db: Repository = Depends()
+    specimen: db_models.Specimen, db: Repository = Depends(use_cache=False)
 ) -> None:
     logging.info(f"Updating Specimen {specimen.uuid}. New version: {specimen.version}")
     # await db.validate_uuid_type(specimen.biosample_uuid, db_models.Biosample)
@@ -293,7 +298,7 @@ async def update_specimen(
 @router.post("/biosamples", status_code=status.HTTP_201_CREATED)
 async def create_biosample(
     biosample: db_models.Biosample,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
     overwrite_mode: OverwriteMode = OverwriteMode.FAIL,
 ) -> None:
     logging.info(f"Creating Biosample {biosample.uuid}")
@@ -305,7 +310,7 @@ async def create_biosample(
 
 @router.patch("/biosamples", status_code=status.HTTP_200_OK)
 async def update_biosample(
-    biosample: db_models.Biosample, db: Repository = Depends()
+    biosample: db_models.Biosample, db: Repository = Depends(use_cache=False)
 ) -> None:
     logging.info(
         f"Updating Biosample {biosample.uuid}. New version: {biosample.version}"
@@ -317,7 +322,9 @@ async def update_biosample(
 
 @router.post("/images/{image_uuid}/ome_metadata", status_code=status.HTTP_201_CREATED)
 async def set_image_ome_metadata(
-    image_uuid: UUID, ome_metadata_file: UploadFile, db: Repository = Depends()
+    image_uuid: UUID,
+    ome_metadata_file: UploadFile,
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.BIAImageOmeMetadata:
     if not ome_metadata_file.size:
         raise exceptions.InvalidRequestException("File has size 0")

--- a/api/src/api/public.py
+++ b/api/src/api/public.py
@@ -15,7 +15,7 @@ router = APIRouter(tags=[constants.OPENAPI_TAG_PUBLIC, constants.OPENAPI_TAG_PRI
 
 @router.get("/object_info_by_accessions")
 async def get_object_info_by_accession(
-    accessions: List[str] = Query(), db: Repository = Depends(use_cache=True)
+    accessions: List[str] = Query(), db: Repository = Depends()
 ) -> List[api_models.ObjectInfo]:
     query = {
         "accession_id": {
@@ -30,7 +30,7 @@ async def get_study_images_by_alias(
     study_accession: str,
     annotator: Annotated[Annotator, Depends(annotator)],
     aliases: List[str] = Query(),
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.BIAImage]:
     study_objects_info = await db.get_object_info(
         {
@@ -61,7 +61,7 @@ async def get_study_images_by_alias(
 async def get_study(
     study_uuid: str,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.BIAStudy:
     study = await db.find_study_by_uuid(study_uuid)
     annotator.annotate_if_needed(study)
@@ -75,7 +75,7 @@ async def get_study_file_references(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.FileReference]:
     """
     First item in response is the next item with uuid greater than start_uuid.
@@ -93,7 +93,7 @@ async def search_studies(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.BIAStudy]:
     """
     @TODO: Define search criteria for the general case
@@ -113,7 +113,7 @@ async def search_studies(
 async def search_images_exact_match(
     search_filter: Annotated[api_models.SearchImageFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.BIAImage]:
     """
     Exact match search of images with a specific attribute.
@@ -190,7 +190,7 @@ async def search_images_exact_match(
 async def search_file_references_exact_match(
     search_filter: Annotated[api_models.SearchFileReferenceFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.FileReference]:
     """
     Exact match search of file references with a specific attribute.
@@ -263,7 +263,7 @@ async def search_file_references_exact_match(
 async def search_studies_exact_match(
     search_filter: Annotated[api_models.SearchStudyFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.BIAStudy]:
     query = {}
     if search_filter.annotations_any:
@@ -343,7 +343,7 @@ async def get_study_images(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.BIAImage]:
     """
     First item in response is the next item with uuid greater than start_uuid.
@@ -360,7 +360,7 @@ async def get_study_images(
 async def get_image(
     image_uuid: UUID,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.BIAImage:
     image = await db.get_image(uuid=image_uuid)
     annotator.annotate_if_needed(image)
@@ -371,7 +371,7 @@ async def get_image(
 @router.get("/image_acquisitions/{image_acquisition_uuid}")
 async def get_image_acquisition(
     image_acquisition_uuid: UUID,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.ImageAcquisition:
     image_acquisition = await db.get_image_acquisition(uuid=image_acquisition_uuid)
 
@@ -381,7 +381,7 @@ async def get_image_acquisition(
 @router.get("/biosamples/{biosample_uuid}")
 async def get_biosample(
     biosample_uuid: UUID,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.Biosample:
     biosample = await db.get_biosample(uuid=biosample_uuid)
 
@@ -391,7 +391,7 @@ async def get_biosample(
 @router.get("/specimens/{specimen_uuid}")
 async def get_specimen(
     specimen_uuid: UUID,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.Specimen:
     specimen = await db.get_specimen(uuid=specimen_uuid)
 
@@ -400,7 +400,7 @@ async def get_specimen(
 
 @router.get("/images/{image_uuid}/ome_metadata")
 async def get_image_ome_metadata(
-    image_uuid: UUID, db: Repository = Depends(use_cache=True)
+    image_uuid: UUID, db: Repository = Depends()
 ) -> db_models.BIAImageOmeMetadata:
     ome_metadata = await db.get_ome_metadata_for_image(image_uuid)
 
@@ -411,7 +411,7 @@ async def get_image_ome_metadata(
 async def get_file_reference(
     file_reference_uuid: str,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.FileReference:
     file_reference = await db.get_file_reference(uuid=UUID(file_reference_uuid))
     annotator.annotate_if_needed(file_reference)
@@ -428,7 +428,7 @@ async def get_file_reference(
 async def search_collections(
     annotator: Annotated[Annotator, Depends(annotator)],
     name: Optional[str] = None,
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> List[db_models.BIACollection]:
     query = {}
     if name:
@@ -444,7 +444,7 @@ async def search_collections(
 async def get_collection(
     collection_uuid: UUID,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=True),
+    db: Repository = Depends(),
 ) -> db_models.BIACollection:
     collection = await db.get_collection(uuid=collection_uuid)
     annotator.annotate_if_needed(collection)

--- a/api/src/api/public.py
+++ b/api/src/api/public.py
@@ -15,7 +15,7 @@ router = APIRouter(tags=[constants.OPENAPI_TAG_PUBLIC, constants.OPENAPI_TAG_PRI
 
 @router.get("/object_info_by_accessions")
 async def get_object_info_by_accession(
-    accessions: List[str] = Query(), db: Repository = Depends(use_cache=False)
+    accessions: List[str] = Query(), db: Repository = Depends(use_cache=True)
 ) -> List[api_models.ObjectInfo]:
     query = {
         "accession_id": {
@@ -30,7 +30,7 @@ async def get_study_images_by_alias(
     study_accession: str,
     annotator: Annotated[Annotator, Depends(annotator)],
     aliases: List[str] = Query(),
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.BIAImage]:
     study_objects_info = await db.get_object_info(
         {
@@ -61,7 +61,7 @@ async def get_study_images_by_alias(
 async def get_study(
     study_uuid: str,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.BIAStudy:
     study = await db.find_study_by_uuid(study_uuid)
     annotator.annotate_if_needed(study)
@@ -75,7 +75,7 @@ async def get_study_file_references(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.FileReference]:
     """
     First item in response is the next item with uuid greater than start_uuid.
@@ -93,7 +93,7 @@ async def search_studies(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.BIAStudy]:
     """
     @TODO: Define search criteria for the general case
@@ -113,7 +113,7 @@ async def search_studies(
 async def search_images_exact_match(
     search_filter: Annotated[api_models.SearchImageFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.BIAImage]:
     """
     Exact match search of images with a specific attribute.
@@ -190,7 +190,7 @@ async def search_images_exact_match(
 async def search_file_references_exact_match(
     search_filter: Annotated[api_models.SearchFileReferenceFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.FileReference]:
     """
     Exact match search of file references with a specific attribute.
@@ -263,7 +263,7 @@ async def search_file_references_exact_match(
 async def search_studies_exact_match(
     search_filter: Annotated[api_models.SearchStudyFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.BIAStudy]:
     query = {}
     if search_filter.annotations_any:
@@ -343,7 +343,7 @@ async def get_study_images(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.BIAImage]:
     """
     First item in response is the next item with uuid greater than start_uuid.
@@ -360,7 +360,7 @@ async def get_study_images(
 async def get_image(
     image_uuid: UUID,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.BIAImage:
     image = await db.get_image(uuid=image_uuid)
     annotator.annotate_if_needed(image)
@@ -371,7 +371,7 @@ async def get_image(
 @router.get("/image_acquisitions/{image_acquisition_uuid}")
 async def get_image_acquisition(
     image_acquisition_uuid: UUID,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.ImageAcquisition:
     image_acquisition = await db.get_image_acquisition(uuid=image_acquisition_uuid)
 
@@ -381,7 +381,7 @@ async def get_image_acquisition(
 @router.get("/biosamples/{biosample_uuid}")
 async def get_biosample(
     biosample_uuid: UUID,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.Biosample:
     biosample = await db.get_biosample(uuid=biosample_uuid)
 
@@ -391,7 +391,7 @@ async def get_biosample(
 @router.get("/specimens/{specimen_uuid}")
 async def get_specimen(
     specimen_uuid: UUID,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.Specimen:
     specimen = await db.get_specimen(uuid=specimen_uuid)
 
@@ -400,7 +400,7 @@ async def get_specimen(
 
 @router.get("/images/{image_uuid}/ome_metadata")
 async def get_image_ome_metadata(
-    image_uuid: UUID, db: Repository = Depends(use_cache=False)
+    image_uuid: UUID, db: Repository = Depends(use_cache=True)
 ) -> db_models.BIAImageOmeMetadata:
     ome_metadata = await db.get_ome_metadata_for_image(image_uuid)
 
@@ -411,7 +411,7 @@ async def get_image_ome_metadata(
 async def get_file_reference(
     file_reference_uuid: str,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.FileReference:
     file_reference = await db.get_file_reference(uuid=UUID(file_reference_uuid))
     annotator.annotate_if_needed(file_reference)
@@ -428,7 +428,7 @@ async def get_file_reference(
 async def search_collections(
     annotator: Annotated[Annotator, Depends(annotator)],
     name: Optional[str] = None,
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> List[db_models.BIACollection]:
     query = {}
     if name:
@@ -444,7 +444,7 @@ async def search_collections(
 async def get_collection(
     collection_uuid: UUID,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(use_cache=False),
+    db: Repository = Depends(use_cache=True),
 ) -> db_models.BIACollection:
     collection = await db.get_collection(uuid=collection_uuid)
     annotator.annotate_if_needed(collection)

--- a/api/src/api/public.py
+++ b/api/src/api/public.py
@@ -15,7 +15,7 @@ router = APIRouter(tags=[constants.OPENAPI_TAG_PUBLIC, constants.OPENAPI_TAG_PRI
 
 @router.get("/object_info_by_accessions")
 async def get_object_info_by_accession(
-    accessions: List[str] = Query(), db: Repository = Depends()
+    accessions: List[str] = Query(), db: Repository = Depends(use_cache=False)
 ) -> List[api_models.ObjectInfo]:
     query = {
         "accession_id": {
@@ -30,7 +30,7 @@ async def get_study_images_by_alias(
     study_accession: str,
     annotator: Annotated[Annotator, Depends(annotator)],
     aliases: List[str] = Query(),
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.BIAImage]:
     study_objects_info = await db.get_object_info(
         {
@@ -61,7 +61,7 @@ async def get_study_images_by_alias(
 async def get_study(
     study_uuid: str,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.BIAStudy:
     study = await db.find_study_by_uuid(study_uuid)
     annotator.annotate_if_needed(study)
@@ -75,7 +75,7 @@ async def get_study_file_references(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.FileReference]:
     """
     First item in response is the next item with uuid greater than start_uuid.
@@ -93,7 +93,7 @@ async def search_studies(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.BIAStudy]:
     """
     @TODO: Define search criteria for the general case
@@ -113,7 +113,7 @@ async def search_studies(
 async def search_images_exact_match(
     search_filter: Annotated[api_models.SearchImageFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.BIAImage]:
     """
     Exact match search of images with a specific attribute.
@@ -190,7 +190,7 @@ async def search_images_exact_match(
 async def search_file_references_exact_match(
     search_filter: Annotated[api_models.SearchFileReferenceFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.FileReference]:
     """
     Exact match search of file references with a specific attribute.
@@ -263,7 +263,7 @@ async def search_file_references_exact_match(
 async def search_studies_exact_match(
     search_filter: Annotated[api_models.SearchStudyFilter, Body(embed=False)],
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.BIAStudy]:
     query = {}
     if search_filter.annotations_any:
@@ -343,7 +343,7 @@ async def get_study_images(
     annotator: Annotated[Annotator, Depends(annotator)],
     start_uuid: UUID | None = None,
     limit: Annotated[int, Query(gt=0)] = 10,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.BIAImage]:
     """
     First item in response is the next item with uuid greater than start_uuid.
@@ -360,7 +360,7 @@ async def get_study_images(
 async def get_image(
     image_uuid: UUID,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.BIAImage:
     image = await db.get_image(uuid=image_uuid)
     annotator.annotate_if_needed(image)
@@ -371,7 +371,7 @@ async def get_image(
 @router.get("/image_acquisitions/{image_acquisition_uuid}")
 async def get_image_acquisition(
     image_acquisition_uuid: UUID,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.ImageAcquisition:
     image_acquisition = await db.get_image_acquisition(uuid=image_acquisition_uuid)
 
@@ -381,7 +381,7 @@ async def get_image_acquisition(
 @router.get("/biosamples/{biosample_uuid}")
 async def get_biosample(
     biosample_uuid: UUID,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.Biosample:
     biosample = await db.get_biosample(uuid=biosample_uuid)
 
@@ -391,7 +391,7 @@ async def get_biosample(
 @router.get("/specimens/{specimen_uuid}")
 async def get_specimen(
     specimen_uuid: UUID,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.Specimen:
     specimen = await db.get_specimen(uuid=specimen_uuid)
 
@@ -400,7 +400,7 @@ async def get_specimen(
 
 @router.get("/images/{image_uuid}/ome_metadata")
 async def get_image_ome_metadata(
-    image_uuid: UUID, db: Repository = Depends()
+    image_uuid: UUID, db: Repository = Depends(use_cache=False)
 ) -> db_models.BIAImageOmeMetadata:
     ome_metadata = await db.get_ome_metadata_for_image(image_uuid)
 
@@ -411,7 +411,7 @@ async def get_image_ome_metadata(
 async def get_file_reference(
     file_reference_uuid: str,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.FileReference:
     file_reference = await db.get_file_reference(uuid=UUID(file_reference_uuid))
     annotator.annotate_if_needed(file_reference)
@@ -428,7 +428,7 @@ async def get_file_reference(
 async def search_collections(
     annotator: Annotated[Annotator, Depends(annotator)],
     name: Optional[str] = None,
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> List[db_models.BIACollection]:
     query = {}
     if name:
@@ -444,7 +444,7 @@ async def search_collections(
 async def get_collection(
     collection_uuid: UUID,
     annotator: Annotated[Annotator, Depends(annotator)],
-    db: Repository = Depends(),
+    db: Repository = Depends(use_cache=False),
 ) -> db_models.BIACollection:
     collection = await db.get_collection(uuid=collection_uuid)
     annotator.annotate_if_needed(collection)

--- a/api/src/models/repository.py
+++ b/api/src/models/repository.py
@@ -87,6 +87,13 @@ class Repository:
         self.close()
 
     def close(self):
+        """
+        When we apply_annotations, we double-close.
+        Ignore the double-close exception
+
+        See https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_client.html#motor.motor_asyncio.AsyncIOMotorClient.close
+        """
+
         try:
             self.connection.close()
         except InvalidOperation:

--- a/api/src/models/repository.py
+++ b/api/src/models/repository.py
@@ -13,6 +13,7 @@ from enum import Enum
 import uuid
 import pymongo
 import os
+from pymongo.errors import InvalidOperation
 
 DB_NAME = os.environ["DB_NAME"]
 COLLECTION_BIA_INTEGRATOR = "bia_integrator"
@@ -86,7 +87,10 @@ class Repository:
         self.close()
 
     def close(self):
-        self.connection.close()
+        try:
+            self.connection.close()
+        except InvalidOperation:
+            pass
 
     async def file_references_for_study(
         self, *args, **kwargs

--- a/api/src/models/repository.py
+++ b/api/src/models/repository.py
@@ -89,15 +89,12 @@ class Repository:
     def close(self):
         """
         When we apply_annotations, we double-close.
-        Ignore the double-close exception
+        Ignore the double-close exception?
 
         See https://motor.readthedocs.io/en/stable/api-asyncio/asyncio_motor_client.html#motor.motor_asyncio.AsyncIOMotorClient.close
         """
 
-        try:
-            self.connection.close()
-        except InvalidOperation:
-            pass
+        self.connection.close()
 
     async def file_references_for_study(
         self, *args, **kwargs


### PR DESCRIPTION
This is deployed already, there was an issue with a 500 error when doing 5(parallel)*44 (sequential) requests getting all images of S-BIAD582. I think somewhere in there a cached db client was reused across requests (maybe for a pending request), but we explicitly close the connection before applying (or not) any annotations.

Updated from the initial PR to only close the connection if apply_annotations=True (so in that case, the 500 error would still happen, but we don't regularly use that now)