### PR TITLE
Remove api prefix

### DIFF
--- a/api/Readme.md
+++ b/api/Readme.md
@@ -37,7 +37,7 @@ Create a local-only test user with:
 curl -H "Content-Type: application/json" \
     --request POST \
     --data '{"email": "test@example.com", "password_plain": "test", "secret_token": "00123456789==" }' \
-    http://localhost:8080/api/v1/auth/users/register
+    http://localhost:8080/v1/auth/users/register
 ```
 
 The response should be just `null` and there should be no errors in the api container.
@@ -68,15 +68,15 @@ Build images and run contains:
 
 Create user:
 
-`curl -H "Content-Type: application/json" --request POST --data '{"email": "test@example.com", "password_plain": "test", "secret_token": "00123456789==" }'  http://localhost:8080/api/v1/auth/users/register`
+`curl -H "Content-Type: application/json" --request POST --data '{"email": "test@example.com", "password_plain": "test", "secret_token": "00123456789==" }'  http://localhost:8080/v1/auth/users/register`
 
 Get auth token
 
-`curl -H "Content-Type: application/x-www-form-urlencoded" --request POST --data 'username=test@example.com&password=test'  http://localhost:8080/api/v1/auth/token`
+`curl -H "Content-Type: application/x-www-form-urlencoded" --request POST --data 'username=test@example.com&password=test'  http://localhost:8080/v1/auth/token`
 
 Copy auth token which you can then use to make calls to the api. E.g. create a study:
 
-`curl -H "Content-Type: application/json" -H "Authorization: Bearer <auth token>" --request POST http://localhost:8080/api/v1/private/studies -d @study_input.json`
+`curl -H "Content-Type: application/json" -H "Authorization: Bearer <auth token>" --request POST http://localhost:8080/v1/private/studies -d @study_input.json`
 
 You should be able to make your changes & can rebuild the api image with the command:
 

--- a/api/src/tests/util.py
+++ b/api/src/tests/util.py
@@ -324,7 +324,7 @@ def get_image_acquisition(
     return rsp.json()
 
 
-TEST_SERVER_BASE_URL = "http://localhost.com/api/v1"
+TEST_SERVER_BASE_URL = "http://localhost.com/v1"
 
 
 def get_client(**kwargs) -> TestClient:

--- a/api/src/tests_load/common/util.py
+++ b/api/src/tests_load/common/util.py
@@ -31,8 +31,7 @@ def batch_response_status_all(arr_batch_op_result, expected_status_code):
 
 def get_study_filerefs(host, study_uuid, n_filerefs=100):
     url = (
-        urljoin(host, f"/api/studies/{study_uuid}/file_references")
-        + f"?limit={n_filerefs}"
+        urljoin(host, f"/studies/{study_uuid}/file_references") + f"?limit={n_filerefs}"
     )
     rsp = requests.get(url, verify=False)
 

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -5,7 +5,7 @@
     "version": "0.1.0"
   },
   "paths": {
-    "/api/v1/auth/token": {
+    "/v1/auth/token": {
       "post": {
         "tags": [
           "private"
@@ -46,7 +46,7 @@
         }
       }
     },
-    "/api/v1/auth/users/register": {
+    "/v1/auth/users/register": {
       "post": {
         "tags": [
           "private"
@@ -85,7 +85,7 @@
         }
       }
     },
-    "/api/v1/private/studies": {
+    "/v1/private/studies": {
       "post": {
         "tags": [
           "private"
@@ -187,7 +187,7 @@
         }
       }
     },
-    "/api/v1/private/studies/{study_uuid}/refresh_counts": {
+    "/v1/private/studies/{study_uuid}/refresh_counts": {
       "post": {
         "tags": [
           "private"
@@ -233,7 +233,7 @@
         }
       }
     },
-    "/api/v1/private/images": {
+    "/v1/private/images": {
       "post": {
         "tags": [
           "private"
@@ -299,7 +299,7 @@
         }
       }
     },
-    "/api/v1/private/images/single": {
+    "/v1/private/images/single": {
       "patch": {
         "tags": [
           "private"
@@ -344,7 +344,7 @@
         ]
       }
     },
-    "/api/v1/private/images/bulk": {
+    "/v1/private/images/bulk": {
       "post": {
         "tags": [
           "private"
@@ -369,7 +369,7 @@
         ]
       }
     },
-    "/api/v1/private/images/{image_uuid}/representations/single": {
+    "/v1/private/images/{image_uuid}/representations/single": {
       "post": {
         "tags": [
           "private"
@@ -424,7 +424,7 @@
         }
       }
     },
-    "/api/v1/private/file_references": {
+    "/v1/private/file_references": {
       "post": {
         "tags": [
           "private"
@@ -490,7 +490,7 @@
         }
       }
     },
-    "/api/v1/private/file_references/single": {
+    "/v1/private/file_references/single": {
       "patch": {
         "tags": [
           "private"
@@ -534,7 +534,7 @@
         ]
       }
     },
-    "/api/v1/private/collections": {
+    "/v1/private/collections": {
       "post": {
         "tags": [
           "private"
@@ -594,7 +594,7 @@
         }
       }
     },
-    "/api/v1/private/image_acquisitions": {
+    "/v1/private/image_acquisitions": {
       "post": {
         "tags": [
           "private"
@@ -696,7 +696,7 @@
         }
       }
     },
-    "/api/v1/private/specimens": {
+    "/v1/private/specimens": {
       "post": {
         "tags": [
           "private"
@@ -798,7 +798,7 @@
         }
       }
     },
-    "/api/v1/private/biosamples": {
+    "/v1/private/biosamples": {
       "post": {
         "tags": [
           "private"
@@ -900,7 +900,7 @@
         }
       }
     },
-    "/api/v1/private/images/{image_uuid}/ome_metadata": {
+    "/v1/private/images/{image_uuid}/ome_metadata": {
       "post": {
         "tags": [
           "private"
@@ -958,7 +958,7 @@
         }
       }
     },
-    "/api/v1/admin/health-check": {
+    "/v1/admin/health-check": {
       "get": {
         "tags": [
           "private"
@@ -982,7 +982,7 @@
         ]
       }
     },
-    "/api/v1/object_info_by_accessions": {
+    "/v1/object_info_by_accessions": {
       "get": {
         "tags": [
           "public",
@@ -1032,7 +1032,7 @@
         }
       }
     },
-    "/api/v1/studies/{study_accession}/images_by_aliases": {
+    "/v1/studies/{study_accession}/images_by_aliases": {
       "get": {
         "tags": [
           "public",
@@ -1101,7 +1101,7 @@
         }
       }
     },
-    "/api/v1/studies/{study_uuid}": {
+    "/v1/studies/{study_uuid}": {
       "get": {
         "tags": [
           "public",
@@ -1154,7 +1154,7 @@
         }
       }
     },
-    "/api/v1/studies/{study_uuid}/file_references": {
+    "/v1/studies/{study_uuid}/file_references": {
       "get": {
         "tags": [
           "public",
@@ -1241,7 +1241,7 @@
         }
       }
     },
-    "/api/v1/search/studies": {
+    "/v1/search/studies": {
       "get": {
         "tags": [
           "public",
@@ -1318,7 +1318,7 @@
         }
       }
     },
-    "/api/v1/search/images/exact_match": {
+    "/v1/search/images/exact_match": {
       "post": {
         "tags": [
           "public",
@@ -1377,7 +1377,7 @@
         }
       }
     },
-    "/api/v1/search/file_references/exact_match": {
+    "/v1/search/file_references/exact_match": {
       "post": {
         "tags": [
           "public",
@@ -1436,7 +1436,7 @@
         }
       }
     },
-    "/api/v1/search/studies/exact_match": {
+    "/v1/search/studies/exact_match": {
       "post": {
         "tags": [
           "public",
@@ -1494,7 +1494,7 @@
         }
       }
     },
-    "/api/v1/studies/{study_uuid}/images": {
+    "/v1/studies/{study_uuid}/images": {
       "get": {
         "tags": [
           "public",
@@ -1581,7 +1581,7 @@
         }
       }
     },
-    "/api/v1/images/{image_uuid}": {
+    "/v1/images/{image_uuid}": {
       "get": {
         "tags": [
           "public",
@@ -1635,7 +1635,7 @@
         }
       }
     },
-    "/api/v1/image_acquisitions/{image_acquisition_uuid}": {
+    "/v1/image_acquisitions/{image_acquisition_uuid}": {
       "get": {
         "tags": [
           "public",
@@ -1679,7 +1679,7 @@
         }
       }
     },
-    "/api/v1/biosamples/{biosample_uuid}": {
+    "/v1/biosamples/{biosample_uuid}": {
       "get": {
         "tags": [
           "public",
@@ -1723,7 +1723,7 @@
         }
       }
     },
-    "/api/v1/specimens/{specimen_uuid}": {
+    "/v1/specimens/{specimen_uuid}": {
       "get": {
         "tags": [
           "public",
@@ -1767,7 +1767,7 @@
         }
       }
     },
-    "/api/v1/images/{image_uuid}/ome_metadata": {
+    "/v1/images/{image_uuid}/ome_metadata": {
       "get": {
         "tags": [
           "public",
@@ -1811,7 +1811,7 @@
         }
       }
     },
-    "/api/v1/file_references/{file_reference_uuid}": {
+    "/v1/file_references/{file_reference_uuid}": {
       "get": {
         "tags": [
           "public",
@@ -1864,7 +1864,7 @@
         }
       }
     },
-    "/api/v1/collections": {
+    "/v1/collections": {
       "get": {
         "tags": [
           "public",
@@ -1928,7 +1928,7 @@
         }
       }
     },
-    "/api/v1/collections/{collection_uuid}": {
+    "/v1/collections/{collection_uuid}": {
       "get": {
         "tags": [
           "public",

--- a/clients/python/bia_integrator_api/api/private_api.py
+++ b/clients/python/bia_integrator_api/api/private_api.py
@@ -197,7 +197,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/biosamples', 'POST',
+            '/v1/private/biosamples', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -350,7 +350,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/collections', 'POST',
+            '/v1/private/collections', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -503,7 +503,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/file_references', 'POST',
+            '/v1/private/file_references', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -656,7 +656,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/image_acquisitions', 'POST',
+            '/v1/private/image_acquisitions', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -809,7 +809,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/images/{image_uuid}/representations/single', 'POST',
+            '/v1/private/images/{image_uuid}/representations/single', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -962,7 +962,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/images', 'POST',
+            '/v1/private/images', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -1093,7 +1093,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/images/bulk', 'POST',
+            '/v1/private/images/bulk', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -1246,7 +1246,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/specimens', 'POST',
+            '/v1/private/specimens', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -1399,7 +1399,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/studies', 'POST',
+            '/v1/private/studies', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -1537,7 +1537,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/biosamples/{biosample_uuid}', 'GET',
+            '/v1/biosamples/{biosample_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1683,7 +1683,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/collections/{collection_uuid}', 'GET',
+            '/v1/collections/{collection_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1829,7 +1829,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/file_references/{file_reference_uuid}', 'GET',
+            '/v1/file_references/{file_reference_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1975,7 +1975,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/images/{image_uuid}', 'GET',
+            '/v1/images/{image_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2113,7 +2113,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/image_acquisitions/{image_acquisition_uuid}', 'GET',
+            '/v1/image_acquisitions/{image_acquisition_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2251,7 +2251,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/images/{image_uuid}/ome_metadata', 'GET',
+            '/v1/images/{image_uuid}/ome_metadata', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2390,7 +2390,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/object_info_by_accessions', 'GET',
+            '/v1/object_info_by_accessions', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2528,7 +2528,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/specimens/{specimen_uuid}', 'GET',
+            '/v1/specimens/{specimen_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2674,7 +2674,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_uuid}', 'GET',
+            '/v1/studies/{study_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2838,7 +2838,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_uuid}/file_references', 'GET',
+            '/v1/studies/{study_uuid}/file_references', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -3002,7 +3002,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_uuid}/images', 'GET',
+            '/v1/studies/{study_uuid}/images', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -3157,7 +3157,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_accession}/images_by_aliases', 'GET',
+            '/v1/studies/{study_accession}/images_by_aliases', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -3286,7 +3286,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/admin/health-check', 'GET',
+            '/v1/admin/health-check', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -3471,7 +3471,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/auth/token', 'POST',
+            '/v1/auth/token', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -3616,7 +3616,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/auth/users/register', 'POST',
+            '/v1/auth/users/register', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -3762,7 +3762,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/collections', 'GET',
+            '/v1/collections', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -3917,7 +3917,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/file_references/exact_match', 'POST',
+            '/v1/search/file_references/exact_match', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -4072,7 +4072,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/images/exact_match', 'POST',
+            '/v1/search/images/exact_match', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -4228,7 +4228,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/studies', 'GET',
+            '/v1/search/studies', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -4381,7 +4381,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/studies/exact_match', 'POST',
+            '/v1/search/studies/exact_match', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -4534,7 +4534,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/images/{image_uuid}/ome_metadata', 'POST',
+            '/v1/private/images/{image_uuid}/ome_metadata', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -4674,7 +4674,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/studies/{study_uuid}/refresh_counts', 'POST',
+            '/v1/private/studies/{study_uuid}/refresh_counts', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -4819,7 +4819,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/biosamples', 'PATCH',
+            '/v1/private/biosamples', 'PATCH',
             _path_params,
             _query_params,
             _header_params,
@@ -4964,7 +4964,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/file_references/single', 'PATCH',
+            '/v1/private/file_references/single', 'PATCH',
             _path_params,
             _query_params,
             _header_params,
@@ -5111,7 +5111,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/images/single', 'PATCH',
+            '/v1/private/images/single', 'PATCH',
             _path_params,
             _query_params,
             _header_params,
@@ -5256,7 +5256,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/image_acquisitions', 'PATCH',
+            '/v1/private/image_acquisitions', 'PATCH',
             _path_params,
             _query_params,
             _header_params,
@@ -5401,7 +5401,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/specimens', 'PATCH',
+            '/v1/private/specimens', 'PATCH',
             _path_params,
             _query_params,
             _header_params,
@@ -5546,7 +5546,7 @@ class PrivateApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/private/studies', 'PATCH',
+            '/v1/private/studies', 'PATCH',
             _path_params,
             _query_params,
             _header_params,

--- a/clients/python/bia_integrator_api/api/public_api.py
+++ b/clients/python/bia_integrator_api/api/public_api.py
@@ -178,7 +178,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/biosamples/{biosample_uuid}', 'GET',
+            '/v1/biosamples/{biosample_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -324,7 +324,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/collections/{collection_uuid}', 'GET',
+            '/v1/collections/{collection_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -470,7 +470,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/file_references/{file_reference_uuid}', 'GET',
+            '/v1/file_references/{file_reference_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -616,7 +616,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/images/{image_uuid}', 'GET',
+            '/v1/images/{image_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -754,7 +754,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/image_acquisitions/{image_acquisition_uuid}', 'GET',
+            '/v1/image_acquisitions/{image_acquisition_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -892,7 +892,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/images/{image_uuid}/ome_metadata', 'GET',
+            '/v1/images/{image_uuid}/ome_metadata', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1031,7 +1031,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/object_info_by_accessions', 'GET',
+            '/v1/object_info_by_accessions', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1169,7 +1169,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/specimens/{specimen_uuid}', 'GET',
+            '/v1/specimens/{specimen_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1315,7 +1315,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_uuid}', 'GET',
+            '/v1/studies/{study_uuid}', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1479,7 +1479,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_uuid}/file_references', 'GET',
+            '/v1/studies/{study_uuid}/file_references', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1643,7 +1643,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_uuid}/images', 'GET',
+            '/v1/studies/{study_uuid}/images', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1798,7 +1798,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/studies/{study_accession}/images_by_aliases', 'GET',
+            '/v1/studies/{study_accession}/images_by_aliases', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -1944,7 +1944,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/collections', 'GET',
+            '/v1/collections', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2099,7 +2099,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/file_references/exact_match', 'POST',
+            '/v1/search/file_references/exact_match', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -2254,7 +2254,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/images/exact_match', 'POST',
+            '/v1/search/images/exact_match', 'POST',
             _path_params,
             _query_params,
             _header_params,
@@ -2410,7 +2410,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/studies', 'GET',
+            '/v1/search/studies', 'GET',
             _path_params,
             _query_params,
             _header_params,
@@ -2563,7 +2563,7 @@ class PublicApi(object):
         }
 
         return self.api_client.call_api(
-            '/api/v1/search/studies/exact_match', 'POST',
+            '/v1/search/studies/exact_match', 'POST',
             _path_params,
             _query_params,
             _header_params,

--- a/clients/python/bia_integrator_api/docs/PrivateApi.md
+++ b/clients/python/bia_integrator_api/docs/PrivateApi.md
@@ -4,43 +4,43 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**create_biosample**](PrivateApi.md#create_biosample) | **POST** /api/v1/private/biosamples | Create Biosample
-[**create_collection**](PrivateApi.md#create_collection) | **POST** /api/v1/private/collections | Create Collection
-[**create_file_references**](PrivateApi.md#create_file_references) | **POST** /api/v1/private/file_references | Create File References
-[**create_image_acquisition**](PrivateApi.md#create_image_acquisition) | **POST** /api/v1/private/image_acquisitions | Create Image Acquisition
-[**create_image_representation**](PrivateApi.md#create_image_representation) | **POST** /api/v1/private/images/{image_uuid}/representations/single | Create Image Representation
-[**create_images**](PrivateApi.md#create_images) | **POST** /api/v1/private/images | Create Images
-[**create_images_bulk**](PrivateApi.md#create_images_bulk) | **POST** /api/v1/private/images/bulk | Create Images Bulk
-[**create_specimen**](PrivateApi.md#create_specimen) | **POST** /api/v1/private/specimens | Create Specimen
-[**create_study**](PrivateApi.md#create_study) | **POST** /api/v1/private/studies | Create Study
-[**get_biosample**](PrivateApi.md#get_biosample) | **GET** /api/v1/biosamples/{biosample_uuid} | Get Biosample
-[**get_collection**](PrivateApi.md#get_collection) | **GET** /api/v1/collections/{collection_uuid} | Get Collection
-[**get_file_reference**](PrivateApi.md#get_file_reference) | **GET** /api/v1/file_references/{file_reference_uuid} | Get File Reference
-[**get_image**](PrivateApi.md#get_image) | **GET** /api/v1/images/{image_uuid} | Get Image
-[**get_image_acquisition**](PrivateApi.md#get_image_acquisition) | **GET** /api/v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
-[**get_image_ome_metadata**](PrivateApi.md#get_image_ome_metadata) | **GET** /api/v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
-[**get_object_info_by_accession**](PrivateApi.md#get_object_info_by_accession) | **GET** /api/v1/object_info_by_accessions | Get Object Info By Accession
-[**get_specimen**](PrivateApi.md#get_specimen) | **GET** /api/v1/specimens/{specimen_uuid} | Get Specimen
-[**get_study**](PrivateApi.md#get_study) | **GET** /api/v1/studies/{study_uuid} | Get Study
-[**get_study_file_references**](PrivateApi.md#get_study_file_references) | **GET** /api/v1/studies/{study_uuid}/file_references | Get Study File References
-[**get_study_images**](PrivateApi.md#get_study_images) | **GET** /api/v1/studies/{study_uuid}/images | Get Study Images
-[**get_study_images_by_alias**](PrivateApi.md#get_study_images_by_alias) | **GET** /api/v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
-[**health_check**](PrivateApi.md#health_check) | **GET** /api/v1/admin/health-check | Health Check
-[**login_for_access_token**](PrivateApi.md#login_for_access_token) | **POST** /api/v1/auth/token | Login For Access Token
-[**register_user**](PrivateApi.md#register_user) | **POST** /api/v1/auth/users/register | Register User
-[**search_collections**](PrivateApi.md#search_collections) | **GET** /api/v1/collections | Search Collections
-[**search_file_references_exact_match**](PrivateApi.md#search_file_references_exact_match) | **POST** /api/v1/search/file_references/exact_match | Search File References Exact Match
-[**search_images_exact_match**](PrivateApi.md#search_images_exact_match) | **POST** /api/v1/search/images/exact_match | Search Images Exact Match
-[**search_studies**](PrivateApi.md#search_studies) | **GET** /api/v1/search/studies | Search Studies
-[**search_studies_exact_match**](PrivateApi.md#search_studies_exact_match) | **POST** /api/v1/search/studies/exact_match | Search Studies Exact Match
-[**set_image_ome_metadata**](PrivateApi.md#set_image_ome_metadata) | **POST** /api/v1/private/images/{image_uuid}/ome_metadata | Set Image Ome Metadata
-[**study_refresh_counts**](PrivateApi.md#study_refresh_counts) | **POST** /api/v1/private/studies/{study_uuid}/refresh_counts | Study Refresh Counts
-[**update_biosample**](PrivateApi.md#update_biosample) | **PATCH** /api/v1/private/biosamples | Update Biosample
-[**update_file_reference**](PrivateApi.md#update_file_reference) | **PATCH** /api/v1/private/file_references/single | Update File Reference
-[**update_image**](PrivateApi.md#update_image) | **PATCH** /api/v1/private/images/single | Update Image
-[**update_image_acquisition**](PrivateApi.md#update_image_acquisition) | **PATCH** /api/v1/private/image_acquisitions | Update Image Acquisition
-[**update_specimen**](PrivateApi.md#update_specimen) | **PATCH** /api/v1/private/specimens | Update Specimen
-[**update_study**](PrivateApi.md#update_study) | **PATCH** /api/v1/private/studies | Update Study
+[**create_biosample**](PrivateApi.md#create_biosample) | **POST** /v1/private/biosamples | Create Biosample
+[**create_collection**](PrivateApi.md#create_collection) | **POST** /v1/private/collections | Create Collection
+[**create_file_references**](PrivateApi.md#create_file_references) | **POST** /v1/private/file_references | Create File References
+[**create_image_acquisition**](PrivateApi.md#create_image_acquisition) | **POST** /v1/private/image_acquisitions | Create Image Acquisition
+[**create_image_representation**](PrivateApi.md#create_image_representation) | **POST** /v1/private/images/{image_uuid}/representations/single | Create Image Representation
+[**create_images**](PrivateApi.md#create_images) | **POST** /v1/private/images | Create Images
+[**create_images_bulk**](PrivateApi.md#create_images_bulk) | **POST** /v1/private/images/bulk | Create Images Bulk
+[**create_specimen**](PrivateApi.md#create_specimen) | **POST** /v1/private/specimens | Create Specimen
+[**create_study**](PrivateApi.md#create_study) | **POST** /v1/private/studies | Create Study
+[**get_biosample**](PrivateApi.md#get_biosample) | **GET** /v1/biosamples/{biosample_uuid} | Get Biosample
+[**get_collection**](PrivateApi.md#get_collection) | **GET** /v1/collections/{collection_uuid} | Get Collection
+[**get_file_reference**](PrivateApi.md#get_file_reference) | **GET** /v1/file_references/{file_reference_uuid} | Get File Reference
+[**get_image**](PrivateApi.md#get_image) | **GET** /v1/images/{image_uuid} | Get Image
+[**get_image_acquisition**](PrivateApi.md#get_image_acquisition) | **GET** /v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
+[**get_image_ome_metadata**](PrivateApi.md#get_image_ome_metadata) | **GET** /v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
+[**get_object_info_by_accession**](PrivateApi.md#get_object_info_by_accession) | **GET** /v1/object_info_by_accessions | Get Object Info By Accession
+[**get_specimen**](PrivateApi.md#get_specimen) | **GET** /v1/specimens/{specimen_uuid} | Get Specimen
+[**get_study**](PrivateApi.md#get_study) | **GET** /v1/studies/{study_uuid} | Get Study
+[**get_study_file_references**](PrivateApi.md#get_study_file_references) | **GET** /v1/studies/{study_uuid}/file_references | Get Study File References
+[**get_study_images**](PrivateApi.md#get_study_images) | **GET** /v1/studies/{study_uuid}/images | Get Study Images
+[**get_study_images_by_alias**](PrivateApi.md#get_study_images_by_alias) | **GET** /v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
+[**health_check**](PrivateApi.md#health_check) | **GET** /v1/admin/health-check | Health Check
+[**login_for_access_token**](PrivateApi.md#login_for_access_token) | **POST** /v1/auth/token | Login For Access Token
+[**register_user**](PrivateApi.md#register_user) | **POST** /v1/auth/users/register | Register User
+[**search_collections**](PrivateApi.md#search_collections) | **GET** /v1/collections | Search Collections
+[**search_file_references_exact_match**](PrivateApi.md#search_file_references_exact_match) | **POST** /v1/search/file_references/exact_match | Search File References Exact Match
+[**search_images_exact_match**](PrivateApi.md#search_images_exact_match) | **POST** /v1/search/images/exact_match | Search Images Exact Match
+[**search_studies**](PrivateApi.md#search_studies) | **GET** /v1/search/studies | Search Studies
+[**search_studies_exact_match**](PrivateApi.md#search_studies_exact_match) | **POST** /v1/search/studies/exact_match | Search Studies Exact Match
+[**set_image_ome_metadata**](PrivateApi.md#set_image_ome_metadata) | **POST** /v1/private/images/{image_uuid}/ome_metadata | Set Image Ome Metadata
+[**study_refresh_counts**](PrivateApi.md#study_refresh_counts) | **POST** /v1/private/studies/{study_uuid}/refresh_counts | Study Refresh Counts
+[**update_biosample**](PrivateApi.md#update_biosample) | **PATCH** /v1/private/biosamples | Update Biosample
+[**update_file_reference**](PrivateApi.md#update_file_reference) | **PATCH** /v1/private/file_references/single | Update File Reference
+[**update_image**](PrivateApi.md#update_image) | **PATCH** /v1/private/images/single | Update Image
+[**update_image_acquisition**](PrivateApi.md#update_image_acquisition) | **PATCH** /v1/private/image_acquisitions | Update Image Acquisition
+[**update_specimen**](PrivateApi.md#update_specimen) | **PATCH** /v1/private/specimens | Update Specimen
+[**update_study**](PrivateApi.md#update_study) | **PATCH** /v1/private/studies | Update Study
 
 
 # **create_biosample**

--- a/clients/python/bia_integrator_api/docs/PublicApi.md
+++ b/clients/python/bia_integrator_api/docs/PublicApi.md
@@ -4,23 +4,23 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**get_biosample**](PublicApi.md#get_biosample) | **GET** /api/v1/biosamples/{biosample_uuid} | Get Biosample
-[**get_collection**](PublicApi.md#get_collection) | **GET** /api/v1/collections/{collection_uuid} | Get Collection
-[**get_file_reference**](PublicApi.md#get_file_reference) | **GET** /api/v1/file_references/{file_reference_uuid} | Get File Reference
-[**get_image**](PublicApi.md#get_image) | **GET** /api/v1/images/{image_uuid} | Get Image
-[**get_image_acquisition**](PublicApi.md#get_image_acquisition) | **GET** /api/v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
-[**get_image_ome_metadata**](PublicApi.md#get_image_ome_metadata) | **GET** /api/v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
-[**get_object_info_by_accession**](PublicApi.md#get_object_info_by_accession) | **GET** /api/v1/object_info_by_accessions | Get Object Info By Accession
-[**get_specimen**](PublicApi.md#get_specimen) | **GET** /api/v1/specimens/{specimen_uuid} | Get Specimen
-[**get_study**](PublicApi.md#get_study) | **GET** /api/v1/studies/{study_uuid} | Get Study
-[**get_study_file_references**](PublicApi.md#get_study_file_references) | **GET** /api/v1/studies/{study_uuid}/file_references | Get Study File References
-[**get_study_images**](PublicApi.md#get_study_images) | **GET** /api/v1/studies/{study_uuid}/images | Get Study Images
-[**get_study_images_by_alias**](PublicApi.md#get_study_images_by_alias) | **GET** /api/v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
-[**search_collections**](PublicApi.md#search_collections) | **GET** /api/v1/collections | Search Collections
-[**search_file_references_exact_match**](PublicApi.md#search_file_references_exact_match) | **POST** /api/v1/search/file_references/exact_match | Search File References Exact Match
-[**search_images_exact_match**](PublicApi.md#search_images_exact_match) | **POST** /api/v1/search/images/exact_match | Search Images Exact Match
-[**search_studies**](PublicApi.md#search_studies) | **GET** /api/v1/search/studies | Search Studies
-[**search_studies_exact_match**](PublicApi.md#search_studies_exact_match) | **POST** /api/v1/search/studies/exact_match | Search Studies Exact Match
+[**get_biosample**](PublicApi.md#get_biosample) | **GET** /v1/biosamples/{biosample_uuid} | Get Biosample
+[**get_collection**](PublicApi.md#get_collection) | **GET** /v1/collections/{collection_uuid} | Get Collection
+[**get_file_reference**](PublicApi.md#get_file_reference) | **GET** /v1/file_references/{file_reference_uuid} | Get File Reference
+[**get_image**](PublicApi.md#get_image) | **GET** /v1/images/{image_uuid} | Get Image
+[**get_image_acquisition**](PublicApi.md#get_image_acquisition) | **GET** /v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
+[**get_image_ome_metadata**](PublicApi.md#get_image_ome_metadata) | **GET** /v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
+[**get_object_info_by_accession**](PublicApi.md#get_object_info_by_accession) | **GET** /v1/object_info_by_accessions | Get Object Info By Accession
+[**get_specimen**](PublicApi.md#get_specimen) | **GET** /v1/specimens/{specimen_uuid} | Get Specimen
+[**get_study**](PublicApi.md#get_study) | **GET** /v1/studies/{study_uuid} | Get Study
+[**get_study_file_references**](PublicApi.md#get_study_file_references) | **GET** /v1/studies/{study_uuid}/file_references | Get Study File References
+[**get_study_images**](PublicApi.md#get_study_images) | **GET** /v1/studies/{study_uuid}/images | Get Study Images
+[**get_study_images_by_alias**](PublicApi.md#get_study_images_by_alias) | **GET** /v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
+[**search_collections**](PublicApi.md#search_collections) | **GET** /v1/collections | Search Collections
+[**search_file_references_exact_match**](PublicApi.md#search_file_references_exact_match) | **POST** /v1/search/file_references/exact_match | Search File References Exact Match
+[**search_images_exact_match**](PublicApi.md#search_images_exact_match) | **POST** /v1/search/images/exact_match | Search Images Exact Match
+[**search_studies**](PublicApi.md#search_studies) | **GET** /v1/search/studies | Search Studies
+[**search_studies_exact_match**](PublicApi.md#search_studies_exact_match) | **POST** /v1/search/studies/exact_match | Search Studies Exact Match
 
 
 # **get_biosample**

--- a/clients/python/bia_integrator_api_README.md
+++ b/clients/python/bia_integrator_api_README.md
@@ -71,60 +71,60 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PrivateApi* | [**create_biosample**](bia_integrator_api/docs/PrivateApi.md#create_biosample) | **POST** /api/v1/private/biosamples | Create Biosample
-*PrivateApi* | [**create_collection**](bia_integrator_api/docs/PrivateApi.md#create_collection) | **POST** /api/v1/private/collections | Create Collection
-*PrivateApi* | [**create_file_references**](bia_integrator_api/docs/PrivateApi.md#create_file_references) | **POST** /api/v1/private/file_references | Create File References
-*PrivateApi* | [**create_image_acquisition**](bia_integrator_api/docs/PrivateApi.md#create_image_acquisition) | **POST** /api/v1/private/image_acquisitions | Create Image Acquisition
-*PrivateApi* | [**create_image_representation**](bia_integrator_api/docs/PrivateApi.md#create_image_representation) | **POST** /api/v1/private/images/{image_uuid}/representations/single | Create Image Representation
-*PrivateApi* | [**create_images**](bia_integrator_api/docs/PrivateApi.md#create_images) | **POST** /api/v1/private/images | Create Images
-*PrivateApi* | [**create_images_bulk**](bia_integrator_api/docs/PrivateApi.md#create_images_bulk) | **POST** /api/v1/private/images/bulk | Create Images Bulk
-*PrivateApi* | [**create_specimen**](bia_integrator_api/docs/PrivateApi.md#create_specimen) | **POST** /api/v1/private/specimens | Create Specimen
-*PrivateApi* | [**create_study**](bia_integrator_api/docs/PrivateApi.md#create_study) | **POST** /api/v1/private/studies | Create Study
-*PrivateApi* | [**get_biosample**](bia_integrator_api/docs/PrivateApi.md#get_biosample) | **GET** /api/v1/biosamples/{biosample_uuid} | Get Biosample
-*PrivateApi* | [**get_collection**](bia_integrator_api/docs/PrivateApi.md#get_collection) | **GET** /api/v1/collections/{collection_uuid} | Get Collection
-*PrivateApi* | [**get_file_reference**](bia_integrator_api/docs/PrivateApi.md#get_file_reference) | **GET** /api/v1/file_references/{file_reference_uuid} | Get File Reference
-*PrivateApi* | [**get_image**](bia_integrator_api/docs/PrivateApi.md#get_image) | **GET** /api/v1/images/{image_uuid} | Get Image
-*PrivateApi* | [**get_image_acquisition**](bia_integrator_api/docs/PrivateApi.md#get_image_acquisition) | **GET** /api/v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
-*PrivateApi* | [**get_image_ome_metadata**](bia_integrator_api/docs/PrivateApi.md#get_image_ome_metadata) | **GET** /api/v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
-*PrivateApi* | [**get_object_info_by_accession**](bia_integrator_api/docs/PrivateApi.md#get_object_info_by_accession) | **GET** /api/v1/object_info_by_accessions | Get Object Info By Accession
-*PrivateApi* | [**get_specimen**](bia_integrator_api/docs/PrivateApi.md#get_specimen) | **GET** /api/v1/specimens/{specimen_uuid} | Get Specimen
-*PrivateApi* | [**get_study**](bia_integrator_api/docs/PrivateApi.md#get_study) | **GET** /api/v1/studies/{study_uuid} | Get Study
-*PrivateApi* | [**get_study_file_references**](bia_integrator_api/docs/PrivateApi.md#get_study_file_references) | **GET** /api/v1/studies/{study_uuid}/file_references | Get Study File References
-*PrivateApi* | [**get_study_images**](bia_integrator_api/docs/PrivateApi.md#get_study_images) | **GET** /api/v1/studies/{study_uuid}/images | Get Study Images
-*PrivateApi* | [**get_study_images_by_alias**](bia_integrator_api/docs/PrivateApi.md#get_study_images_by_alias) | **GET** /api/v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
-*PrivateApi* | [**health_check**](bia_integrator_api/docs/PrivateApi.md#health_check) | **GET** /api/v1/admin/health-check | Health Check
-*PrivateApi* | [**login_for_access_token**](bia_integrator_api/docs/PrivateApi.md#login_for_access_token) | **POST** /api/v1/auth/token | Login For Access Token
-*PrivateApi* | [**register_user**](bia_integrator_api/docs/PrivateApi.md#register_user) | **POST** /api/v1/auth/users/register | Register User
-*PrivateApi* | [**search_collections**](bia_integrator_api/docs/PrivateApi.md#search_collections) | **GET** /api/v1/collections | Search Collections
-*PrivateApi* | [**search_file_references_exact_match**](bia_integrator_api/docs/PrivateApi.md#search_file_references_exact_match) | **POST** /api/v1/search/file_references/exact_match | Search File References Exact Match
-*PrivateApi* | [**search_images_exact_match**](bia_integrator_api/docs/PrivateApi.md#search_images_exact_match) | **POST** /api/v1/search/images/exact_match | Search Images Exact Match
-*PrivateApi* | [**search_studies**](bia_integrator_api/docs/PrivateApi.md#search_studies) | **GET** /api/v1/search/studies | Search Studies
-*PrivateApi* | [**search_studies_exact_match**](bia_integrator_api/docs/PrivateApi.md#search_studies_exact_match) | **POST** /api/v1/search/studies/exact_match | Search Studies Exact Match
-*PrivateApi* | [**set_image_ome_metadata**](bia_integrator_api/docs/PrivateApi.md#set_image_ome_metadata) | **POST** /api/v1/private/images/{image_uuid}/ome_metadata | Set Image Ome Metadata
-*PrivateApi* | [**study_refresh_counts**](bia_integrator_api/docs/PrivateApi.md#study_refresh_counts) | **POST** /api/v1/private/studies/{study_uuid}/refresh_counts | Study Refresh Counts
-*PrivateApi* | [**update_biosample**](bia_integrator_api/docs/PrivateApi.md#update_biosample) | **PATCH** /api/v1/private/biosamples | Update Biosample
-*PrivateApi* | [**update_file_reference**](bia_integrator_api/docs/PrivateApi.md#update_file_reference) | **PATCH** /api/v1/private/file_references/single | Update File Reference
-*PrivateApi* | [**update_image**](bia_integrator_api/docs/PrivateApi.md#update_image) | **PATCH** /api/v1/private/images/single | Update Image
-*PrivateApi* | [**update_image_acquisition**](bia_integrator_api/docs/PrivateApi.md#update_image_acquisition) | **PATCH** /api/v1/private/image_acquisitions | Update Image Acquisition
-*PrivateApi* | [**update_specimen**](bia_integrator_api/docs/PrivateApi.md#update_specimen) | **PATCH** /api/v1/private/specimens | Update Specimen
-*PrivateApi* | [**update_study**](bia_integrator_api/docs/PrivateApi.md#update_study) | **PATCH** /api/v1/private/studies | Update Study
-*PublicApi* | [**get_biosample**](bia_integrator_api/docs/PublicApi.md#get_biosample) | **GET** /api/v1/biosamples/{biosample_uuid} | Get Biosample
-*PublicApi* | [**get_collection**](bia_integrator_api/docs/PublicApi.md#get_collection) | **GET** /api/v1/collections/{collection_uuid} | Get Collection
-*PublicApi* | [**get_file_reference**](bia_integrator_api/docs/PublicApi.md#get_file_reference) | **GET** /api/v1/file_references/{file_reference_uuid} | Get File Reference
-*PublicApi* | [**get_image**](bia_integrator_api/docs/PublicApi.md#get_image) | **GET** /api/v1/images/{image_uuid} | Get Image
-*PublicApi* | [**get_image_acquisition**](bia_integrator_api/docs/PublicApi.md#get_image_acquisition) | **GET** /api/v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
-*PublicApi* | [**get_image_ome_metadata**](bia_integrator_api/docs/PublicApi.md#get_image_ome_metadata) | **GET** /api/v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
-*PublicApi* | [**get_object_info_by_accession**](bia_integrator_api/docs/PublicApi.md#get_object_info_by_accession) | **GET** /api/v1/object_info_by_accessions | Get Object Info By Accession
-*PublicApi* | [**get_specimen**](bia_integrator_api/docs/PublicApi.md#get_specimen) | **GET** /api/v1/specimens/{specimen_uuid} | Get Specimen
-*PublicApi* | [**get_study**](bia_integrator_api/docs/PublicApi.md#get_study) | **GET** /api/v1/studies/{study_uuid} | Get Study
-*PublicApi* | [**get_study_file_references**](bia_integrator_api/docs/PublicApi.md#get_study_file_references) | **GET** /api/v1/studies/{study_uuid}/file_references | Get Study File References
-*PublicApi* | [**get_study_images**](bia_integrator_api/docs/PublicApi.md#get_study_images) | **GET** /api/v1/studies/{study_uuid}/images | Get Study Images
-*PublicApi* | [**get_study_images_by_alias**](bia_integrator_api/docs/PublicApi.md#get_study_images_by_alias) | **GET** /api/v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
-*PublicApi* | [**search_collections**](bia_integrator_api/docs/PublicApi.md#search_collections) | **GET** /api/v1/collections | Search Collections
-*PublicApi* | [**search_file_references_exact_match**](bia_integrator_api/docs/PublicApi.md#search_file_references_exact_match) | **POST** /api/v1/search/file_references/exact_match | Search File References Exact Match
-*PublicApi* | [**search_images_exact_match**](bia_integrator_api/docs/PublicApi.md#search_images_exact_match) | **POST** /api/v1/search/images/exact_match | Search Images Exact Match
-*PublicApi* | [**search_studies**](bia_integrator_api/docs/PublicApi.md#search_studies) | **GET** /api/v1/search/studies | Search Studies
-*PublicApi* | [**search_studies_exact_match**](bia_integrator_api/docs/PublicApi.md#search_studies_exact_match) | **POST** /api/v1/search/studies/exact_match | Search Studies Exact Match
+*PrivateApi* | [**create_biosample**](bia_integrator_api/docs/PrivateApi.md#create_biosample) | **POST** /v1/private/biosamples | Create Biosample
+*PrivateApi* | [**create_collection**](bia_integrator_api/docs/PrivateApi.md#create_collection) | **POST** /v1/private/collections | Create Collection
+*PrivateApi* | [**create_file_references**](bia_integrator_api/docs/PrivateApi.md#create_file_references) | **POST** /v1/private/file_references | Create File References
+*PrivateApi* | [**create_image_acquisition**](bia_integrator_api/docs/PrivateApi.md#create_image_acquisition) | **POST** /v1/private/image_acquisitions | Create Image Acquisition
+*PrivateApi* | [**create_image_representation**](bia_integrator_api/docs/PrivateApi.md#create_image_representation) | **POST** /v1/private/images/{image_uuid}/representations/single | Create Image Representation
+*PrivateApi* | [**create_images**](bia_integrator_api/docs/PrivateApi.md#create_images) | **POST** /v1/private/images | Create Images
+*PrivateApi* | [**create_images_bulk**](bia_integrator_api/docs/PrivateApi.md#create_images_bulk) | **POST** /v1/private/images/bulk | Create Images Bulk
+*PrivateApi* | [**create_specimen**](bia_integrator_api/docs/PrivateApi.md#create_specimen) | **POST** /v1/private/specimens | Create Specimen
+*PrivateApi* | [**create_study**](bia_integrator_api/docs/PrivateApi.md#create_study) | **POST** /v1/private/studies | Create Study
+*PrivateApi* | [**get_biosample**](bia_integrator_api/docs/PrivateApi.md#get_biosample) | **GET** /v1/biosamples/{biosample_uuid} | Get Biosample
+*PrivateApi* | [**get_collection**](bia_integrator_api/docs/PrivateApi.md#get_collection) | **GET** /v1/collections/{collection_uuid} | Get Collection
+*PrivateApi* | [**get_file_reference**](bia_integrator_api/docs/PrivateApi.md#get_file_reference) | **GET** /v1/file_references/{file_reference_uuid} | Get File Reference
+*PrivateApi* | [**get_image**](bia_integrator_api/docs/PrivateApi.md#get_image) | **GET** /v1/images/{image_uuid} | Get Image
+*PrivateApi* | [**get_image_acquisition**](bia_integrator_api/docs/PrivateApi.md#get_image_acquisition) | **GET** /v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
+*PrivateApi* | [**get_image_ome_metadata**](bia_integrator_api/docs/PrivateApi.md#get_image_ome_metadata) | **GET** /v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
+*PrivateApi* | [**get_object_info_by_accession**](bia_integrator_api/docs/PrivateApi.md#get_object_info_by_accession) | **GET** /v1/object_info_by_accessions | Get Object Info By Accession
+*PrivateApi* | [**get_specimen**](bia_integrator_api/docs/PrivateApi.md#get_specimen) | **GET** /v1/specimens/{specimen_uuid} | Get Specimen
+*PrivateApi* | [**get_study**](bia_integrator_api/docs/PrivateApi.md#get_study) | **GET** /v1/studies/{study_uuid} | Get Study
+*PrivateApi* | [**get_study_file_references**](bia_integrator_api/docs/PrivateApi.md#get_study_file_references) | **GET** /v1/studies/{study_uuid}/file_references | Get Study File References
+*PrivateApi* | [**get_study_images**](bia_integrator_api/docs/PrivateApi.md#get_study_images) | **GET** /v1/studies/{study_uuid}/images | Get Study Images
+*PrivateApi* | [**get_study_images_by_alias**](bia_integrator_api/docs/PrivateApi.md#get_study_images_by_alias) | **GET** /v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
+*PrivateApi* | [**health_check**](bia_integrator_api/docs/PrivateApi.md#health_check) | **GET** /v1/admin/health-check | Health Check
+*PrivateApi* | [**login_for_access_token**](bia_integrator_api/docs/PrivateApi.md#login_for_access_token) | **POST** /v1/auth/token | Login For Access Token
+*PrivateApi* | [**register_user**](bia_integrator_api/docs/PrivateApi.md#register_user) | **POST** /v1/auth/users/register | Register User
+*PrivateApi* | [**search_collections**](bia_integrator_api/docs/PrivateApi.md#search_collections) | **GET** /v1/collections | Search Collections
+*PrivateApi* | [**search_file_references_exact_match**](bia_integrator_api/docs/PrivateApi.md#search_file_references_exact_match) | **POST** /v1/search/file_references/exact_match | Search File References Exact Match
+*PrivateApi* | [**search_images_exact_match**](bia_integrator_api/docs/PrivateApi.md#search_images_exact_match) | **POST** /v1/search/images/exact_match | Search Images Exact Match
+*PrivateApi* | [**search_studies**](bia_integrator_api/docs/PrivateApi.md#search_studies) | **GET** /v1/search/studies | Search Studies
+*PrivateApi* | [**search_studies_exact_match**](bia_integrator_api/docs/PrivateApi.md#search_studies_exact_match) | **POST** /v1/search/studies/exact_match | Search Studies Exact Match
+*PrivateApi* | [**set_image_ome_metadata**](bia_integrator_api/docs/PrivateApi.md#set_image_ome_metadata) | **POST** /v1/private/images/{image_uuid}/ome_metadata | Set Image Ome Metadata
+*PrivateApi* | [**study_refresh_counts**](bia_integrator_api/docs/PrivateApi.md#study_refresh_counts) | **POST** /v1/private/studies/{study_uuid}/refresh_counts | Study Refresh Counts
+*PrivateApi* | [**update_biosample**](bia_integrator_api/docs/PrivateApi.md#update_biosample) | **PATCH** /v1/private/biosamples | Update Biosample
+*PrivateApi* | [**update_file_reference**](bia_integrator_api/docs/PrivateApi.md#update_file_reference) | **PATCH** /v1/private/file_references/single | Update File Reference
+*PrivateApi* | [**update_image**](bia_integrator_api/docs/PrivateApi.md#update_image) | **PATCH** /v1/private/images/single | Update Image
+*PrivateApi* | [**update_image_acquisition**](bia_integrator_api/docs/PrivateApi.md#update_image_acquisition) | **PATCH** /v1/private/image_acquisitions | Update Image Acquisition
+*PrivateApi* | [**update_specimen**](bia_integrator_api/docs/PrivateApi.md#update_specimen) | **PATCH** /v1/private/specimens | Update Specimen
+*PrivateApi* | [**update_study**](bia_integrator_api/docs/PrivateApi.md#update_study) | **PATCH** /v1/private/studies | Update Study
+*PublicApi* | [**get_biosample**](bia_integrator_api/docs/PublicApi.md#get_biosample) | **GET** /v1/biosamples/{biosample_uuid} | Get Biosample
+*PublicApi* | [**get_collection**](bia_integrator_api/docs/PublicApi.md#get_collection) | **GET** /v1/collections/{collection_uuid} | Get Collection
+*PublicApi* | [**get_file_reference**](bia_integrator_api/docs/PublicApi.md#get_file_reference) | **GET** /v1/file_references/{file_reference_uuid} | Get File Reference
+*PublicApi* | [**get_image**](bia_integrator_api/docs/PublicApi.md#get_image) | **GET** /v1/images/{image_uuid} | Get Image
+*PublicApi* | [**get_image_acquisition**](bia_integrator_api/docs/PublicApi.md#get_image_acquisition) | **GET** /v1/image_acquisitions/{image_acquisition_uuid} | Get Image Acquisition
+*PublicApi* | [**get_image_ome_metadata**](bia_integrator_api/docs/PublicApi.md#get_image_ome_metadata) | **GET** /v1/images/{image_uuid}/ome_metadata | Get Image Ome Metadata
+*PublicApi* | [**get_object_info_by_accession**](bia_integrator_api/docs/PublicApi.md#get_object_info_by_accession) | **GET** /v1/object_info_by_accessions | Get Object Info By Accession
+*PublicApi* | [**get_specimen**](bia_integrator_api/docs/PublicApi.md#get_specimen) | **GET** /v1/specimens/{specimen_uuid} | Get Specimen
+*PublicApi* | [**get_study**](bia_integrator_api/docs/PublicApi.md#get_study) | **GET** /v1/studies/{study_uuid} | Get Study
+*PublicApi* | [**get_study_file_references**](bia_integrator_api/docs/PublicApi.md#get_study_file_references) | **GET** /v1/studies/{study_uuid}/file_references | Get Study File References
+*PublicApi* | [**get_study_images**](bia_integrator_api/docs/PublicApi.md#get_study_images) | **GET** /v1/studies/{study_uuid}/images | Get Study Images
+*PublicApi* | [**get_study_images_by_alias**](bia_integrator_api/docs/PublicApi.md#get_study_images_by_alias) | **GET** /v1/studies/{study_accession}/images_by_aliases | Get Study Images By Alias
+*PublicApi* | [**search_collections**](bia_integrator_api/docs/PublicApi.md#search_collections) | **GET** /v1/collections | Search Collections
+*PublicApi* | [**search_file_references_exact_match**](bia_integrator_api/docs/PublicApi.md#search_file_references_exact_match) | **POST** /v1/search/file_references/exact_match | Search File References Exact Match
+*PublicApi* | [**search_images_exact_match**](bia_integrator_api/docs/PublicApi.md#search_images_exact_match) | **POST** /v1/search/images/exact_match | Search Images Exact Match
+*PublicApi* | [**search_studies**](bia_integrator_api/docs/PublicApi.md#search_studies) | **GET** /v1/search/studies | Search Studies
+*PublicApi* | [**search_studies_exact_match**](bia_integrator_api/docs/PublicApi.md#search_studies_exact_match) | **POST** /v1/search/studies/exact_match | Search Studies Exact Match
 
 
 ## Documentation For Models


### PR DESCRIPTION
Changes needed to make the api work under the TM reverse proxy
* move openapi.json, docs out of root to versioned path
* remove /api/ prefix from root. This is so clients get generated with /vN/... paths and then we can configure clients to use https://ebi.ac.uk/bioimage-archive/api as the base (instead of https://ebi.ac.uk/bioimage-archive)

These are *very* breaking changes, all fixable with a client update (once the branch is merged in)