### PR TITLE
minor fixes to align annotation model, as well as licence spelling …

### DIFF
--- a/bia-shared-datamodels/src/bia_models/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_models/bia_data_model.py
@@ -107,7 +107,7 @@ class ImageAnnotationDataset(
     file: List[UUID] = Field()
     annotation_file: List[UUID] = Field()
     submitted_in_study: UUID = Field()
-    annotation_method: UUID = Field()
+    annotation_method: List[UUID] = Field()
 
 
 class AnnotationFileReference(
@@ -116,7 +116,7 @@ class AnnotationFileReference(
 ):
     source_image: List[UUID] = Field()
     submission_dataset: UUID = Field()
-    creation_process: UUID = Field()
+    creation_process: List[UUID] = Field()
 
 
 class DerivedImage(
@@ -125,7 +125,7 @@ class DerivedImage(
 ):
     source_image: List[UUID] = Field()
     submission_dataset: UUID = Field()
-    creation_process: UUID = Field()
+    creation_process: List[UUID] = Field()
     representation: List[UUID] = Field()
 
 

--- a/bia-shared-datamodels/src/bia_models/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_models/semantic_models.py
@@ -103,7 +103,7 @@ class Study(DocumentMixin):
     """
 
     accession_id: str = Field(description="""Unique ID provided by BioStudies.""")
-    license: LicenseType = Field(
+    licence: LicenceType = Field(
         description="""The license under which the data associated with the study is made avaliable."""
     )
     see_also: Optional[List[ExternalReference]] = Field(
@@ -189,7 +189,7 @@ class FundingBody(BaseModel):
     )
 
 
-class LicenseType(str, Enum):
+class LicenceType(str, Enum):
     # No Copyright. You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
     CC0 = "CC0"
     # You are free to: Share — copy and redistribute the material in any medium or format. Adapt — remix, transform, and build upon the material  for any purpose, even commercially. You must give appropriate credit, provide a link to the license, and indicate if changes were made.  You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
@@ -207,7 +207,7 @@ class DatasetMixin(BaseModel):
     """
 
     file: List[FileReference] = Field(
-        description="""Files associated with the dataset"""
+        description="""Files associated with the dataset."""
     )
     file_reference_count: int = Field(
         description="""Number of files associated with the study."""
@@ -516,7 +516,7 @@ class ImageAnnotationDataset(DatasetMixin):
     image: List[DerivedImage] = Field(
         description="""Images associated with the dataset."""
     )
-    example_image_uri: list[str] = Field(
+    example_image_uri: List[str] = Field(
         description="A viewable image that is typical of the dataset."
     )
     image_count: int = Field(
@@ -529,13 +529,13 @@ class AnnotationMethod(ProtocolMixin):
     Information about the annotation process, such as methods used, or how much of a dataset was annotated.
     """
 
-    source_dataset: List[Union[ExperimentalImagingDataset | AnyUrl]] = Field(
+    source_dataset: Optional[List[Union[ExperimentalImagingDataset | AnyUrl]]] = Field(
         description="""The datasets that were annotated."""
     )
-    annotation_criteria: str = Field(
+    annotation_criteria: Optional[str] = Field(
         description="""Rules used to generate annotations."""
     )
-    annotation_coverage: str = Field(
+    annotation_coverage: Optional[str] = Field(
         description="""Which images from the dataset were annotated, and what percentage of the data has been annotated from what is available."""
     )
     method_type: AnnotationType = Field(
@@ -551,13 +551,13 @@ class AnnotationMixin(BaseModel):
     source_image: List[ImageRepresentation] = Field(
         description="""The original image(s) this file is annotating."""
     )
-    transformation_description: str = Field(
+    transformation_description: Optional[str] = Field(
         description="""Any transformations required to link annotations to the image."""
     )
-    spatial_information: str = Field(
+    spatial_information: Optional[str] = Field(
         description="""Spatial information for non-pixel annotations."""
     )
-    creation_process: AnnotationMethod = Field(
+    creation_process: List[AnnotationMethod] = Field(
         description="""The process that was followed to create the annotation."""
     )
 

--- a/bia-shared-datamodels/test/utils.py
+++ b/bia-shared-datamodels/test/utils.py
@@ -155,7 +155,7 @@ def get_template_derived_image() -> bia_data_model.DerivedImage:
                 get_template_image_representation().uuid,
             ],
             "submission_dataset": get_template_image_annotation_dataset().uuid,
-            "creation_process": get_template_annotation_method().uuid,
+            "creation_process": [get_template_annotation_method().uuid],
             "representation": [
                 get_template_image_representation().uuid,
             ],
@@ -188,7 +188,7 @@ def get_template_image_annotation_dataset() -> bia_data_model.ImageAnnotationDat
             "file": [],  # This should be a list of FileReference UUIDs ...
             "annotation_file": [],  # This should be a list of AnnotationFileReference UUIDs ...
             "submitted_in_study": get_template_study().uuid,
-            "annotation_method": get_template_annotation_method().uuid,
+            "annotation_method": [get_template_annotation_method().uuid],
             "file_reference_count": 0,
             "image_count": 0,
             "example_image_uri": ["https://dummy.url.org"],
@@ -294,7 +294,7 @@ def get_template_annotation_file_reference() -> bia_data_model.AnnotationFileRef
             ],
             "transformation_description": "Template transformation description",
             "spatial_information": "Template spatial information",
-            "creation_process": get_template_annotation_method().uuid,
+            "creation_process": [get_template_annotation_method().uuid],
         }
     )
 
@@ -383,7 +383,7 @@ def get_template_study() -> bia_data_model.Study:
         {
             "uuid": uuid4(),
             "accession_id": "S-BIADTEST",
-            "license": semantic_models.LicenseType.CC0,
+            "licence": semantic_models.LicenceType.CC0,
             "attribute": {},
             "related_publication": [],
             # From DocumentMixin


### PR DESCRIPTION
Creation process was a list on the annotation dataset (similar to image acquisition, to allow for splitting into multiple smaller steps). So we needed the DerivedImage and AnnotationFileReference to also have the list value to mirror the information on the dataset.

Also updated the spelling of license to licence.

An additional changes i'm considering, but have not included, is trying to further standardise when we put mini-count 1 restrictions on list fields, vs when we have optional list fields - suggestions welcome on this topic.
