### PR TITLE
removed dataset type enums for validation

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -31,9 +31,6 @@ class FileReference(
     DocumentMixin,
 ):
     submission_dataset_uuid: UUID = Field()
-    submission_dataset_type: DatasetType = Field(
-        description="""The type of dataset in which this file was submitted to the BioImage Archive."""
-    )
 
 
 class ImageRepresentation(
@@ -43,7 +40,6 @@ class ImageRepresentation(
     # We may want to store the FileReference -> Image(Represenation) rather than in the original_file_reference_uuid
     original_file_reference_uuid: Optional[List[UUID]] = Field()
     representation_of_uuid: UUID = Field()
-    abstract_image_type: AbstractImageType = Field()
 
 
 class ExperimentalImagingDataset(
@@ -133,20 +129,3 @@ class AnnotationMethod(
 ):
     pass
 
-
-class DatasetType(str, Enum):
-    """
-    The type of Dataset stored in the BIA. Used by File Referneces to
-    """
-
-    ExperimentalImagingDataset = "ExperimentalImagingDataset"
-    ImageAnnotationDataset = "ImageAnnotationDataset"
-
-
-class AbstractImageType(str, Enum):
-    """
-    The type of Abstract Image stored in the BIA. Used by Image representations to store
-    """
-
-    ExperimentallyDerivedImage = "ExperimentallyDerivedImage"
-    DerivedImage = "DerivedImage"

--- a/bia-shared-datamodels/test/utils.py
+++ b/bia-shared-datamodels/test/utils.py
@@ -297,7 +297,6 @@ def get_template_file_reference() -> bia_data_model.FileReference:
             "uri": "https://dummy.uri.co",
             "attribute": {},
             "submission_dataset_uuid": get_template_experimental_imaging_dataset().uuid,
-            "submission_dataset_type": bia_data_model.DatasetType.ExperimentalImagingDataset
         }
     )
     return file_reference
@@ -310,7 +309,6 @@ def get_template_image_representation() -> bia_data_model.ImageRepresentation:
         {
             "uuid": uuid4(),
             "representation_of_uuid": get_template_experimentally_captured_image().uuid,
-            "abstract_image_type": bia_data_model.AbstractImageType.DerivedImage,
             "original_file_reference_uuid": [
                 get_template_file_reference().uuid,
             ],


### PR DESCRIPTION
These enums were created to deal with different types at the end of the submitted_in_dataset_uuid paths, but we think this could be better handled by using two subclasses (thought this might introduce the same issue with the link from derived image -source_image-> file representation). In any case, this should probably be looked into when desiging the UUID validation & have more thinking about it (perhaps a design doc). Removing for now, and cut this ticket https://app.clickup.com/t/86956e5g9 to track the follow-up work.