### PR TITLE
fix tests after model update with version and model version, and extend forbidding extra fields to nested nodes

### DIFF
--- a/bia-export/test/input_data/biosample/S-BIADTEST/64a67727-4e7c-469a-91c4-6219ae072e99.json
+++ b/bia-export/test/input_data/biosample/S-BIADTEST/64a67727-4e7c-469a-91c4-6219ae072e99.json
@@ -17,5 +17,6 @@
     ],
     "intrinsic_variable_description": [
         "Test intrinsic variable 1\\nwith escaped character"
-    ]
+    ],
+    "version": 1
 }

--- a/bia-export/test/input_data/biosample/S-BIADTEST/6950718c-4917-47a1-a807-11b874e80a23.json
+++ b/bia-export/test/input_data/biosample/S-BIADTEST/6950718c-4917-47a1-a807-11b874e80a23.json
@@ -17,5 +17,6 @@
     ],
     "intrinsic_variable_description": [
         "Test intrinsic variable 2"
-    ]
+    ],
+    "version": 1
 }

--- a/bia-export/test/input_data/experimental_imaging_datasets/S-BIADTEST/47a4ab60-c76d-4424-bfaa-c2a024de720c.json
+++ b/bia-export/test/input_data/experimental_imaging_datasets/S-BIADTEST/47a4ab60-c76d-4424-bfaa-c2a024de720c.json
@@ -10,5 +10,6 @@
     ],
     "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
     "correlation_method": [],
-    "example_image_uri": []
+    "example_image_uri": [],
+    "version": 1
 }

--- a/bia-export/test/input_data/image_acquisitions/S-BIADTEST/c2e44a1b-a43c-476e-8ddf-8587f4c955b3.json
+++ b/bia-export/test/input_data/image_acquisitions/S-BIADTEST/c2e44a1b-a43c-476e-8ddf-8587f4c955b3.json
@@ -4,5 +4,6 @@
     "protocol_description": "Test image acquisition parameters 1",
     "imaging_instrument_description": "Test imaging instrument 1",
     "fbbi_id": [],
-    "imaging_method_name": "confocal microscopy"
+    "imaging_method_name": "confocal microscopy",
+    "version": 1
 }

--- a/bia-export/test/input_data/specimen_imaging_preparation_protocols/S-BIADTEST/7199d730-29f1-4ad8-b599-e9089cbb2d7b.json
+++ b/bia-export/test/input_data/specimen_imaging_preparation_protocols/S-BIADTEST/7199d730-29f1-4ad8-b599-e9089cbb2d7b.json
@@ -2,5 +2,6 @@
     "title_id": "Test specimen 1",
     "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
     "protocol_description": "Test sample preparation protocol 1",
-    "signal_channel_information": []
+    "signal_channel_information": [],
+    "version": 1
 }

--- a/bia-export/test/input_data/studies/S-BIADTEST.json
+++ b/bia-export/test/input_data/studies/S-BIADTEST.json
@@ -1,5 +1,10 @@
 {
     "uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+    "version": 1,
+    "model": {
+        "type_name": "Study",
+        "version": 1
+    },
     "accession_id": "S-BIADTEST",
     "licence": "CC0",
     "author": [

--- a/bia-export/test/output_data/bia_export.json
+++ b/bia-export/test/output_data/bia_export.json
@@ -1,5 +1,10 @@
 {
     "uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+    "version": 1,
+    "model": {
+        "type_name": "Study",
+        "version": 1
+    },
     "accession_id": "S-BIADTEST",
     "licence": "CC0",
     "author": [
@@ -75,6 +80,11 @@
         {
             "title_id": "Study Component 1",
             "uuid": "47a4ab60-c76d-4424-bfaa-c2a024de720c",
+            "version": 1,
+            "model": {
+                "type_name": "ExperimentalImagingDataset",
+                "version": 1
+            },
             "description": "Description of study component 1",
             "analysis_method": [
                 {

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
@@ -53,6 +53,7 @@ def extract_annotation_method_dicts(submission: Submission) -> List[Dict[str, An
         model_dict["accno"] = section.__dict__.get("accno", "")
         model_dict["accession_id"] = submission.accno
         model_dict["uuid"] = generate_annotation_method_uuid(model_dict)
+        model_dict["version"] = 1
         model_dict = filter_model_dictionary(model_dict, bia_data_model.AnnotationMethod)
 
         model_dicts.append(model_dict)

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
@@ -75,6 +75,7 @@ def extract_biosample_dicts(submission: Submission) -> List[Dict[str, Any]]:
 
         model_dict["accession_id"] = submission.accno
         model_dict["uuid"] = generate_biosample_uuid(model_dict)
+        model_dict["version"] = 1
         model_dict = filter_model_dictionary(model_dict, bia_data_model.BioSample)
         model_dicts.append(model_dict)
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -96,6 +96,7 @@ def get_experimental_imaging_dataset(
             "analysis_method": analysis_method_list,
             "correlation_method": correlation_method_list,
             "example_image_uri": [],
+            "version": 1
         }
         model_dict["uuid"] = generate_experimental_imaging_dataset_uuid(model_dict)
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
@@ -45,6 +45,7 @@ def get_file_reference_by_study_component(
                 "accession_id": submission.accno,
                 "file_path": str(f.path),
                 "size_in_bytes": str(f.size),
+                "version": 1
             }
             fileref_uuid = dict_to_uuid(
                 file_dict, ["accession_id", "file_path", "size_in_bytes"]

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
@@ -52,6 +52,7 @@ def extract_image_acquisition_dicts(submission: Submission) -> List[Dict[str, An
         model_dict["accno"] = section.__dict__.get("accno", "")
         model_dict["accession_id"] = submission.accno
         model_dict["uuid"] = generate_image_acquisition_uuid(model_dict)
+        model_dict["version"] = 1
         model_dict = filter_model_dictionary(model_dict, bia_data_model.ImageAcquisition)
         model_dicts.append(model_dict)
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
@@ -47,6 +47,7 @@ def extract_specimen_growth_protocol_dicts(submission: Submission) -> List[Dict[
         model_dict["accno"] = section.__dict__.get("accno", "")
         model_dict["accession_id"] = submission.accno
         model_dict["uuid"] = generate_specimen_growth_protocol_uuid(model_dict)
+        model_dict["version"] = 1
         model_dict = filter_model_dictionary(model_dict, bia_data_model.SpecimenGrowthProtocol)
 
         model_dicts.append(model_dict)

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
@@ -50,6 +50,7 @@ def extract_specimen_preparation_protocol_dicts(submission: Submission) -> List[
         model_dict["accno"] = section.__dict__.get("accno", "")
         model_dict["accession_id"] = submission.accno
         model_dict["uuid"] = generate_specimen_imaging_preparation_uuid(model_dict)
+        model_dict["version"] = 1
         model_dict = filter_model_dictionary(model_dict, bia_data_model.SpecimenImagingPrepartionProtocol)
 
         model_dicts.append(model_dict)

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
@@ -65,6 +65,7 @@ def get_study(
         "author": [c.model_dump() for c in contributors],
         "grant": [g.model_dump() for g in grants],
         "attribute": study_attributes,
+        "version": 1
     }
     # study_uuid = dict_to_uuid(study_dict, ["accession_id",])
     # study_dict["uuid"] = study_uuid

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
@@ -155,5 +155,5 @@ def persist(object_list: List, object_path: str, sumbission_accno: str):
 
 def filter_model_dictionary(dictionary: dict, target_model: Type[BaseModel]):
     accepted_fields = target_model.model_fields.keys()
-    result_dict = {key: dictionary[key] for key in accepted_fields}
+    result_dict = {key: dictionary[key]  for key in accepted_fields if key in dictionary}
     return result_dict

--- a/bia-ingest-shared-models/test/utils.py
+++ b/bia-ingest-shared-models/test/utils.py
@@ -33,6 +33,7 @@ def get_test_annotation_method() -> List[bia_data_model.AnnotationMethod]:
             "annotation_coverage": "",
             "method_type": "other",
             "source_dataset": [],
+            "version": 1,
         },
     ]
 
@@ -58,12 +59,14 @@ def get_test_specimen_growth_protocol() -> List[bia_data_model.SpecimenGrowthPro
             "accession_id": "S-BIADTEST",
             "title_id": "Test specimen 1",
             "protocol_description": "Test growth protocol 1",
+            "version": 1,
         },
         {
             "accno": "Specimen-2",
             "accession_id": "S-BIADTEST",
             "title_id": "Test specimen 2",
             "protocol_description": "Test growth protocol 2",
+            "version": 1,
         },
     ]
 
@@ -94,6 +97,7 @@ def get_test_specimen_imaging_preparation_protocol() -> (
             "title_id": "Test specimen 1",
             "protocol_description": "Test sample preparation protocol 1",
             "signal_channel_information": [],
+            "version": 1,
         },
         {
             "accno": "Specimen-2",
@@ -101,6 +105,7 @@ def get_test_specimen_imaging_preparation_protocol() -> (
             "title_id": "Test specimen 2",
             "protocol_description": "Test sample preparation protocol 2",
             "signal_channel_information": [],
+            "version": 1,
         },
     ]
 
@@ -158,6 +163,7 @@ def get_test_biosample() -> List[bia_data_model.BioSample]:
             "intrinsic_variable_description": [
                 "Test intrinsic variable 1\nwith escaped character",
             ],
+            "version": 1,
         },
         {
             "accno": "Biosample-2",
@@ -176,6 +182,7 @@ def get_test_biosample() -> List[bia_data_model.BioSample]:
             "intrinsic_variable_description": [
                 "Test intrinsic variable 2",
             ],
+            "version": 1,
         },
     ]
 
@@ -206,6 +213,7 @@ def get_test_image_acquisition() -> List[bia_data_model.ImageAcquisition]:
             "imaging_instrument_description": "Test imaging instrument 1",
             "imaging_method_name": "confocal microscopy",
             "fbbi_id": [],
+            "version": 1,
         },
         {
             "accno": "Image acquisition-7",
@@ -215,6 +223,7 @@ def get_test_image_acquisition() -> List[bia_data_model.ImageAcquisition]:
             "imaging_instrument_description": "Test imaging instrument 2",
             "imaging_method_name": "fluorescence microscopy",
             "fbbi_id": [],
+            "version": 1,
         },
     ]
     image_acquisition = []
@@ -272,6 +281,7 @@ def get_test_experimental_imaging_dataset() -> (
         ],
         "example_image_uri": [],
         "description": "Description of study component 1",
+        "version": 1,
     }
     experimental_imaging_dataset_uuid = dict_to_uuid(
         experimental_imaging_dataset_dict,
@@ -294,16 +304,19 @@ def get_test_experimental_imaging_dataset() -> (
             "accession_id": "S-BIADTEST",
             "file_path": "study_component2/im06.png",
             "size_in_bytes": 3,
+            "version": 1,
         },
         {
             "accession_id": "S-BIADTEST",
             "file_path": "study_component2/im08.png",
             "size_in_bytes": 123,
+            "version": 1,
         },
         {
             "accession_id": "S-BIADTEST",
             "file_path": "study_component2/ann01-05",
             "size_in_bytes": 11,
+            "version": 1,
         },
     ]
     experimental_imaging_dataset_dict = {
@@ -317,6 +330,7 @@ def get_test_experimental_imaging_dataset() -> (
         ],
         "example_image_uri": [],
         "description": "Description of study component 2",
+        "version": 1,
     }
     experimental_imaging_dataset_uuid = dict_to_uuid(
         experimental_imaging_dataset_dict,
@@ -495,6 +509,7 @@ def get_test_study() -> bia_data_model.Study:
             "Test keyword3",
         ],
         "grant": [g.model_dump() for g in grant],
+        "version": 1,
     }
     study_uuid = dict_to_uuid(
         study_dict,

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -25,9 +25,6 @@ class DocumentMixin(BaseModel):
         Optional because for some usecases (e.g. api) we want to accept objects without it because we have the info we need to set it."""
     )
 
-    # Throw error if you try to validate/create model from a dictionary with keys that aren't a field in the model
-    model_config = ConfigDict(extra="forbid")
-
     def __init__(self, *args, **data):
         model_version_spec = self.model_config.get("model_version_latest")
         if model_version_spec is None:
@@ -41,6 +38,7 @@ class DocumentMixin(BaseModel):
         )
         model_metadata_existing = data.get("model", None)
         if model_metadata_existing:
+            model_metadata_existing = ModelMetadata(**model_metadata_existing)
             if model_metadata_existing != model_metadata_expected:
                 raise exceptions.UnexpectedDocumentType(
                     f"Document {str(data.get('uuid'))} has model metadata {model_metadata_existing}, expected : {model_metadata_expected}"

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from enum import Enum
 from datetime import date
-from typing import List, Optional, Union
+from typing import List, Optional
 
-from pydantic import BaseModel, Field, EmailStr, AnyUrl
+from pydantic import BaseModel, Field, EmailStr, AnyUrl, ConfigDict
+
+
+class ConfiguredBaseModel(BaseModel):
+    # Throw error if you try to validate/create model from a dictionary with keys that aren't a field in the model
+    model_config = ConfigDict(extra="forbid")
 
 
 #######################################################################################################
@@ -12,7 +17,7 @@ from pydantic import BaseModel, Field, EmailStr, AnyUrl
 #######################################################################################################
 
 
-class Study(BaseModel):
+class Study(ConfiguredBaseModel):
     """
     A piece of scientific work that resulted in the creation of imaging data.
     """
@@ -67,7 +72,7 @@ class Study(BaseModel):
     )
 
 
-class Publication(BaseModel):
+class Publication(ConfiguredBaseModel):
     """
     A published paper or written work.
     """
@@ -83,7 +88,7 @@ class Publication(BaseModel):
     doi: Optional[str] = Field(None, description="""Digital Object Identifier (DOI)""")
 
 
-class ExternalReference(BaseModel):
+class ExternalReference(ConfiguredBaseModel):
     """
     An object outside the BIA that a user wants to refer to.
     """
@@ -99,7 +104,7 @@ class ExternalReference(BaseModel):
     )
 
 
-class Grant(BaseModel):
+class Grant(ConfiguredBaseModel):
     """ """
 
     id: Optional[str] = Field(
@@ -113,7 +118,7 @@ class Grant(BaseModel):
     )
 
 
-class FundingBody(BaseModel):
+class FundingBody(ConfiguredBaseModel):
     """ """
 
     display_name: str = Field(
@@ -137,7 +142,7 @@ class LicenceType(str, Enum):
 #######################################################################################################
 
 
-class PersonMixin(BaseModel):
+class PersonMixin(ConfiguredBaseModel):
     """
     Person information
     """
@@ -147,7 +152,7 @@ class PersonMixin(BaseModel):
     )
 
 
-class OrganisationMixin(BaseModel):
+class OrganisationMixin(ConfiguredBaseModel):
     """
     Organisation information
     """
@@ -199,7 +204,7 @@ class Affiliation(OrganisationMixin):
 #######################################################################################################
 
 
-class DatasetMixin(BaseModel):
+class DatasetMixin(ConfiguredBaseModel):
     """
     A logical grouping of data (in files) based on the process involved in it's creation.
     """
@@ -220,7 +225,7 @@ class DatasetMixin(BaseModel):
     )
 
 
-class FileReference(BaseModel):
+class FileReference(ConfiguredBaseModel):
     """
     Information about a file, provided in file list.
     """
@@ -242,7 +247,7 @@ class FileReference(BaseModel):
 
 
 
-class ProtocolMixin(BaseModel):
+class ProtocolMixin(ConfiguredBaseModel):
     """
     A protocol for either capturing, combining, or analysing images.
     """
@@ -258,7 +263,7 @@ class ProtocolMixin(BaseModel):
 #######################################################################################################
 
 
-class AbstractImageMixin(BaseModel):
+class AbstractImageMixin(ConfiguredBaseModel):
     """
     The abstract notion of an image that can have many representions in different image formats.
     """
@@ -272,7 +277,7 @@ class AbstractImageMixin(BaseModel):
     )
 
 
-class ImageRepresentation(BaseModel):
+class ImageRepresentation(ConfiguredBaseModel):
     """
     The viewable or processable represention of an image in a particular image file format.
     This object was created from one or more file refences (usually one) provided by submitters to the BioImage Archive.
@@ -336,7 +341,7 @@ class ImageRepresentation(BaseModel):
     )
 
 
-class RenderedView(BaseModel):
+class RenderedView(ConfiguredBaseModel):
     """
     A particular view of an image, such as as a specific timestamp of a time series, or a view direction of a 3D model.
     """
@@ -353,7 +358,7 @@ class RenderedView(BaseModel):
     )
 
 
-class Channel(BaseModel):
+class Channel(ConfiguredBaseModel):
     """
     An image channel.
     """
@@ -448,7 +453,7 @@ class SpecimenImagingPrepartionProtocol(ProtocolMixin):
     signal_channel_information: Optional[List[SignalChannelInformation]]
 
 
-class SignalChannelInformation(BaseModel):
+class SignalChannelInformation(ConfiguredBaseModel):
     """
     Information about how signals were generated, staining compounds and their targets.
     """
@@ -473,7 +478,7 @@ class SpecimenGrowthProtocol(ProtocolMixin):
     pass
 
 
-class Specimen(BaseModel):
+class Specimen(ConfiguredBaseModel):
     """
     The subject of an image acquisition, and the result of a BioSample being prepared to be imaged.
     """
@@ -492,7 +497,7 @@ class Specimen(BaseModel):
     # )
 
 
-class BioSample(BaseModel):
+class BioSample(ConfiguredBaseModel):
     """
     The biological entity that has undergone preparation (as a Sample) in order to be imaged.
     """
@@ -514,7 +519,7 @@ class BioSample(BaseModel):
     )
 
 
-class Taxon(BaseModel):
+class Taxon(ConfiguredBaseModel):
     """
     The classification of a biological entity.
     """
@@ -586,7 +591,7 @@ class AnnotationMethod(ProtocolMixin):
     )
 
 
-class AnnotationMixin(BaseModel):
+class AnnotationMixin(ConfiguredBaseModel):
     """
     Information providing additional metadata or highlighting parts of an image.
     """

--- a/bia-shared-datamodels/test/utils.py
+++ b/bia-shared-datamodels/test/utils.py
@@ -66,6 +66,11 @@ def get_template_specimen_imaging_preparation_protocol() -> (
                 "signal_channel_information": [
                     get_template_signal_channel_information()
                 ],
+                "version": 1,
+                "model": {
+                "type_name": "SpecimenImagingPrepartionProtocol", 
+                "version": 1
+            }
             }
         )
     )
@@ -78,6 +83,11 @@ def get_template_specimen_growth_protocol() -> bia_data_model.SpecimenGrowthProt
             "uuid": uuid4(),
             "title_id": "Test specimen preparation protocol",
             "protocol_description": "Test description",
+            "version": 1,
+            "model": {
+                "type_name": "SpecimenGrowthProtocol", 
+                "version": 1
+            }
         }
     )
     return specimen_growth_protocol
@@ -101,14 +111,16 @@ def get_template_biosample() -> bia_data_model.BioSample:
             "intrinsic_variable_description": [
                 "Description of internal treatment",
             ],
+            "version": 1,
+            "model": {
+                "type_name": "BioSample", 
+                "version": 1
+            }
         }
     )
     return biosample
 
 
-# Depends on:
-#   bia_data_model.BioSample
-#   bia_data_model.SpecimenImagingPreparationProtocol
 def get_template_specimen() -> bia_data_model.Specimen:
     specimen = bia_data_model.Specimen.model_validate(
         {
@@ -122,12 +134,16 @@ def get_template_specimen() -> bia_data_model.Specimen:
             "growth_protocol_uuid": [
                 get_template_specimen_growth_protocol().uuid,
             ],
+            "version": 1,
+            "model": {
+                "type_name": "Specimen", 
+                "version": 1
+            }
         }
     )
     return specimen
 
 
-# Depends on ExperimentalImagingDataset
 def get_template_annotation_method() -> bia_data_model.AnnotationMethod:
     annotation_method = bia_data_model.AnnotationMethod.model_validate(
         {
@@ -137,16 +153,16 @@ def get_template_annotation_method() -> bia_data_model.AnnotationMethod:
             "annotation_criteria": "Template annotation criteria",
             "annotation_coverage": "Template annotation coverage",
             "method_type": semantic_models.AnnotationType.class_labels,
+            "version": 1,
+            "model": {
+                "type_name": "AnnotationMethod", 
+                "version": 1
+            }
         }
     )
     return annotation_method
 
 
-# Depends on:
-#   bia_data_model.ExperimentalImagingDataset (circular dependency)
-#   bia_data_model.ImageAcquisition
-#   bia_data_model.ImageRepresentation
-#   bia_data_model.Specimen
 def get_template_experimentally_captured_image() -> (
     bia_data_model.ExperimentallyCapturedImage
 ):
@@ -157,14 +173,15 @@ def get_template_experimentally_captured_image() -> (
             "submission_dataset_uuid": get_template_experimental_imaging_dataset().uuid,
             "subject_uuid": get_template_specimen().uuid,
             "attribute": {},
+            "version": 1,
+            "model": {
+                "type_name": "ExperimentallyCapturedImage", 
+                "version": 1
+            }
         }
     )
 
 
-# Depends on:
-#   bia_data_model.ImageAnnotationDataset (circular dependency)
-#   bia_data_model.AnnotationMethod
-#   bia_data_model.ImageRepresentation
 def get_template_derived_image() -> bia_data_model.DerivedImage:
     derived_image = bia_data_model.DerivedImage.model_validate(
         {
@@ -177,13 +194,16 @@ def get_template_derived_image() -> bia_data_model.DerivedImage:
             "transformation_description": "Template transformation description",
             "spatial_information": "Template spatial information",
             "attribute": {},
+            "version": 1,
+            "model": {
+                "type_name": "DerivedImage", 
+                "version": 1
+            }
         }
     )
     return derived_image
 
 
-# Depends on:
-#   bia_data_model.AnnotationMethod
 def get_template_image_annotation_dataset() -> bia_data_model.ImageAnnotationDataset:
     image_annotation_dataset = bia_data_model.ImageAnnotationDataset.model_validate(
         {
@@ -191,6 +211,11 @@ def get_template_image_annotation_dataset() -> bia_data_model.ImageAnnotationDat
             "submitted_in_study_uuid": get_template_study().uuid,
             "title_id": "Template image annotation dataset",
             "example_image_uri": ["https://dummy.url.org"],
+            "version": 1,
+            "model": {
+                "type_name": "ImageAnnotationDataset", 
+                "version": 1
+            }
         }
     )
     return image_annotation_dataset
@@ -207,6 +232,11 @@ def get_template_image_acquisition() -> bia_data_model.ImageAcquisition:
             "fbbi_id": [
                 "Test FBBI ID",
             ],
+            "version": 1,
+            "model": {
+                "type_name": "ImageAcquisition", 
+                "version": 1
+            }
         }
     )
     return image_acquisition
@@ -231,11 +261,6 @@ def get_template_image_correlation_method() -> semantic_models.ImageCorrelationM
     )
 
 
-# Depends on:
-#   bia_data_model.SpecimenPreparationProtocol
-#   bia_data_model.ImageAcquisition
-#   bia_data_model.BioSample
-#   bia_data_model.SpecimenGrowthProtocol
 def get_template_experimental_imaging_dataset() -> (
     bia_data_model.ExperimentalImagingDataset
 ):
@@ -252,15 +277,14 @@ def get_template_experimental_imaging_dataset() -> (
                     get_template_image_correlation_method().model_dump(),
                 ],
                 "example_image_uri": ["https://dummy.url.org"],
+                "version": 1,
+                "model": {"type_name": "ExperimentalImagingDataset", "version": 1},
             }
         )
     )
     return experimental_imaging_dataset
 
 
-# Depends on:
-#   bia_data_model.ImageAnnotationDataset
-#   bia_data_model.ExperimentalImagingDataset (circular)
 def get_template_annotation_file_reference() -> bia_data_model.AnnotationFileReference:
     return bia_data_model.AnnotationFileReference.model_validate(
         {
@@ -277,15 +301,11 @@ def get_template_annotation_file_reference() -> bia_data_model.AnnotationFileRef
             "transformation_description": "Template transformation description",
             "spatial_information": "Template spatial information",
             "creation_process_uuid": [get_template_annotation_method().uuid],
+            "version": 1,
+            "model": {"type_name": "AnnotationFileReference", "version": 1},
         }
     )
 
-
-# Depends on:
-#   bia_data_model.ImageAnnotationDataset
-#   or
-#   bia_data_model.ExperimentalImagingDataset
-#   the latter is tested here.
 def get_template_file_reference() -> bia_data_model.FileReference:
     file_reference = bia_data_model.FileReference.model_validate(
         {
@@ -296,13 +316,13 @@ def get_template_file_reference() -> bia_data_model.FileReference:
             "uri": "https://dummy.uri.co",
             "attribute": {},
             "submission_dataset_uuid": get_template_experimental_imaging_dataset().uuid,
+            "version": 1,
+            "model": {"type_name": "FileReference", "version": 1},
         }
     )
     return file_reference
 
 
-# Depends on:
-#   bia_data_model.FileReference
 def get_template_image_representation() -> bia_data_model.ImageRepresentation:
     return bia_data_model.ImageRepresentation.model_validate(
         {
@@ -328,6 +348,8 @@ def get_template_image_representation() -> bia_data_model.ImageRepresentation:
                 get_template_rendered_view().model_dump(),
             ],
             "attribute": {},
+            "version": 1,
+            "model": {"type_name": "ImageRepresentation", "version": 1},
         }
     )
 
@@ -338,7 +360,7 @@ def get_template_affiliation() -> semantic_models.Affiliation:
             "display_name": "Template Affiliation Organisation",
             "rorid": "None",
             "address": "None",
-            "website": "https://www.none.com",
+            "website": "https://www.none.com"
         }
     )
     return affiliation
@@ -356,7 +378,7 @@ def get_template_contributor() -> semantic_models.Contributor:
             "rorid": "None",
             "address": "None",
             "website": "https://www.none.com",
-            "orcid": "None",
+            "orcid": "None"
         }
     )
     return contributor
@@ -381,6 +403,8 @@ def get_template_study() -> bia_data_model.Study:
                 "Template keyword2",
             ],
             "description": "Template description",
-        }
+            "version": 1,
+            "model": {"type_name": "Study", "version": 1},
+        },
     )
     return study


### PR DESCRIPTION
Fixes tests broken by: https://github.com/BioImage-Archive/bia-integrator/pull/128#pullrequestreview-2208119050

Also moves the configuration that forbids extra fields into the semantic models file to be inherited instead of BaseModel. This stops extra fields from being passed into models that govern 'nested'/'embedded' json objects inside other json objects

Also updates the filter model dictionary function to work with/expect optional fields.