### PR TITLE
Api reverse links

### DIFF
--- a/api/api/app.py
+++ b/api/api/app.py
@@ -26,16 +26,6 @@ app = FastAPI(
 
 app.openapi_version = "3.0.2"
 
-# app.include_router(private.router, prefix="/v2")
-# routes applied in the order they are declared
-
-
-async def test_func(val):
-    pass
-
-
-ObjectReference.validators_for_type[Study] = [test_func]
-
 
 app.include_router(public.make_router(), prefix="/v2")
 app.include_router(private.make_router(), prefix="/v2")

--- a/api/api/app.py
+++ b/api/api/app.py
@@ -1,8 +1,6 @@
 from . import public
 from . import private
 from .models.repository import repository_create, Repository
-from bia_shared_datamodels.bia_data_model import ObjectReference, Study
-
 
 from fastapi import FastAPI
 from typing import AsyncGenerator

--- a/api/api/app.py
+++ b/api/api/app.py
@@ -1,6 +1,7 @@
 from . import public
 from . import private
 from .models.repository import repository_create, Repository
+from bia_shared_datamodels.bia_data_model import ObjectReference, Study
 
 
 from fastapi import FastAPI
@@ -27,5 +28,14 @@ app.openapi_version = "3.0.2"
 
 # app.include_router(private.router, prefix="/v2")
 # routes applied in the order they are declared
+
+
+async def test_func(val):
+    pass
+
+
+ObjectReference.validators_for_type[Study] = [test_func]
+
+
 app.include_router(public.make_router(), prefix="/v2")
 app.include_router(private.make_router(), prefix="/v2")

--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -65,7 +65,9 @@ class Repository:
     def __init__(self) -> None:
         mongo_connstring = os.environ["MONGO_CONNSTRING"]
         self.connection = AsyncIOMotorClient(
-            mongo_connstring, uuidRepresentation="standard", maxPoolSize=10
+            mongo_connstring,
+            uuidRepresentation=UuidRepresentation.STANDARD,
+            maxPoolSize=10,
         )
         self.db = self.connection.get_database(
             DB_NAME,
@@ -161,7 +163,7 @@ class Repository:
         doc = await self._get_doc_raw(uuid=uuid)
 
         if doc is None:
-            raise exceptions.DocumentNotFound("Study does not exist")
+            raise exceptions.DocumentNotFound("Document does not exist")
 
         return doc_type(**doc)
 

--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -7,7 +7,7 @@ import os
 from enum import Enum
 import bia_shared_datamodels.bia_data_model as shared_data_models
 import pymongo
-from typing import Any
+from typing import Type, List, Any
 from .. import exceptions
 import datetime
 
@@ -81,7 +81,11 @@ class Repository:
 
             raise exceptions.InvalidUpdateException(str(e))
 
-    async def get_doc(self, uuid: shared_data_models.UUID, doc_type):
+    async def get_doc(
+        self,
+        uuid: shared_data_models.UUID,
+        doc_type: Type[shared_data_models.BaseModel],
+    ) -> Any:
         doc = await self._get_doc_raw(uuid=uuid)
 
         if doc is None:
@@ -89,7 +93,11 @@ class Repository:
 
         return doc_type(**doc)
 
-    async def get_docs(self, doc_filter: dict, doc_type):
+    async def get_docs(
+        self,
+        doc_filter: dict,
+        doc_type: Type[shared_data_models.BaseModel],
+    ) -> Any:
         if not len(doc_filter.keys()):
             raise Exception("Need at least one filter")
 
@@ -119,13 +127,13 @@ class Repository:
 
         return result == doc
 
-    async def _get_doc_raw(self, **kwargs) -> Any:
+    async def _get_doc_raw(self, **kwargs) -> dict:
         doc = await self.biaint.find_one(kwargs)
         doc.pop("_id")
 
         return doc
 
-    async def _get_docs_raw(self, **kwargs) -> Any:
+    async def _get_docs_raw(self, **kwargs) -> List[dict]:
         docs = []
 
         async for doc in self.biaint.find(kwargs):

--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -66,7 +66,7 @@ class Repository:
         mongo_connstring = os.environ["MONGO_CONNSTRING"]
         self.connection = AsyncIOMotorClient(
             mongo_connstring,
-            uuidRepresentation=UuidRepresentation.STANDARD,
+            uuidRepresentation="standard",
             maxPoolSize=10,
         )
         self.db = self.connection.get_database(

--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -84,7 +84,7 @@ class Repository:
     async def get_doc(
         self,
         uuid: shared_data_models.UUID,
-        doc_type: Type[shared_data_models.BaseModel],
+        doc_type: Type[shared_data_models.DocumentMixin],
     ) -> Any:
         doc = await self._get_doc_raw(uuid=uuid)
 
@@ -96,7 +96,7 @@ class Repository:
     async def get_docs(
         self,
         doc_filter: dict,
-        doc_type: Type[shared_data_models.BaseModel],
+        doc_type: Type[shared_data_models.DocumentMixin],
     ) -> Any:
         if not len(doc_filter.keys()):
             raise Exception("Need at least one filter")

--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -92,7 +92,7 @@ class Repository:
         ) in object_to_check.get_object_reference_fields().items():
             if not getattr(object_to_check, link_attribute_name):
                 """
-                If a field optional and a link to another object,
+                If a field is a link to another object (the for) and optional (doesn't exist as an attribute on the object to validate),
                     then if not set we skip it (because it's optional)
                     else (it's set to some non-None value) we check that the referenced object matches expected type (below)
                 We don't need to check if the field itself is optional because it's typed and Pydantic does it already

--- a/api/api/private.py
+++ b/api/api/private.py
@@ -20,7 +20,7 @@ models_private: List[shared_data_models.DocumentMixin] = [
     shared_data_models.Specimen,
     shared_data_models.ExperimentallyCapturedImage,
     shared_data_models.ImageAcquisition,
-    shared_data_models.SpecimenImagingPrepartionProtocol,
+    shared_data_models.SpecimenImagingPreparationProtocol,
     shared_data_models.SpecimenGrowthProtocol,
     shared_data_models.BioSample,
     shared_data_models.ImageAnnotationDataset,

--- a/api/api/private.py
+++ b/api/api/private.py
@@ -5,13 +5,14 @@ import bia_shared_datamodels.bia_data_model as shared_data_models
 from .models.repository import Repository
 from . import constants
 from fastapi import APIRouter, Depends, status
+from typing import List, Type
 
 router = APIRouter(
     prefix="/private",
     # dependencies=[Depends(get_current_user)], TODO
     tags=[constants.OPENAPI_TAG_PRIVATE],
 )
-models_private = [
+models_private: List[shared_data_models.DocumentMixin] = [
     shared_data_models.Study,
     shared_data_models.FileReference,
     shared_data_models.ImageRepresentation,
@@ -29,7 +30,7 @@ models_private = [
 ]
 
 
-def make_post_item(t):
+def make_post_item(t: Type[shared_data_models.DocumentMixin]):
     async def post_item(doc: t, db: Repository = Depends()) -> None:
         await db.persist_doc(doc)
 

--- a/api/api/public.py
+++ b/api/api/public.py
@@ -20,7 +20,7 @@ models_public: List[shared_data_models.DocumentMixin] = [
     shared_data_models.Specimen,
     shared_data_models.ExperimentallyCapturedImage,
     shared_data_models.ImageAcquisition,
-    shared_data_models.SpecimenImagingPrepartionProtocol,
+    shared_data_models.SpecimenImagingPreparationProtocol,
     shared_data_models.SpecimenGrowthProtocol,
     shared_data_models.BioSample,
     shared_data_models.ImageAnnotationDataset,
@@ -62,8 +62,12 @@ def make_reverse_links(router: APIRouter) -> APIRouter:
     for model in models_public:
         uuid_fields = model.fields_by_type(UUID)
         for uuid_field_name, uuid_field_type in uuid_fields.items():
-            if len(uuid_field_type.metadata):
-                parent_type = uuid_field_type.metadata[0]  # convention
+            if (
+                len(uuid_field_type.metadata)
+                and type(uuid_field_type.metadata[0])
+                is shared_data_models.ObjectReference
+            ):
+                parent_type = uuid_field_type.metadata[0].link_dest_type  # convention
 
                 # List validators (e.g. MinLength) are also set in the type.metadata list
                 #   -> only generate backlinks for types that have metadata that is also one of the exposed types

--- a/api/api/public.py
+++ b/api/api/public.py
@@ -5,7 +5,6 @@ from pydantic.alias_generators import to_snake
 import bia_shared_datamodels.bia_data_model as shared_data_models
 from .models.repository import Repository
 from . import constants
-from uuid import UUID
 from typing import List, Type
 
 router = APIRouter(

--- a/api/api/public.py
+++ b/api/api/public.py
@@ -6,14 +6,13 @@ import bia_shared_datamodels.bia_data_model as shared_data_models
 from .models.repository import Repository
 from . import constants
 from uuid import UUID
-from typing import List
+from typing import List, Type
 
 router = APIRouter(
     prefix="",
-    # dependencies=[Depends(get_current_user)], TODO
     tags=[constants.OPENAPI_TAG_PUBLIC],
 )
-models_public = [
+models_public: List[shared_data_models.DocumentMixin] = [
     shared_data_models.Study,
     shared_data_models.FileReference,
     shared_data_models.ImageRepresentation,
@@ -31,7 +30,7 @@ models_public = [
 ]
 
 
-def make_get_item(t):
+def make_get_item(t: Type[shared_data_models.DocumentMixin]):
     # variables are function-scoped => add wrapper to bind each value of t
     # https://eev.ee/blog/2011/04/24/gotcha-python-scoping-closures/
 
@@ -43,7 +42,9 @@ def make_get_item(t):
 
 
 def make_reverse_links(router: APIRouter) -> APIRouter:
-    def make_reverse_link_handler(source_attribute: str, source_type):
+    def make_reverse_link_handler(
+        source_attribute: str, source_type: Type[shared_data_models.DocumentMixin]
+    ):
         async def get_descendents(
             uuid: shared_data_models.UUID, db: Repository = Depends()
         ) -> List[source_type]:

--- a/api/api/tests/conftest.py
+++ b/api/api/tests/conftest.py
@@ -1,0 +1,139 @@
+from bia_shared_datamodels import mock_objects, bia_data_model
+import uuid as uuid_lib
+from fastapi.testclient import TestClient
+import pytest
+import json
+import jsonpickle
+
+TEST_SERVER_BASE_URL = "http://localhost.com/v2"
+
+
+def mock_object_jsonsafe(fn_mock_generator, passthrough={}):
+    """
+    makes non-json serialisable types (UUID, URL, datetime.date) into strings
+    """
+
+    obj = fn_mock_generator(**passthrough)
+    str_obj = json.dumps(obj, default=lambda v: str(v))
+    serialisable_obj = json.loads(str_obj)
+
+    return serialisable_obj
+
+
+def get_uuid() -> str:
+    # @TODO: make this constant and require mongo to always be clean?
+    generated = uuid_lib.uuid4()
+
+    return str(generated)
+
+
+def get_client(**kwargs) -> TestClient:
+    from fastapi.responses import JSONResponse
+    from fastapi import Request
+    import traceback
+
+    from ..app import app
+
+    @app.exception_handler(Exception)
+    def generic_exception_handler(request: Request, exc: Exception):
+        return JSONResponse(
+            status_code=500,
+            content=traceback.format_exception(exc, value=exc, tb=exc.__traceback__),
+        )
+
+    return TestClient(app, base_url=TEST_SERVER_BASE_URL, **kwargs)
+
+
+@pytest.fixture(scope="module")
+def api_client() -> TestClient:
+    client = get_client(raise_server_exceptions=False)
+    # authenticate_client(client)  # @TODO: DELETEME
+
+    return client
+
+
+@pytest.fixture(scope="function")
+def existing_study(api_client: TestClient) -> dict:
+    study = mock_object_jsonsafe(
+        mock_objects.get_study_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+
+    rsp = api_client.post("private/study", json=study)
+    assert rsp.status_code == 201, rsp.json()
+
+    return study
+
+
+@pytest.fixture(scope="function")
+def existing_experimental_imaging_dataset(
+    existing_study, api_client: TestClient
+) -> dict:
+    dataset = mock_object_jsonsafe(
+        mock_objects.get_experimental_imaging_dataset_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+    dataset["submitted_in_study_uuid"] = existing_study["uuid"]
+
+    rsp = api_client.post("private/experimental_imaging_dataset", json=dataset)
+    assert rsp.status_code == 201, rsp.json()
+
+    return dataset
+
+
+@pytest.fixture(scope="function")
+def existing_specimen_imaging_preparation_protocol(api_client: TestClient):
+    specimen_imaging_preparation_protocol = mock_object_jsonsafe(
+        mock_objects.get_specimen_imaging_preparation_protocol_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+
+    rsp = api_client.post(
+        "private/specimen_imaging_preparation_protocol",
+        json=specimen_imaging_preparation_protocol,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return specimen_imaging_preparation_protocol
+
+
+@pytest.fixture(scope="function")
+def existing_biosample(api_client: TestClient):
+    biosample = mock_object_jsonsafe(
+        mock_objects.get_biosample_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+
+    rsp = api_client.post(
+        "private/bio_sample",
+        json=biosample,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return biosample
+
+
+@pytest.fixture(scope="function")
+def existing_specimen(
+    api_client: TestClient,
+    existing_specimen_imaging_preparation_protocol,
+    existing_biosample,
+):
+    specimen = mock_object_jsonsafe(
+        mock_objects.get_specimen_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+    specimen |= {
+        "imaging_preparation_protocol_uuid": [
+            existing_specimen_imaging_preparation_protocol["uuid"]
+        ],
+        "sample_of_uuid": [existing_biosample["uuid"]],
+    }
+
+    rsp = api_client.post(
+        "private/specimen",
+        json=specimen,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return specimen

--- a/api/api/tests/conftest.py
+++ b/api/api/tests/conftest.py
@@ -3,7 +3,6 @@ import uuid as uuid_lib
 from fastapi.testclient import TestClient
 import pytest
 import json
-import jsonpickle
 
 TEST_SERVER_BASE_URL = "http://localhost.com/v2"
 

--- a/api/api/tests/conftest.py
+++ b/api/api/tests/conftest.py
@@ -114,10 +114,29 @@ def existing_biosample(api_client: TestClient):
 
 
 @pytest.fixture(scope="function")
+def existing_specimen_growth_protocol(
+    api_client: TestClient,
+):
+    specimen_growth_protocol = mock_object_jsonsafe(
+        mock_objects.get_specimen_growth_protocol_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+
+    rsp = api_client.post(
+        "private/specimen_growth_protocol",
+        json=specimen_growth_protocol,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return specimen_growth_protocol
+
+
+@pytest.fixture(scope="function")
 def existing_specimen(
     api_client: TestClient,
     existing_specimen_imaging_preparation_protocol,
     existing_biosample,
+    existing_specimen_growth_protocol,
 ):
     specimen = mock_object_jsonsafe(
         mock_objects.get_specimen_dict,
@@ -128,6 +147,7 @@ def existing_specimen(
             existing_specimen_imaging_preparation_protocol["uuid"]
         ],
         "sample_of_uuid": [existing_biosample["uuid"]],
+        "growth_protocol_uuid": [existing_specimen_growth_protocol["uuid"]],
     }
 
     rsp = api_client.post(
@@ -137,3 +157,92 @@ def existing_specimen(
     assert rsp.status_code == 201, rsp.json()
 
     return specimen
+
+
+@pytest.fixture(scope="function")
+def existing_file_reference(
+    api_client: TestClient, existing_experimental_imaging_dataset: dict
+):
+    file_reference = mock_object_jsonsafe(
+        mock_objects.get_file_reference_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+
+    file_reference |= {
+        "submission_dataset_uuid": existing_experimental_imaging_dataset["uuid"]
+    }
+
+    rsp = api_client.post(
+        "private/file_reference",
+        json=file_reference,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return file_reference
+
+
+@pytest.fixture(scope="function")
+def existing_image_acquisition(api_client: TestClient):
+    image_acquisition = mock_object_jsonsafe(
+        mock_objects.get_image_acquisition_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+
+    rsp = api_client.post(
+        "private/image_acquisition",
+        json=image_acquisition,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return image_acquisition
+
+
+@pytest.fixture(scope="function")
+def existing_experimentally_captured_image(
+    api_client: TestClient,
+    existing_specimen: dict,
+    existing_experimental_imaging_dataset: dict,
+    existing_image_acquisition: dict,
+):
+    experimentally_captured_image = mock_object_jsonsafe(
+        mock_objects.get_experimentally_captured_image_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+
+    experimentally_captured_image |= {
+        "subject_uuid": existing_specimen["uuid"],
+        "submission_dataset_uuid": existing_experimental_imaging_dataset["uuid"],
+        "acquisition_process_uuid": [existing_image_acquisition["uuid"]],
+    }
+
+    rsp = api_client.post(
+        "private/experimentally_captured_image",
+        json=experimentally_captured_image,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return experimentally_captured_image
+
+
+@pytest.fixture(scope="function")
+def existing_image_representation(
+    api_client: TestClient,
+    existing_experimentally_captured_image: dict,
+    existing_file_reference: dict,
+):
+    image_representation = mock_object_jsonsafe(
+        mock_objects.get_image_representation_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+    image_representation |= {
+        "representation_of_uuid": existing_experimentally_captured_image["uuid"],
+        "original_file_reference_uuid": [existing_file_reference["uuid"]],
+    }
+
+    rsp = api_client.post(
+        "private/image_representation",
+        json=image_representation,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return image_representation

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -111,3 +111,7 @@ def test_duplicate_uuid_fails(
 
 def test_object_update_version_bumped_passes():
     assert 0, "TODO: indices then add this"
+
+
+def test_object_update_version_enforced():
+    assert 0, "TODO: longer todo, check version works as expected"

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -87,3 +87,50 @@ def test_create_study(api_client: TestClient):
     rsp = api_client.get(f"study/{study['uuid']}")
     assert rsp.status_code == 200, rsp.text
     assert rsp.json() == study
+
+
+def test_get_study_datasets(api_client: TestClient):
+    study_uuid = get_uuid()
+    study = {
+        "uuid": study_uuid,
+        "version": 0,
+        "release_date": "2023-01-31",
+        "accession_id": study_uuid,
+        "title": "Test BIA study",
+        "description": "description",
+        "licence": "CC_BY_4.0",
+        "see_also": [],
+        "model": {"type_name": "Study", "version": 1},
+        "acknowledgement": "test",
+        "funding_statement": "test",
+        "grant": [],
+        "keyword": [],
+        "related_publication": [],
+        "author": [
+            {
+                "address": None,
+                "display_name": "Test name",
+                "contact_email": "test_email@test.com",
+                "orcid": None,
+                "role": None,
+                "rorid": None,
+                "website": None,
+                "affiliation": [
+                    {
+                        "display_name": "Test",
+                        "address": None,
+                        "rorid": None,
+                        "website": None,
+                    }
+                ],
+            }
+        ],
+        "attribute": {},
+    }
+
+    rsp = api_client.post("private/study", json=study)
+    assert rsp.status_code == 201, rsp.json()
+
+    rsp = api_client.get(f"study/{study_uuid}/experimental_imaging_dataset")
+    assert rsp.status_code == 200, rsp.json()
+    assert rsp.json() == []

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -1,136 +1,28 @@
 """
 WIP minimal tests
+tl;dr avoid importing get_uuid to make sure we reuse mocks
 """
 
 from fastapi.testclient import TestClient
-import pytest
-import uuid as uuid_lib
 
 
-TEST_SERVER_BASE_URL = "http://localhost.com/v2"
-
-
-def get_uuid() -> str:
-    # @TODO: make this constant and require mongo to always be clean?
-    generated = uuid_lib.uuid4()
-
-    return str(generated)
-
-
-def get_client(**kwargs) -> TestClient:
-    from fastapi.responses import JSONResponse
-    from fastapi import Request
-    import traceback
-
-    from ..app import app
-
-    @app.exception_handler(Exception)
-    def generic_exception_handler(request: Request, exc: Exception):
-        return JSONResponse(
-            status_code=500,
-            content=traceback.format_exception(exc, value=exc, tb=exc.__traceback__),
-        )
-
-    return TestClient(app, base_url=TEST_SERVER_BASE_URL, **kwargs)
-
-
-@pytest.fixture(scope="module")
-def api_client() -> TestClient:
-    client = get_client(raise_server_exceptions=False)
-    # authenticate_client(client)  # @TODO: DELETEME
-
-    return client
-
-
-def test_create_study(api_client: TestClient):
-    study_uuid = get_uuid()
-    study = {
-        "uuid": study_uuid,
-        "version": 0,
-        "release_date": "2023-01-31",
-        "accession_id": study_uuid,
-        "title": "Test BIA study",
-        "description": "description",
-        "licence": "CC_BY_4.0",
-        "see_also": [],
-        "model": {"type_name": "Study", "version": 1},
-        "acknowledgement": "test",
-        "funding_statement": "test",
-        "grant": [],
-        "keyword": [],
-        "related_publication": [],
-        "author": [
-            {
-                "address": None,
-                "display_name": "Test name",
-                "contact_email": "test_email@test.com",
-                "orcid": None,
-                "role": None,
-                "rorid": None,
-                "website": None,
-                "affiliation": [
-                    {
-                        "display_name": "Test",
-                        "address": None,
-                        "rorid": None,
-                        "website": None,
-                    }
-                ],
-            }
-        ],
-        "attribute": {},
-    }
-
-    rsp = api_client.post("private/study", json=study)
-    assert rsp.status_code == 201, rsp.json()
-
-    rsp = api_client.get(f"study/{study['uuid']}")
+def test_get_created_study(api_client: TestClient, existing_study):
+    rsp = api_client.get(f"study/{existing_study['uuid']}")
     assert rsp.status_code == 200, rsp.text
-    assert rsp.json() == study
+    assert rsp.json() == existing_study
 
 
-def test_get_study_datasets(api_client: TestClient):
-    study_uuid = get_uuid()
-    study = {
-        "uuid": study_uuid,
-        "version": 0,
-        "release_date": "2023-01-31",
-        "accession_id": study_uuid,
-        "title": "Test BIA study",
-        "description": "description",
-        "licence": "CC_BY_4.0",
-        "see_also": [],
-        "model": {"type_name": "Study", "version": 1},
-        "acknowledgement": "test",
-        "funding_statement": "test",
-        "grant": [],
-        "keyword": [],
-        "related_publication": [],
-        "author": [
-            {
-                "address": None,
-                "display_name": "Test name",
-                "contact_email": "test_email@test.com",
-                "orcid": None,
-                "role": None,
-                "rorid": None,
-                "website": None,
-                "affiliation": [
-                    {
-                        "display_name": "Test",
-                        "address": None,
-                        "rorid": None,
-                        "website": None,
-                    }
-                ],
-            }
-        ],
-        "attribute": {},
-    }
-
-    rsp = api_client.post("private/study", json=study)
-    assert rsp.status_code == 201, rsp.json()
-
-    rsp = api_client.get(f"study/{study_uuid}/experimental_imaging_dataset")
+def test_get_study_datasets(
+    api_client: TestClient, existing_study, existing_experimental_imaging_dataset
+):
+    rsp = api_client.get(f"study/{existing_study['uuid']}/experimental_imaging_dataset")
     assert rsp.status_code == 200, rsp.json()
-    assert rsp.json() == []
+    assert rsp.json() == [existing_experimental_imaging_dataset]
+
+
+def test_get_biosample_specimens(
+    api_client: TestClient, existing_biosample, existing_specimen
+):
+    rsp = api_client.get(f"bio_sample/{existing_biosample['uuid']}/specimen")
+    assert rsp.status_code == 200, rsp.json()
+    assert rsp.json() == [existing_specimen]

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -109,6 +109,31 @@ def test_duplicate_uuid_fails(
     assert rsp.status_code == 404, rsp.json()
 
 
+def test_optional_link_unset_passes(
+    api_client: TestClient, existing_image_representation: dict
+):
+    image_representation = existing_image_representation.copy()
+
+    image_representation["uuid"] = get_uuid()
+    del image_representation["original_file_reference_uuid"]
+
+    rsp = api_client.post(
+        "private/image_representation",
+        json=image_representation,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+
+def test_optional_reverse_link(
+    api_client: TestClient, existing_image_representation: dict
+):
+    rsp = api_client.get(
+        f"file_reference/{existing_image_representation['original_file_reference_uuid'][0]}/image_representation"
+    )
+    assert rsp.status_code == 200, rsp.json()
+    assert rsp.json() == [existing_image_representation]
+
+
 def test_object_update_version_bumped_passes():
     assert 0, "TODO: indices then add this"
 

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -4,6 +4,7 @@ tl;dr avoid importing get_uuid to make sure we reuse mocks
 """
 
 from fastapi.testclient import TestClient
+from .conftest import get_uuid
 
 
 def test_get_created_study(api_client: TestClient, existing_study):
@@ -26,3 +27,87 @@ def test_get_biosample_specimens(
     rsp = api_client.get(f"bio_sample/{existing_biosample['uuid']}/specimen")
     assert rsp.status_code == 200, rsp.json()
     assert rsp.json() == [existing_specimen]
+
+
+def test_create_object_missing_dependency_fails(
+    api_client: TestClient, existing_specimen: dict
+):
+    """
+    overwrite uuid and sample uuid on an existing specimen to get a new specimen with a missing sample uuid
+    """
+    specimen = existing_specimen.copy()
+    specimen["uuid"] = get_uuid()
+    specimen["sample_of_uuid"] = [get_uuid()]
+
+    rsp = api_client.post(
+        "private/specimen",
+        json=specimen,
+    )
+    assert rsp.status_code == 404, rsp.json()
+
+    # Error should mention the uuid referenced in sample_of_uuid that doesn't exist
+    rsp_body = rsp.json()
+    assert specimen["sample_of_uuid"][0] in rsp_body["detail"]
+
+
+def test_create_object_mistyped_dependency_fails(
+    api_client: TestClient, existing_specimen: dict, existing_study: dict
+):
+    specimen = existing_specimen.copy()
+    specimen["uuid"] = get_uuid()
+    specimen["imaging_preparation_protocol_uuid"] = [existing_study["uuid"]]
+
+    rsp = api_client.post(
+        "private/specimen",
+        json=specimen,
+    )
+    assert rsp.status_code == 404, rsp.json()
+
+    # Error message should mention the referenced uuid that doesn't exist
+    rsp_body = rsp.json()
+    assert specimen["imaging_preparation_protocol_uuid"][0] in rsp_body["detail"]
+
+
+def test_create_object_duplicate_dependency_fails(
+    api_client: TestClient, existing_specimen: dict
+):
+    """
+    accidental feature of the dependency check implementation
+       if a list of referenced objects contains duplicates (presumably there by accident), object creation should fail
+    except the error is "Not found" instead of something to do with duplicates
+    """
+
+    specimen = existing_specimen.copy()
+    specimen["uuid"] = get_uuid()
+    specimen["sample_of_uuid"] = specimen["sample_of_uuid"] + specimen["sample_of_uuid"]
+
+    rsp = api_client.post(
+        "private/specimen",
+        json=specimen,
+    )
+    assert rsp.status_code == 404, rsp.json()
+
+    # Error message should mention the referenced uuid that doesn't exist
+    rsp_body = rsp.json()
+    assert specimen["sample_of_uuid"][0] in rsp_body["detail"]
+
+
+def test_duplicate_uuid_fails(
+    api_client: TestClient, existing_specimen: dict, existing_study: dict
+):
+    """
+    ! Should fail (maybe with a different status code)
+    Needs indices
+    """
+    specimen = existing_specimen.copy()
+    specimen["uuid"] = existing_study["uuid"]
+
+    rsp = api_client.post(
+        "private/specimen",
+        json=specimen,
+    )
+    assert rsp.status_code == 404, rsp.json()
+
+
+def test_object_update_version_bumped_passes():
+    assert 0, "TODO: indices then add this"

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -92,21 +92,22 @@ def test_create_object_duplicate_dependency_fails(
     assert specimen["sample_of_uuid"][0] in rsp_body["detail"]
 
 
-def test_duplicate_uuid_fails(
-    api_client: TestClient, existing_specimen: dict, existing_study: dict
-):
-    """
-    ! Should fail (maybe with a different status code)
-    Needs indices
-    """
-    specimen = existing_specimen.copy()
-    specimen["uuid"] = existing_study["uuid"]
+#   TODO - when we add indices
+# def test_duplicate_uuid_fails(
+#    api_client: TestClient, existing_specimen: dict, existing_study: dict
+# ):
+#    """
+#    ! Should fail (maybe with a different status code)
+#    Needs indices
+#    """
+#    specimen = existing_specimen.copy()
+#    specimen["uuid"] = existing_study["uuid"]
 
-    rsp = api_client.post(
-        "private/specimen",
-        json=specimen,
-    )
-    assert rsp.status_code == 404, rsp.json()
+#    rsp = api_client.post(
+#        "private/specimen",
+#        json=specimen,
+#    )
+#    assert rsp.status_code == 404, rsp.json()
 
 
 def test_optional_link_unset_passes(
@@ -134,9 +135,11 @@ def test_optional_reverse_link(
     assert rsp.json() == [existing_image_representation]
 
 
-def test_object_update_version_bumped_passes():
-    assert 0, "TODO: indices then add this"
+#   TODO - When we add indices
+# def test_object_update_version_bumped_passes():
+#    assert 0, "TODO: indices then add this"
 
 
-def test_object_update_version_enforced():
-    assert 0, "TODO: longer todo, check version works as expected"
+#   TODO - When we add indices
+# def test_object_update_version_enforced():
+#    assert 0, "TODO: longer todo, check version works as expected"

--- a/bia-export/bia_export/website_conversion.py
+++ b/bia-export/bia_export/website_conversion.py
@@ -7,7 +7,7 @@ from .website_models import (
     ImageAcquisition,
     BioSample,
     SpecimenGrowthProtocol,
-    SpecimenImagingPrepartionProtocol,
+    SpecimenImagingPreparationProtocol,
 )
 from glob import glob
 from typing import List, Type
@@ -103,10 +103,10 @@ def create_experimental_imaging_datasets(
                 "bia_type": bia_data_model.BioSample,
                 "previously_displayed": set(),
             },
-            SpecimenImagingPrepartionProtocol: {
+            SpecimenImagingPreparationProtocol: {
                 "source_directory": "specimen_imaging_preparation_protocols",
                 "association_field": "specimen",
-                "bia_type": bia_data_model.SpecimenImagingPrepartionProtocol,
+                "bia_type": bia_data_model.SpecimenImagingPreparationProtocol,
                 "previously_displayed": set(),
             },
             SpecimenGrowthProtocol: {
@@ -165,7 +165,7 @@ def create_experimental_imaging_datasets(
             eid_dict["specimen_imaging_preparation_protocol"] = process_details_section(
                 root_directory,
                 accession_id,
-                detail_map[SpecimenImagingPrepartionProtocol],
+                detail_map[SpecimenImagingPreparationProtocol],
                 association_by_type["specimen"],
             )
             eid_dict["specimen_growth_protocol"] = process_details_section(

--- a/bia-export/bia_export/website_models.py
+++ b/bia-export/bia_export/website_models.py
@@ -15,7 +15,7 @@ class ExperimentalImagingDataset(bia_data_model.ExperimentalImagingDataset):
     acquisition_process: list[ImageAcquisition] = Field(
         description="""Processes involved in the creation of the images and files in this dataset."""
     )
-    specimen_imaging_preparation_protocol: list[SpecimenImagingPrepartionProtocol] = (
+    specimen_imaging_preparation_protocol: list[SpecimenImagingPreparationProtocol] = (
         Field(
             description="""Processes involved in the preprapartion of the samples for imaged."""
         )
@@ -45,7 +45,7 @@ class SpecimenGrowthProtocol(bia_data_model.SpecimenGrowthProtocol, DetailSectio
     pass
 
 
-class SpecimenImagingPrepartionProtocol(
-    bia_data_model.SpecimenImagingPrepartionProtocol, DetailSection
+class SpecimenImagingPreparationProtocol(
+    bia_data_model.SpecimenImagingPreparationProtocol, DetailSection
 ):
     pass

--- a/bia-export/test/output_data/bia_export.json
+++ b/bia-export/test/output_data/bia_export.json
@@ -134,7 +134,7 @@
                     "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
                     "version": 1,
                     "model": {
-                        "type_name": "SpecimenImagingPrepartionProtocol",
+                        "type_name": "SpecimenImagingPreparationProtocol",
                         "version": 1
                     },
                     "protocol_description": "Test sample preparation protocol 1",

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
@@ -19,13 +19,13 @@ logging.basicConfig(level=logging.INFO)
 
 def get_specimen_imaging_preparation_protocol(
     submission: Submission, persist_artefacts=False
-) -> List[bia_data_model.SpecimenImagingPrepartionProtocol]:
+) -> List[bia_data_model.SpecimenImagingPreparationProtocol]:
     specimen_preparation_protocol_model_dicts = (
         extract_specimen_preparation_protocol_dicts(submission)
     )
     specimen_preparation_protocols = dicts_to_api_models(
         specimen_preparation_protocol_model_dicts,
-        bia_data_model.SpecimenImagingPrepartionProtocol,
+        bia_data_model.SpecimenImagingPreparationProtocol,
     )
 
     if persist_artefacts and specimen_preparation_protocols:
@@ -62,7 +62,7 @@ def extract_specimen_preparation_protocol_dicts(
         model_dict["uuid"] = generate_specimen_imaging_preparation_uuid(model_dict)
         model_dict["version"] = 1
         model_dict = filter_model_dictionary(
-            model_dict, bia_data_model.SpecimenImagingPrepartionProtocol
+            model_dict, bia_data_model.SpecimenImagingPreparationProtocol
         )
 
         model_dicts.append(model_dict)

--- a/bia-ingest-shared-models/test/utils.py
+++ b/bia-ingest-shared-models/test/utils.py
@@ -91,7 +91,7 @@ def get_test_specimen_growth_protocol() -> List[bia_data_model.SpecimenGrowthPro
 
 
 def get_test_specimen_imaging_preparation_protocol() -> (
-    List[bia_data_model.SpecimenImagingPrepartionProtocol]
+    List[bia_data_model.SpecimenImagingPreparationProtocol]
 ):
     # For UUID
     attributes_to_consider = [
@@ -123,10 +123,10 @@ def get_test_specimen_imaging_preparation_protocol() -> (
     for protocol_dict in protocol_info:
         protocol_dict["uuid"] = dict_to_uuid(protocol_dict, attributes_to_consider)
         protocol_dict = filter_model_dictionary(
-            protocol_dict, bia_data_model.SpecimenImagingPrepartionProtocol
+            protocol_dict, bia_data_model.SpecimenImagingPreparationProtocol
         )
         protocol.append(
-            bia_data_model.SpecimenImagingPrepartionProtocol.model_validate(
+            bia_data_model.SpecimenImagingPreparationProtocol.model_validate(
                 protocol_dict
             )
         )

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -220,7 +220,7 @@ class ImageRepresentation(
     # We may want to store the FileReference -> Image(Represenation) rather than in the original_file_reference_uuid
     original_file_reference_uuid: Annotated[
         Optional[List[UUID]], ObjectReference(FileReference)
-    ] = Field(default_factory=lambda : [])
+    ] = Field(default_factory=lambda: [])
     representation_of_uuid: UUID = Field()  # @TODO: Branching links
 
     model_config = ConfigDict(model_version_latest=1)

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -65,7 +65,7 @@ class ObjectReference:
         @TODO: Tidy if we're going to keep this.
         !! How do we avoid memory leaks if fn_validator local but can't get deleted because it has a reference here?
         """
-        if cls._validators_for_type.get(type_to_validate):
+        if cls._validators_by_type.get(type_to_validate):
             """
             Singleton-type pattern (static attribute as a container of hooks) for the validators collection.
             Can't have a container object because all types are declared at startup (so no point in execution where we can create it and pass it in before models are declared).
@@ -74,7 +74,7 @@ class ObjectReference:
             """
             raise Exception("Overwriting validators not supported.")
 
-        cls._validators_for_type[type_to_validate] = fn_validator
+        cls._validators_by_type[type_to_validate] = fn_validator
 
 
 class ModelMetadata(BaseModel):

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -78,7 +78,14 @@ class DocumentMixin(BaseModel):
         fields_filtered = {}
 
         for field_name, field_info in cls.model_fields.items():
-            if field_info.annotation is field_type:
+            # conditions split for clarity
+            field_type_exact = field_info.annotation is field_type
+            field_type_container_list = (
+                hasattr(field_info.annotation, "__origin__")
+                and field_info.annotation.__origin__ is list
+                and field_info.annotation.__args__[0] is field_type
+            )
+            if field_type_exact or field_type_container_list:
                 fields_filtered[field_name] = field_info
 
         return fields_filtered
@@ -131,7 +138,7 @@ class ExperimentalImagingDataset(
 
 class Specimen(semantic_models.Specimen, DocumentMixin):
     imaging_preparation_protocol_uuid: List[UUID] = Field(min_length=1)
-    sample_of_uuid: List[UUID] = Field(min_length=1)
+    sample_of_uuid: Annotated[List[UUID], BioSample] = Field(min_length=1)
     growth_protocol_uuid: List[UUID] = Field()
 
     model_config = ConfigDict(model_version_latest=1)

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -274,7 +274,7 @@ class ImageAcquisition(
 
 
 class SpecimenImagingPreparationProtocol(
-    semantic_models.SpecimenImagingPrepartionProtocol,
+    semantic_models.SpecimenImagingPreparationProtocol,
     DocumentMixin,
     UserIdentifiedObject,
 ):

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from . import semantic_models, exceptions
 from pydantic import BaseModel, Field, ConfigDict
-from typing import List, Optional
+from pydantic.fields import FieldInfo
+from typing import List, Optional, Any, Dict
 from uuid import UUID
-from enum import Enum
-from typing_extensions import Annotated, get_args, get_origin
+from typing_extensions import Annotated
 
 # from pydantic.functional_validators import WrapValidator
 # from pydantic_core.core_schema import ValidationInfo
@@ -57,7 +57,7 @@ class DocumentMixin(BaseModel):
         super().__init__(*args, **data)
 
     @classmethod
-    def get_model_metadata(cls):
+    def get_model_metadata(cls) -> ModelMetadata:
         model_version_spec = cls.model_config.get("model_version_latest")
         if model_version_spec is None:
             raise exceptions.ModelDefinitionInvalid(
@@ -70,11 +70,15 @@ class DocumentMixin(BaseModel):
         )
 
     @classmethod
-    def fields_by_type(cls, type_name):
+    def fields_by_type(cls, field_type: Any) -> Dict[str, FieldInfo]:
+        """
+        @param field_type is the _actual class_ (not class name as a string) to search for
+            typed as any because it can be a descendent of DocumentMixin or UUID
+        """
         fields_filtered = {}
 
         for field_name, field_info in cls.model_fields.items():
-            if field_info.annotation is type_name:
+            if field_info.annotation is field_type:
                 fields_filtered[field_name] = field_info
 
         return fields_filtered

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -189,7 +189,7 @@ class FileReference(
     semantic_models.FileReference,
     DocumentMixin,
 ):
-    submission_dataset_uuid: UUID = Field()
+    submission_dataset_uuid: UUID = Field()  # @TODO: Branching links
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -199,8 +199,10 @@ class ImageRepresentation(
     DocumentMixin,
 ):
     # We may want to store the FileReference -> Image(Represenation) rather than in the original_file_reference_uuid
-    original_file_reference_uuid: Optional[List[UUID]] = Field()
-    representation_of_uuid: UUID = Field()
+    original_file_reference_uuid: Annotated[Optional[List[UUID]], FileReference] = (
+        Field()
+    )
+    representation_of_uuid: UUID = Field()  # @TODO: Branching links
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -222,7 +224,7 @@ class Specimen(semantic_models.Specimen, DocumentMixin):
     sample_of_uuid: Annotated[List[UUID], ObjectReference(BioSample)] = Field(
         min_length=1
     )
-    growth_protocol_uuid: List[UUID] = Field()
+    growth_protocol_uuid: Annotated[List[UUID], SpecimenGrowthProtocol] = Field()
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -231,9 +233,9 @@ class ExperimentallyCapturedImage(
     semantic_models.ExperimentallyCapturedImage,
     DocumentMixin,
 ):
-    acquisition_process_uuid: List[UUID] = Field()
-    submission_dataset_uuid: UUID = Field()
-    subject_uuid: UUID = Field()
+    acquisition_process_uuid: Annotated[List[UUID], ImageAcquisition] = Field()
+    submission_dataset_uuid: Annotated[UUID, ExperimentalImagingDataset] = Field()
+    subject_uuid: Annotated[UUID, Specimen] = Field()
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -275,7 +277,7 @@ class ImageAnnotationDataset(
     DocumentMixin,
     UserIdentifiedObject,
 ):
-    submitted_in_study_uuid: UUID = Field()
+    submitted_in_study_uuid: Annotated[UUID, Study] = Field()
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -284,9 +286,9 @@ class AnnotationFileReference(
     semantic_models.AnnotationFileReference,
     DocumentMixin,
 ):
-    submission_dataset_uuid: UUID = Field()
-    source_image_uuid: List[UUID] = Field()
-    creation_process_uuid: List[UUID] = Field()
+    submission_dataset_uuid: UUID = Field()  # @TODO: Branching links
+    source_image_uuid: List[UUID] = Field()  # @TODO: Branching links
+    creation_process_uuid: Annotated[List[UUID], AnnotationMethod] = Field()
 
     model_config = ConfigDict(model_version_latest=1)
 
@@ -295,9 +297,9 @@ class DerivedImage(
     semantic_models.DerivedImage,
     DocumentMixin,
 ):
-    source_image_uuid: List[UUID] = Field()
-    submission_dataset_uuid: UUID = Field()
-    creation_process_uuid: List[UUID] = Field()
+    source_image_uuid: List[UUID] = Field()  # @TODO: Branching links
+    submission_dataset_uuid: Annotated[UUID, ImageAnnotationDataset] = Field()
+    creation_process_uuid: Annotated[List[UUID], AnnotationMethod] = Field()
 
     model_config = ConfigDict(model_version_latest=1)
 

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -22,24 +22,24 @@ class ObjectReference:
     def __init__(self, link_dest_type):
         self.link_dest_type = link_dest_type
 
-    @classmethod
-    def generic_validator(cls, val, info: core_schema.ValidationInfo) -> UUID:
-        return val
-        # if ObjectReference.validators_for_type.get(link_dest_type, None):
-        #    return ObjectReference.validators_for_type[link_dest_type](val)
-        # else:
-        #    return val
+    async def generic_validator(self, val, info: core_schema.ValidationInfo) -> UUID:
+        for validator in ObjectReference.validators_for_type.get(
+            self.link_dest_type, []
+        ):
+            validator(val)
 
-    @classmethod
+        return val
+
+    # @classmethod
     def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: GetCoreSchemaHandler
+        self, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
 
         return core_schema.chain_schema(
             [
                 handler.generate_schema(source_type),
                 core_schema.with_info_plain_validator_function(
-                    function=cls.generic_validator,
+                    function=self.generic_validator,
                 ),
             ]
         )

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -238,7 +238,9 @@ def get_image_acquisition_dict(completeness=Completeness.COMPLETE) -> dict:
             "fbbi_id": [
                 "Test FBBI ID",
             ],
-            "imaging_method_name": ["Template imaging method name",],
+            "imaging_method_name": [
+                "Template imaging method name",
+            ],
             "model": {"type_name": "ImageAcquisition", "version": 1},
         }
     return image_acquisition

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -339,7 +339,6 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
     image_representation = {
         "uuid": uuid4(),
         "representation_of_uuid": get_experimentally_captured_image_dict()["uuid"],
-        "original_file_reference_uuid": [],
         "image_format": "Template image format",
         "attribute": {},
         "total_size_in_bytes": 0,

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -81,7 +81,7 @@ def get_specimen_imaging_preparation_protocol_dict(
                 get_signal_channel_information_dict(Completeness.COMPLETE)
             ],
             "model": {
-                "type_name": "SpecimenImagingPrepartionProtocol",
+                "type_name": "SpecimenImagingPreparationProtocol",
                 "version": 1,
             },
         }

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -388,13 +388,13 @@ class ExperimentalImagingDataset(DatasetMixin):
     # acquisition_process: list[ImageAcquisition] = Field(
     #     description="""Processes involved in the creation of the images and files in this dataset."""
     # )
-    # specimen_imaging_preparation_protocol: list[SpecimenImagingPrepartionProtocol] = Field(
+    # specimen_imaging_preparation_protocol: list[SpecimenImagingPreparationProtocol] = Field(
     #     description="""Processes involved in the preprapartion of the samples for imaged."""
     # )
     # biological_entity: list[BioSample] = Field(
     #     description="""The biological entity or entities that were imaged."""
     # )
-    # specimen_growth_protocol: Optional[list[SpecimenImagingPrepartionProtocol]] = Field(
+    # specimen_growth_protocol: Optional[list[SpecimenImagingPreparationProtocol]] = Field(
     #     description="""Processes involved in the growth of the samples that were then imaged."""
     # )
     analysis_method: Optional[list[ImageAnalysisMethod]] = Field(
@@ -451,7 +451,7 @@ class ImageAcquisition(ProtocolMixin):
     )
 
 
-class SpecimenImagingPrepartionProtocol(ProtocolMixin):
+class SpecimenImagingPreparationProtocol(ProtocolMixin):
     """
     The process to prepare biological entity for imaging.
     """
@@ -497,7 +497,7 @@ class Specimen(ConfiguredBaseModel):
     # sample_of: List[BioSample] = Field(
     #     description="""The biological matter that sampled to create the specimen."""
     # )
-    # imaging_preparation_protocol: List[SpecimenImagingPrepartionProtocol] = Field(
+    # imaging_preparation_protocol: List[SpecimenImagingPreparationProtocol] = Field(
     #     description="""How the biosample was prepared for imaging."""
     # )
     # growth_protocol: Optional[List[SpecimenGrowthProtocol]] = Field(
@@ -687,6 +687,6 @@ DatasetMixin.model_rebuild()
 ImageAnnotationDataset.model_rebuild()
 ExperimentalImagingDataset.model_rebuild()
 BioSample.model_rebuild()
-SpecimenImagingPrepartionProtocol.model_rebuild()
+SpecimenImagingPreparationProtocol.model_rebuild()
 AnnotationMethod.model_rebuild()
 ImageRepresentation.model_rebuild()

--- a/bia-shared-datamodels/test/test_shared_models.py
+++ b/bia-shared-datamodels/test/test_shared_models.py
@@ -93,41 +93,33 @@ class TestCreateObject:
         # Check that the dictionary is indeed "Minimal" - no optional fields included, and list fields are of minimum length
         for key in mimimal_dict:
             less_than_minimal_dict = mimimal_dict.copy()
-            if isinstance(less_than_minimal_dict[key], list):
-                if len(less_than_minimal_dict[key]):
-                    """
-                    Minimal object includes at least one element of a list attribute
-                    """
+            if isinstance(less_than_minimal_dict[key], list) and len(
+                less_than_minimal_dict[key]
+            ):
+                """
+                Minimal object includes at least one element of a list attribute
+                This checks if minimum length constraints are enforced / really minimal in the mocks
+                """
 
-                    less_than_minimal_dict[key] = []
+                less_than_minimal_dict[key] = []
 
-                    try:
-                        expected_model_type(**less_than_minimal_dict)
-                    except ValidationError:
-                        pass
-                    except Exception as e:
-                        raise Exception(f"Expected ValidationError, got: {e}")
-                    else:
-                        raise Exception(
-                            f"Expected ValidationError, got no error for empty list {key}"
-                        )
+                try:
+                    expected_model_type(**less_than_minimal_dict)
+                except ValidationError:
+                    pass
+                except Exception as e:
+                    raise Exception(f"Expected ValidationError, got: {e}")
                 else:
-                    """
-                    minimal object has an empty list. If the attribute has a default, then the minimal object wasn't minimal in the first place
-                    """
-                    del less_than_minimal_dict[key]
+                    raise Exception(
+                        f"Expected ValidationError, got no error for empty list {key}"
+                    )
 
-                    try:
-                        expected_model_type(**less_than_minimal_dict)
-                    except ValidationError:
-                        pass
-                    except Exception as e:
-                        raise Exception(f"Expected ValidationError, got: {e}")
-                    else:
-                        raise Exception(
-                            f"Expected ValidationError, got no error after deleting {key}- is the generated minimal object really minimal?"
-                        )
             else:
+                """
+                ! Note this is not isinstance(less_than_minimal_dict[key], list) or not len(less_than_minimal_dict[key])
+                minimal object has an empty list, or minimal object attribute is a non-abstract type
+                This checks if "field exists" constraints are enforced / really minimal in the mocks
+                """
                 del less_than_minimal_dict[key]
                 try:
                     expected_model_type(**less_than_minimal_dict)

--- a/bia-shared-datamodels/test/test_shared_models.py
+++ b/bia-shared-datamodels/test/test_shared_models.py
@@ -14,7 +14,7 @@ from typing import Callable
             mock_objects.get_signal_channel_information_dict,
         ),
         (
-            bia_data_model.SpecimenImagingPrepartionProtocol,
+            bia_data_model.SpecimenImagingPreparationProtocol,
             mock_objects.get_specimen_imaging_preparation_protocol_dict,
         ),
         (

--- a/bia-shared-datamodels/test/test_shared_models.py
+++ b/bia-shared-datamodels/test/test_shared_models.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError, BaseModel
 from bia_shared_datamodels import bia_data_model, semantic_models, mock_objects
 from typing import Callable
 
+
 @pytest.mark.parametrize(
     ("expected_model_type", "dict_creation_func"),
     (
@@ -34,7 +35,10 @@ from typing import Callable
             mock_objects.get_image_annotation_dataset_dict,
         ),
         (bia_data_model.ImageAcquisition, mock_objects.get_image_acquisition_dict),
-        (semantic_models.ImageAnalysisMethod, mock_objects.get_image_analysis_method_dict),
+        (
+            semantic_models.ImageAnalysisMethod,
+            mock_objects.get_image_analysis_method_dict,
+        ),
         (
             semantic_models.ImageCorrelationMethod,
             mock_objects.get_image_correlation_method_dict,
@@ -48,7 +52,10 @@ from typing import Callable
             mock_objects.get_annotation_file_reference_dict,
         ),
         (bia_data_model.FileReference, mock_objects.get_file_reference_dict),
-        (bia_data_model.ImageRepresentation, mock_objects.get_image_representation_dict),
+        (
+            bia_data_model.ImageRepresentation,
+            mock_objects.get_image_representation_dict,
+        ),
         (semantic_models.Affiliation, mock_objects.get_affiliation_dict),
         (semantic_models.Contributor, mock_objects.get_contributor_dict),
         (bia_data_model.Study, mock_objects.get_study_dict),
@@ -73,7 +80,6 @@ class TestCreateObject:
             is expected_model_type
         )
 
-
     def test_create_minimal_object(
         self,
         expected_model_type: BaseModel,
@@ -87,17 +93,53 @@ class TestCreateObject:
         # Check that the dictionary is indeed "Minimal" - no optional fields included, and list fields are of minimum length
         for key in mimimal_dict:
             less_than_minimal_dict = mimimal_dict.copy()
-            if (
-                isinstance(less_than_minimal_dict[key], list)
-                and len(less_than_minimal_dict[key]) > 0
-            ):
-                less_than_minimal_dict[key] = []
-                with pytest.raises(ValidationError):
-                    expected_model_type(**less_than_minimal_dict)
+            if isinstance(less_than_minimal_dict[key], list):
+                if len(less_than_minimal_dict[key]):
+                    """
+                    Minimal object includes at least one element of a list attribute
+                    """
 
-            del less_than_minimal_dict[key]
-            with pytest.raises(ValidationError):
-                expected_model_type(**less_than_minimal_dict)
+                    less_than_minimal_dict[key] = []
+
+                    try:
+                        expected_model_type(**less_than_minimal_dict)
+                    except ValidationError:
+                        pass
+                    except Exception as e:
+                        raise Exception(f"Expected ValidationError, got: {e}")
+                    else:
+                        raise Exception(
+                            f"Expected ValidationError, got no error for empty list {key}"
+                        )
+                else:
+                    """
+                    minimal object has an empty list. If the attribute has a default, then the minimal object wasn't minimal in the first place
+                    """
+                    del less_than_minimal_dict[key]
+
+                    try:
+                        expected_model_type(**less_than_minimal_dict)
+                    except ValidationError:
+                        pass
+                    except Exception as e:
+                        raise Exception(f"Expected ValidationError, got: {e}")
+                    else:
+                        raise Exception(
+                            f"Expected ValidationError, got no error after deleting {key}- is the generated minimal object really minimal?"
+                        )
+            else:
+                del less_than_minimal_dict[key]
+                try:
+                    expected_model_type(**less_than_minimal_dict)
+                except ValidationError:
+                    pass
+                except Exception as e:
+                    raise Exception(f"Expected ValidationError, got: {e}")
+                else:
+                    raise Exception(
+                        f"Expected ValidationError, got no error for deleted key {key}"
+                    )
+
         # Check that there are no inconsistencies in the model definition's optional fields
         assert (
             type(expected_model_type(**minimal_model.model_dump()))

--- a/bia-shared-datamodels/test/test_shared_models.py
+++ b/bia-shared-datamodels/test/test_shared_models.py
@@ -114,23 +114,21 @@ class TestCreateObject:
                         f"Expected ValidationError, got no error for empty list {key}"
                     )
 
+            """
+            Checks if "field exists" constraints are enforced at all
+                - fallthrough for lists with minimum length constraints for the extra-check of required fields always being required
+            """
+            del less_than_minimal_dict[key]
+            try:
+                expected_model_type(**less_than_minimal_dict)
+            except ValidationError:
+                pass
+            except Exception as e:
+                raise Exception(f"Expected ValidationError, got: {e}")
             else:
-                """
-                ! Note this is not isinstance(less_than_minimal_dict[key], list) or not len(less_than_minimal_dict[key])
-                minimal object has an empty list, or minimal object attribute is a non-abstract type
-                This checks if "field exists" constraints are enforced / really minimal in the mocks
-                """
-                del less_than_minimal_dict[key]
-                try:
-                    expected_model_type(**less_than_minimal_dict)
-                except ValidationError:
-                    pass
-                except Exception as e:
-                    raise Exception(f"Expected ValidationError, got: {e}")
-                else:
-                    raise Exception(
-                        f"Expected ValidationError, got no error for deleted key {key}"
-                    )
+                raise Exception(
+                    f"Expected ValidationError, got no error for deleted key {key}"
+                )
 
         # Check that there are no inconsistencies in the model definition's optional fields
         assert (


### PR DESCRIPTION
For https://app.clickup.com/t/86959dg0w , https://app.clickup.com/t/869527km2

Adding `ObjectReference` as it as (with the runtime validation hooks) just so we don't lose it when we squash, in case we ever have a usecase for it. Will make a PR deleting that part (so ObjectReference will just be a container for the link target) after that

Not fully tested, but tests should cover "one of each" for the major usecases (validating that a dependency object exists, and generating reverse links)