### PR TITLE
Fix windows path error

### DIFF
--- a/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
@@ -44,7 +44,7 @@ class Attribute(BaseModel):
 
 
 class File(BaseModel):
-    path: pathlib.Path
+    path: pathlib.PosixPath
     size: int
     type: str
     attributes: List[Attribute] = []

--- a/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
@@ -44,7 +44,7 @@ class Attribute(BaseModel):
 
 
 class File(BaseModel):
-    path: pathlib.PosixPath
+    path: pathlib.Path
     size: int
     type: str
     attributes: List[Attribute] = []
@@ -247,7 +247,7 @@ def file_uri(
     """For a given accession and file object, return the HTTP URI where we can expect
     to be able to access that file."""
 
-    return file_uri_template.format(accession_id=accession_id, relpath=file.path)
+    return file_uri_template.format(accession_id=accession_id, relpath=file.path.as_posix())
 
 
 def get_file_uri_template_for_accession(accession_id: str) -> str:

--- a/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
@@ -247,7 +247,16 @@ def file_uri(
     """For a given accession and file object, return the HTTP URI where we can expect
     to be able to access that file."""
 
-    return file_uri_template.format(accession_id=accession_id, relpath=file.path.as_posix())
+    # KB 09/08/2024 we are having an issue with url containing '\' when
+    # testing on windows during CI/CD.
+    # Use of PosixPath does not work -> not implemented error. Use of
+    # Path.as_posix() as commented out below does not seem to work either!
+    #return file_uri_template.format(accession_id=accession_id, relpath=file.path.as_posix())
+
+    # Hence split and manually rejoin
+    relpath = "/".join(file.path.parts)
+    return file_uri_template.format(accession_id=accession_id, relpath=relpath)
+
 
 
 def get_file_uri_template_for_accession(accession_id: str) -> str:

--- a/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
@@ -247,16 +247,7 @@ def file_uri(
     """For a given accession and file object, return the HTTP URI where we can expect
     to be able to access that file."""
 
-    # KB 09/08/2024 we are having an issue with url containing '\' when
-    # testing on windows during CI/CD.
-    # Use of PosixPath does not work -> not implemented error. Use of
-    # Path.as_posix() as commented out below does not seem to work either!
-    #return file_uri_template.format(accession_id=accession_id, relpath=file.path.as_posix())
-
-    # Hence split and manually rejoin
-    relpath = "/".join(file.path.parts)
-    return file_uri_template.format(accession_id=accession_id, relpath=relpath)
-
+    return file_uri_template.format(accession_id=accession_id, relpath=file.path.as_posix())
 
 
 def get_file_uri_template_for_accession(accession_id: str) -> str:

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
@@ -105,7 +105,7 @@ def get_file_reference_for_submission_dataset(
     for f in files_in_file_list:
         file_dict = {
             "accession_id": accession_id,
-            "file_path": str(f.path),
+            "file_path": str(f.path.as_posix()),
             "size_in_bytes": str(f.size),
         }
         fileref_uuid = dict_to_uuid(


### PR DESCRIPTION
Fix error due to formation of url from file paths on windows
during CI/CD using `as_posix` method of `Path`