### PR TITLE
Precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+  # - repo: https://github.com/psf/black
+  #   rev: 22.10.0
+  #   hooks:
+  #   -   id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.8
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix  ]
+      # Run the formatter.
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ A system for ingesting imaging datasets, tracking images and their representatio
 
 ## Help
 See [documentation](https://bia-integrator.readthedocs.io) for more details
+
+
+# Development
+
+This repo uses precommit hooks to enforce code standards, install with:
+
+  pre-commit install

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 88


### PR DESCRIPTION
- We had a go at using precommit hooks in https://github.com/BioImage-Archive/bia-agent/blob/main/.pre-commit-config.yaml and it was fine/good
- Added them here to for formatting the repo
  - N.B that you can't use black and ruff-format together as they can end up disagreeing

Also note that if you make a commit that the ruff formatter doesn't like, it'll make the changes to the file then you'll have to add the file again.

If you add a file with bad linting (unused variable) the commit won't pass and you'll have to find the issue.

Currently missing: linting and formatting the webdeveloment stuff