### PR TITLE
Multi study ingest & export

### DIFF
--- a/bia-export/bia_export/cli.py
+++ b/bia-export/bia_export/cli.py
@@ -3,7 +3,9 @@ import logging
 from rich.logging import RichHandler
 from typing_extensions import Annotated
 from pathlib import Path
-from .website_conversion import create_study
+from .website_conversion import create_studies
+from typing import List
+import json
 
 logging.basicConfig(
     level="NOTSET", format="%(message)s", datefmt="[%X]", handlers=[RichHandler()]
@@ -15,17 +17,17 @@ app = typer.Typer()
 
 @app.command()
 def website_study(
-    accession_id: Annotated[str, typer.Argument(help="Accession ID of the study to export")],
+    accession_id_list: Annotated[List[str], typer.Argument(help="Accession IDs of the studies to export")],
     root_directory: Annotated[Path, typer.Option("--root", "-r", help="If root directory specified then use files there, rather than calling API")] = None,
     output_filename: Annotated[Path, typer.Option("--out_file", "-o",)] = Path("bia-images-export.json")
     ):
 
     abs_root = root_directory.resolve()
-    study = create_study(accession_id, abs_root)
+    studies_map = create_studies(accession_id_list, abs_root)
 
     logging.info(f"Writing study info to {output_filename.absolute()}")
     with open(output_filename, "w") as output:
-        output.write(study.model_dump_json(indent=4)) 
+        output.write(json.dumps(studies_map, indent=4))
 
 
 @app.command()

--- a/bia-export/bia_export/website_conversion.py
+++ b/bia-export/bia_export/website_conversion.py
@@ -56,6 +56,14 @@ def find_associated_objects(
     return linked_object
 
 
+def create_studies(accession_id_list: str, root_directory: Path) -> dict:
+    study_map = {}
+    for accession_id in accession_id_list:
+        study  = create_study(accession_id, root_directory)
+        study_map[accession_id] = study.model_dump(mode='json')
+    return study_map
+
+
 def create_study(accession_id: str, root_directory: Path) -> Study:
 
     if root_directory:
@@ -171,7 +179,7 @@ def create_experimental_imaging_datasets(
             eid_dict["specimen_growth_protocol"] = process_details_section(
                 root_directory,
                 accession_id,
-                detail_map[BioSample],
+                detail_map[SpecimenGrowthProtocol],
                 association_by_type["specimen"],
             )
             eid_dict["acquisition_process"] = process_details_section(

--- a/bia-export/test/output_data/bia_export.json
+++ b/bia-export/test/output_data/bia_export.json
@@ -1,254 +1,256 @@
 {
-    "uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
-    "version": 1,
-    "model": {
-        "type_name": "Study",
-        "version": 1
-    },
-    "accession_id": "S-BIADTEST",
-    "licence": "CC0",
-    "author": [
-        {
-            "rorid": null,
-            "address": null,
-            "website": null,
-            "orcid": "0000-0000-0000-0000",
-            "display_name": "Test Author1",
-            "affiliation": [
-                {
-                    "rorid": null,
-                    "address": null,
-                    "website": null,
-                    "display_name": "Test College 1"
-                }
-            ],
-            "contact_email": "test_author1@ebi.ac.uk",
-            "role": "corresponding author"
+    "S-BIADTEST": {
+        "uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+        "version": 1,
+        "model": {
+            "type_name": "Study",
+            "version": 1
         },
-        {
-            "rorid": null,
-            "address": null,
-            "website": null,
-            "orcid": "1111-1111-1111-1111",
-            "display_name": "Test Author2",
-            "affiliation": [
-                {
-                    "rorid": null,
-                    "address": null,
-                    "website": null,
-                    "display_name": "Test College 2"
-                }
-            ],
-            "contact_email": "test_author2@ebi.ac.uk",
-            "role": "first author"
-        }
-    ],
-    "title": "A test submission with title greater than 25 characters",
-    "release_date": "2024-02-13",
-    "description": "A test submission to allow testing without retrieving from bia server",
-    "keyword": [
-        "Test keyword1",
-        "Test keyword2",
-        "Test keyword3"
-    ],
-    "acknowledgement": "We thank you",
-    "see_also": [],
-    "related_publication": [],
-    "grant": [
-        {
-            "id": "TESTFUNDS1",
-            "funder": [
-                {
-                    "display_name": "Test funding body1",
-                    "id": null
-                }
-            ]
-        },
-        {
-            "id": "TESTFUNDS2",
-            "funder": [
-                {
-                    "display_name": "Test funding body2",
-                    "id": null
-                }
-            ]
-        }
-    ],
-    "funding_statement": "This work was funded by the EBI",
-    "attribute": {},
-    "experimental_imaging_component": [
-        {
-            "title_id": "Study Component 1",
-            "uuid": "47a4ab60-c76d-4424-bfaa-c2a024de720c",
-            "version": 1,
-            "model": {
-                "type_name": "ExperimentalImagingDataset",
-                "version": 1
+        "accession_id": "S-BIADTEST",
+        "licence": "CC0",
+        "author": [
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0000-0000-0000",
+                "display_name": "Test Author1",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Test College 1"
+                    }
+                ],
+                "contact_email": "test_author1@ebi.ac.uk",
+                "role": "corresponding author"
             },
-            "description": "Description of study component 1",
-            "attribute": {
-                "associations": [
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "1111-1111-1111-1111",
+                "display_name": "Test Author2",
+                "affiliation": [
                     {
-                        "biosample": "Test Biosample 1",
-                        "image_acquisition": "Test Primary Screen Image Acquisition",
-                        "specimen": "Test specimen 1"
-                    },
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "Test College 2"
+                    }
+                ],
+                "contact_email": "test_author2@ebi.ac.uk",
+                "role": "first author"
+            }
+        ],
+        "title": "A test submission with title greater than 25 characters",
+        "release_date": "2024-02-13",
+        "description": "A test submission to allow testing without retrieving from bia server",
+        "keyword": [
+            "Test keyword1",
+            "Test keyword2",
+            "Test keyword3"
+        ],
+        "acknowledgement": "We thank you",
+        "see_also": [],
+        "related_publication": [],
+        "grant": [
+            {
+                "id": "TESTFUNDS1",
+                "funder": [
                     {
-                        "biosample": "Test Biosample 2",
-                        "image_acquisition": "Test Primary Screen Image Acquisition",
-                        "specimen": "Test specimen 1"
+                        "display_name": "Test funding body1",
+                        "id": null
                     }
                 ]
             },
-            "analysis_method": [
-                {
-                    "protocol_description": "Test image analysis",
-                    "features_analysed": "Test image analysis overview"
-                }
-            ],
-            "correlation_method": [],
-            "example_image_uri": [],
-            "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
-            "acquisition_process": [
-                {
-                    "default_open": true,
-                    "title_id": "Test Primary Screen Image Acquisition",
-                    "uuid": "c2e44a1b-a43c-476e-8ddf-8587f4c955b3",
-                    "version": 1,
-                    "model": {
-                        "type_name": "ImageAcquisition",
-                        "version": 1
-                    },
-                    "protocol_description": "Test image acquisition parameters 1",
-                    "imaging_instrument_description": "Test imaging instrument 1",
-                    "fbbi_id": [],
-                    "imaging_method_name": [
-                        "confocal microscopy"
-                    ]
-                }
-            ],
-            "specimen_imaging_preparation_protocol": [
-                {
-                    "default_open": true,
-                    "title_id": "Test specimen 1",
-                    "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
-                    "version": 1,
-                    "model": {
-                        "type_name": "SpecimenImagingPreparationProtocol",
-                        "version": 1
-                    },
-                    "protocol_description": "Test sample preparation protocol 1",
-                    "signal_channel_information": []
-                }
-            ],
-            "biological_entity": [
-                {
-                    "default_open": true,
-                    "title_id": "Test Biosample 1",
-                    "uuid": "64a67727-4e7c-469a-91c4-6219ae072e99",
-                    "version": 1,
-                    "model": {
-                        "type_name": "BioSample",
-                        "version": 1
-                    },
-                    "organism_classification": [
+            {
+                "id": "TESTFUNDS2",
+                "funder": [
+                    {
+                        "display_name": "Test funding body2",
+                        "id": null
+                    }
+                ]
+            }
+        ],
+        "funding_statement": "This work was funded by the EBI",
+        "attribute": {},
+        "experimental_imaging_component": [
+            {
+                "title_id": "Study Component 1",
+                "uuid": "47a4ab60-c76d-4424-bfaa-c2a024de720c",
+                "version": 1,
+                "model": {
+                    "type_name": "ExperimentalImagingDataset",
+                    "version": 1
+                },
+                "description": "Description of study component 1",
+                "attribute": {
+                    "associations": [
                         {
-                            "common_name": "human",
-                            "scientific_name": "Homo sapiens",
-                            "ncbi_id": null
+                            "biosample": "Test Biosample 1",
+                            "image_acquisition": "Test Primary Screen Image Acquisition",
+                            "specimen": "Test specimen 1"
+                        },
+                        {
+                            "biosample": "Test Biosample 2",
+                            "image_acquisition": "Test Primary Screen Image Acquisition",
+                            "specimen": "Test specimen 1"
                         }
-                    ],
-                    "biological_entity_description": "Test biological entity 1",
-                    "experimental_variable_description": [
-                        "Test experimental entity 1"
-                    ],
-                    "extrinsic_variable_description": [
-                        "Test extrinsic variable 1"
-                    ],
-                    "intrinsic_variable_description": [
-                        "Test intrinsic variable 1\\nwith escaped character"
                     ]
                 },
-                {
-                    "default_open": true,
-                    "title_id": "Test Biosample 2",
-                    "uuid": "6950718c-4917-47a1-a807-11b874e80a23",
-                    "version": 1,
-                    "model": {
-                        "type_name": "BioSample",
-                        "version": 1
-                    },
-                    "organism_classification": [
-                        {
-                            "common_name": "mouse",
-                            "scientific_name": "Mus musculus",
-                            "ncbi_id": null
-                        }
-                    ],
-                    "biological_entity_description": "Test biological entity 2",
-                    "experimental_variable_description": [
-                        "Test experimental entity 2"
-                    ],
-                    "extrinsic_variable_description": [
-                        "Test extrinsic variable 2"
-                    ],
-                    "intrinsic_variable_description": [
-                        "Test intrinsic variable 2"
-                    ]
-                }
-            ],
-            "specimen_growth_protocol": []
-        },
-        {
-            "title_id": "Study Component 2",
-            "uuid": "850a1ca3-9681-4a8a-b625-477936fcb954",
-            "version": 1,
-            "model": {
-                "type_name": "ExperimentalImagingDataset",
-                "version": 1
-            },
-            "description": "Description of study component 2",
-            "attribute": {
-                "associations": [
+                "analysis_method": [
                     {
-                        "image_analysis": "Test image analysis",
-                        "image_correlation": null,
-                        "biosample": "Test Biosample 2 ",
-                        "image_acquisition": "Test Primary Screen Image Acquisition",
-                        "specimen": "Test specimen 2"
+                        "protocol_description": "Test image analysis",
+                        "features_analysed": "Test image analysis overview"
                     }
-                ]
-            },
-            "analysis_method": [
-                {
-                    "protocol_description": "Test image analysis",
-                    "features_analysed": "Test image analysis overview"
-                }
-            ],
-            "correlation_method": [],
-            "example_image_uri": [],
-            "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
-            "acquisition_process": [
-                {
-                    "default_open": false,
-                    "title_id": "Test Primary Screen Image Acquisition",
-                    "uuid": "c2e44a1b-a43c-476e-8ddf-8587f4c955b3",
-                    "version": 1,
-                    "model": {
-                        "type_name": "ImageAcquisition",
-                        "version": 1
+                ],
+                "correlation_method": [],
+                "example_image_uri": [],
+                "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+                "acquisition_process": [
+                    {
+                        "default_open": true,
+                        "title_id": "Test Primary Screen Image Acquisition",
+                        "uuid": "c2e44a1b-a43c-476e-8ddf-8587f4c955b3",
+                        "version": 1,
+                        "model": {
+                            "type_name": "ImageAcquisition",
+                            "version": 1
+                        },
+                        "protocol_description": "Test image acquisition parameters 1",
+                        "imaging_instrument_description": "Test imaging instrument 1",
+                        "fbbi_id": [],
+                        "imaging_method_name": [
+                            "confocal microscopy"
+                        ]
+                    }
+                ],
+                "specimen_imaging_preparation_protocol": [
+                    {
+                        "default_open": true,
+                        "title_id": "Test specimen 1",
+                        "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
+                        "version": 1,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 1
+                        },
+                        "protocol_description": "Test sample preparation protocol 1",
+                        "signal_channel_information": []
+                    }
+                ],
+                "biological_entity": [
+                    {
+                        "default_open": true,
+                        "title_id": "Test Biosample 1",
+                        "uuid": "64a67727-4e7c-469a-91c4-6219ae072e99",
+                        "version": 1,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 1
+                        },
+                        "organism_classification": [
+                            {
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Test biological entity 1",
+                        "experimental_variable_description": [
+                            "Test experimental entity 1"
+                        ],
+                        "extrinsic_variable_description": [
+                            "Test extrinsic variable 1"
+                        ],
+                        "intrinsic_variable_description": [
+                            "Test intrinsic variable 1\\nwith escaped character"
+                        ]
                     },
-                    "protocol_description": "Test image acquisition parameters 1",
-                    "imaging_instrument_description": "Test imaging instrument 1",
-                    "fbbi_id": [],
-                    "imaging_method_name": [
-                        "confocal microscopy"
+                    {
+                        "default_open": true,
+                        "title_id": "Test Biosample 2",
+                        "uuid": "6950718c-4917-47a1-a807-11b874e80a23",
+                        "version": 1,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 1
+                        },
+                        "organism_classification": [
+                            {
+                                "common_name": "mouse",
+                                "scientific_name": "Mus musculus",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Test biological entity 2",
+                        "experimental_variable_description": [
+                            "Test experimental entity 2"
+                        ],
+                        "extrinsic_variable_description": [
+                            "Test extrinsic variable 2"
+                        ],
+                        "intrinsic_variable_description": [
+                            "Test intrinsic variable 2"
+                        ]
+                    }
+                ],
+                "specimen_growth_protocol": []
+            },
+            {
+                "title_id": "Study Component 2",
+                "uuid": "850a1ca3-9681-4a8a-b625-477936fcb954",
+                "version": 1,
+                "model": {
+                    "type_name": "ExperimentalImagingDataset",
+                    "version": 1
+                },
+                "description": "Description of study component 2",
+                "attribute": {
+                    "associations": [
+                        {
+                            "image_analysis": "Test image analysis",
+                            "image_correlation": null,
+                            "biosample": "Test Biosample 2 ",
+                            "image_acquisition": "Test Primary Screen Image Acquisition",
+                            "specimen": "Test specimen 2"
+                        }
                     ]
-                }
-            ],
-            "specimen_imaging_preparation_protocol": [],
-            "biological_entity": [],
-            "specimen_growth_protocol": []
-        }
-    ]
+                },
+                "analysis_method": [
+                    {
+                        "protocol_description": "Test image analysis",
+                        "features_analysed": "Test image analysis overview"
+                    }
+                ],
+                "correlation_method": [],
+                "example_image_uri": [],
+                "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
+                "acquisition_process": [
+                    {
+                        "default_open": false,
+                        "title_id": "Test Primary Screen Image Acquisition",
+                        "uuid": "c2e44a1b-a43c-476e-8ddf-8587f4c955b3",
+                        "version": 1,
+                        "model": {
+                            "type_name": "ImageAcquisition",
+                            "version": 1
+                        },
+                        "protocol_description": "Test image acquisition parameters 1",
+                        "imaging_instrument_description": "Test imaging instrument 1",
+                        "fbbi_id": [],
+                        "imaging_method_name": [
+                            "confocal microscopy"
+                        ]
+                    }
+                ],
+                "specimen_imaging_preparation_protocol": [],
+                "biological_entity": [],
+                "specimen_growth_protocol": []
+            }
+        ]
+    }
 }

--- a/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
@@ -9,7 +9,7 @@ import requests
 from pydantic import BaseModel, TypeAdapter
 
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 STUDY_URL_TEMPLATE = "https://www.ebi.ac.uk/biostudies/api/v1/studies/{accession}"

--- a/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
@@ -9,7 +9,7 @@ import requests
 from pydantic import BaseModel, TypeAdapter
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('biaingest')
 
 
 STUDY_URL_TEMPLATE = "https://www.ebi.ac.uk/biostudies/api/v1/studies/{accession}"

--- a/bia-ingest-shared-models/bia_ingest_sm/cli.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli.py
@@ -1,5 +1,5 @@
 import typer
-from typing import Optional
+from typing import List
 from typing_extensions import Annotated
 from bia_ingest_sm.biostudies import load_submission
 from bia_ingest_sm.conversion.study import get_study
@@ -9,31 +9,62 @@ from bia_ingest_sm.conversion.experimental_imaging_dataset import (
 from bia_ingest_sm.conversion.file_reference import get_file_reference_by_dataset
 from bia_ingest_sm.conversion.specimen import get_specimen
 from bia_ingest_sm.conversion.image_acquisition import get_image_acquisition
+import logging
+from rich import print
+from rich.logging import RichHandler
+from .config import RESULT_SUMMARY, ObjectValidationResult
+from .cli_logging import tabulate_errors
 
 app = typer.Typer()
 
 
+logging.basicConfig(
+    level=logging.INFO, 
+    format="%(message)s",
+    handlers=[RichHandler(show_time=False)]
+)
+
+logger = logging.getLogger('biaingest')
+
 @app.command(help="Ingest from biostudies and echo json of bia_data_model.Study")
-def ingest(accession_id: Annotated[str, typer.Argument()],) -> None:
-    submission = load_submission(accession_id)
+def ingest(accession_id_list: Annotated[List[str], typer.Argument()],
+           verbose: Annotated[bool, typer.Option("-v")] = False)  -> None:
+    
 
-    study = get_study(submission, persist_artefacts=True)
+    if verbose:
+        logger.setLevel(logging.DEBUG)
 
-    experimental_imaging_datasets = get_experimental_imaging_dataset(
-        submission, persist_artefacts=True
-    )
+    for accession_id in accession_id_list:
+        print(f"[blue]-------- Starting ingest of {accession_id} --------[/blue]")
+        logger.debug(f"starting ingest of {accession_id}")
 
-    file_references = get_file_reference_by_dataset(
-        submission, experimental_imaging_datasets, persist_artefacts=True
-    )
+        RESULT_SUMMARY[accession_id] = ObjectValidationResult()
 
-    image_acquisitions = get_image_acquisition(submission, persist_artefacts=True)
+        submission = load_submission(accession_id)
 
-    # Specimen
-    # Biosample and Specimen artefacts are processed as part of bia_data_models.Specimen (note - this is very different from Biostudies.Specimen)
-    specimens = get_specimen(submission, persist_artefacts=True)
+        study = get_study(submission, persist_artefacts=True)
 
-    # typer.echo(study.model_dump_json(indent=2))
+        experimental_imaging_datasets = get_experimental_imaging_dataset(
+            submission, persist_artefacts=True
+        )
+
+        file_references = get_file_reference_by_dataset(
+            submission, experimental_imaging_datasets, persist_artefacts=True
+        )
+
+        image_acquisitions = get_image_acquisition(submission, persist_artefacts=True)
+
+        # Specimen
+        # Biosample and Specimen artefacts are processed as part of bia_data_models.Specimen (note - this is very different from Biostudies.Specimen)
+        specimens = get_specimen(submission, persist_artefacts=True)
+
+        # typer.echo(study.model_dump_json(indent=2))
+        
+        logger.debug(f"COMPLETED: Ingest of: {accession_id}")
+        print(f"[green]-------- Completed ingest of {accession_id} --------[/green]")
+    
+    print(tabulate_errors(RESULT_SUMMARY))
+
 
 
 @app.callback()

--- a/bia-ingest-shared-models/bia_ingest_sm/cli.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli.py
@@ -23,7 +23,7 @@ logging.basicConfig(
     handlers=[RichHandler(show_time=False)]
 )
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger()
 
 @app.command(help="Ingest from biostudies and echo json of bia_data_model.Study")
 def ingest(accession_id_list: Annotated[List[str], typer.Argument()],

--- a/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
@@ -1,0 +1,26 @@
+from rich.table import Table
+from rich.text import Text
+from .config import ObjectValidationResult
+
+def tabulate_errors(dict_of_results: dict[ObjectValidationResult]) -> Table:
+    table = Table("Accession ID", "Status", "Errors")
+    for accession_id_key in dict_of_results:
+        error_message = ""
+        validation_result: ObjectValidationResult = dict_of_results[accession_id_key]
+        errors = validation_result.model_dump()
+        for field, value in errors.items():
+            if value > 0:
+                error_message += f"{field}: {value}; "
+    
+        if error_message == "":
+            status = Text("Success")
+            status.stylize("green")
+        else:
+            status = Text("Failures")
+            status.stylize("red")
+            error_message = Text(error_message)
+            error_message.stylize("red")   
+
+        table.add_row(accession_id_key, status, error_message)
+
+    return table

--- a/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
@@ -24,11 +24,10 @@ class ObjectValidationResult(BaseModel):
     Contributor_ValidationErrorCount: int = Field(default=0)
     Organisation_ValidationErrorCount: int = Field(default=0)
 
-def tabulate_errors(dict_of_results: dict[ObjectValidationResult]) -> Table:
+def tabulate_errors(dict_of_results: dict[str, ObjectValidationResult]) -> Table:
     table = Table("Accession ID", "Status", "Error: Count;")
-    for accession_id_key in dict_of_results:
+    for accession_id_key, validation_result in dict_of_results.items():
         error_message = ""
-        validation_result: ObjectValidationResult = dict_of_results[accession_id_key]
         errors = validation_result.model_dump()
         for field, value in errors.items():
             if value > 0:

--- a/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
@@ -1,9 +1,31 @@
 from rich.table import Table
 from rich.text import Text
-from .config import ObjectValidationResult
+from pydantic import BaseModel, Field
+
+class ObjectValidationResult(BaseModel):
+    StudyValidation_ErrorCount: int = Field(default=0)
+    ExperimentalImagingDataseta_ValidationErrorCount: int = Field(default=0)
+    AnnotationDataseta_ValidationErrorCount: int = Field(default=0)
+    FileReferenceValidation_ErrorCount: int = Field(default=0)
+    BioSample_ValidationErrorCount: int = Field(default=0)
+    SpecimenGrowthProtocol_ValidationErrorCount: int = Field(default=0)
+    SpecimenImagingPreparationProtocol_ValidationErrorCount: int = Field(default=0)
+    Specimen_ValidationErrorCount: int = Field(default=0)
+    DerivedImage_ValidationErrorCount: int = Field(default=0)
+    AnnotationMethod_ValidationErrorCount: int = Field(default=0)
+    AnnotationDataset_ValidationErrorCount: int = Field(default=0)
+    AnnotationFile_ValidationErrorCount: int = Field(default=0)
+    ImageAnalysisMethod_ValidationErrorCount: int = Field(default=0)
+    ImageCorrelationMethod_ValidationErrorCount: int = Field(default=0)
+    RenderedView_ValidationErrorCount: int = Field(default=0)
+    Channel_ValidationErrorCount: int = Field(default=0)
+    Organism_ValidationErrorCount: int = Field(default=0)
+    ExternalLink_ValidationErrorCount: int = Field(default=0)
+    Contributor_ValidationErrorCount: int = Field(default=0)
+    Organisation_ValidationErrorCount: int = Field(default=0)
 
 def tabulate_errors(dict_of_results: dict[ObjectValidationResult]) -> Table:
-    table = Table("Accession ID", "Status", "Errors")
+    table = Table("Accession ID", "Status", "Error: Count;")
     for accession_id_key in dict_of_results:
         error_message = ""
         validation_result: ObjectValidationResult = dict_of_results[accession_id_key]

--- a/bia-ingest-shared-models/bia_ingest_sm/config.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/config.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 import os
 
-from pydantic import Field
+from pydantic import Field, BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
+import logging
 
 default_output_base = (
     f"{Path(os.environ.get('HOME', '')) / '.cache' / 'bia-integrator-data-sm'}"
@@ -27,3 +27,28 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+RESULT_SUMMARY = {}
+
+class ObjectValidationResult(BaseModel):
+    StudyValidation_ErrorCount: int = Field(default=0)
+    ExperimentalImagingDataseta_ValidationErrorCount: int = Field(default=0)
+    AnnotationDataseta_ValidationErrorCount: int = Field(default=0)
+    FileReferenceValidation_ErrorCount: int = Field(default=0)
+    BioSample_ValidationErrorCount: int = Field(default=0)
+    SpecimenGrowthProtocol_ValidationErrorCount: int = Field(default=0)
+    SpecimenImagingPreparationProtocol_ValidationErrorCount: int = Field(default=0)
+    Specimen_ValidationErrorCount: int = Field(default=0)
+    DerivedImage_ValidationErrorCount: int = Field(default=0)
+    AnnotationMethod_ValidationErrorCount: int = Field(default=0)
+    AnnotationDataset_ValidationErrorCount: int = Field(default=0)
+    AnnotationFile_ValidationErrorCount: int = Field(default=0)
+    ImageAnalysisMethod_ValidationErrorCount: int = Field(default=0)
+    ImageCorrelationMethod_ValidationErrorCount: int = Field(default=0)
+    RenderedView_ValidationErrorCount: int = Field(default=0)
+    Channel_ValidationErrorCount: int = Field(default=0)
+    Organism_ValidationErrorCount: int = Field(default=0)
+    ExternalLink_ValidationErrorCount: int = Field(default=0)
+    Contributor_ValidationErrorCount: int = Field(default=0)
+    Organisation_ValidationErrorCount: int = Field(default=0)

--- a/bia-ingest-shared-models/bia_ingest_sm/config.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/config.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 import os
 
-from pydantic import Field, BaseModel
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-import logging
 
 default_output_base = (
     f"{Path(os.environ.get('HOME', '')) / '.cache' / 'bia-integrator-data-sm'}"
@@ -28,27 +27,3 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-
-RESULT_SUMMARY = {}
-
-class ObjectValidationResult(BaseModel):
-    StudyValidation_ErrorCount: int = Field(default=0)
-    ExperimentalImagingDataseta_ValidationErrorCount: int = Field(default=0)
-    AnnotationDataseta_ValidationErrorCount: int = Field(default=0)
-    FileReferenceValidation_ErrorCount: int = Field(default=0)
-    BioSample_ValidationErrorCount: int = Field(default=0)
-    SpecimenGrowthProtocol_ValidationErrorCount: int = Field(default=0)
-    SpecimenImagingPreparationProtocol_ValidationErrorCount: int = Field(default=0)
-    Specimen_ValidationErrorCount: int = Field(default=0)
-    DerivedImage_ValidationErrorCount: int = Field(default=0)
-    AnnotationMethod_ValidationErrorCount: int = Field(default=0)
-    AnnotationDataset_ValidationErrorCount: int = Field(default=0)
-    AnnotationFile_ValidationErrorCount: int = Field(default=0)
-    ImageAnalysisMethod_ValidationErrorCount: int = Field(default=0)
-    ImageCorrelationMethod_ValidationErrorCount: int = Field(default=0)
-    RenderedView_ValidationErrorCount: int = Field(default=0)
-    Channel_ValidationErrorCount: int = Field(default=0)
-    Organism_ValidationErrorCount: int = Field(default=0)
-    ExternalLink_ValidationErrorCount: int = Field(default=0)
-    Contributor_ValidationErrorCount: int = Field(default=0)
-    Organisation_ValidationErrorCount: int = Field(default=0)

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
@@ -13,7 +13,7 @@ from ..biostudies import (
 )
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_annotation_method(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
@@ -11,10 +11,10 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('biaingest')
 
 
 def get_annotation_method(
@@ -23,7 +23,7 @@ def get_annotation_method(
 
     annotation_method_model_dicts = extract_annotation_method_dicts(submission)
     annotation_methods = dicts_to_api_models(
-        annotation_method_model_dicts, bia_data_model.AnnotationMethod
+        annotation_method_model_dicts, bia_data_model.AnnotationMethod, RESULT_SUMMARY[submission.accno]
     )
 
     if persist_artefacts and annotation_methods:
@@ -63,6 +63,11 @@ def extract_annotation_method_dicts(submission: Submission) -> List[Dict[str, An
         )
 
         model_dicts.append(model_dict)
+
+
+    logger.info(
+        f"Ingesting: {submission.accno}. Created bia_data_model.AnnotationMethod. Count: {len(model_dicts)}"
+    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
@@ -11,19 +11,18 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
 logger = logging.getLogger('biaingest')
 
 
 def get_annotation_method(
-    submission: Submission, persist_artefacts=False
+    submission: Submission, result_summary: dict, persist_artefacts=False
 ) -> List[bia_data_model.AnnotationMethod]:
 
     annotation_method_model_dicts = extract_annotation_method_dicts(submission)
     annotation_methods = dicts_to_api_models(
-        annotation_method_model_dicts, bia_data_model.AnnotationMethod, RESULT_SUMMARY[submission.accno]
+        annotation_method_model_dicts, bia_data_model.AnnotationMethod, result_summary[submission.accno]
     )
 
     if persist_artefacts and annotation_methods:

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
@@ -11,10 +11,10 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model, semantic_models
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('biaingest')
 
 
 def get_biosample(
@@ -22,7 +22,7 @@ def get_biosample(
 ) -> List[bia_data_model.BioSample]:
 
     biosample_model_dicts = extract_biosample_dicts(submission)
-    biosamples = dicts_to_api_models(biosample_model_dicts, bia_data_model.BioSample)
+    biosamples = dicts_to_api_models(biosample_model_dicts, bia_data_model.BioSample, RESULT_SUMMARY[submission.accno])
 
     if persist_artefacts and biosamples:
         persist(biosamples, "biosamples", submission.accno)
@@ -78,6 +78,11 @@ def extract_biosample_dicts(submission: Submission) -> List[Dict[str, Any]]:
         model_dict["version"] = 1
         model_dict = filter_model_dictionary(model_dict, bia_data_model.BioSample)
         model_dicts.append(model_dict)
+
+
+    logger.info(
+        f"Ingesting: {submission.accno}. Created bia_data_model.BioSample. Count: {len(model_dicts)}"
+    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
@@ -13,7 +13,7 @@ from ..biostudies import (
 )
 from bia_shared_datamodels import bia_data_model, semantic_models
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_biosample(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
@@ -11,18 +11,17 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model, semantic_models
 
 logger = logging.getLogger('biaingest')
 
 
 def get_biosample(
-    submission: Submission, persist_artefacts=False
+    submission: Submission, result_summary: dict, persist_artefacts=False
 ) -> List[bia_data_model.BioSample]:
 
     biosample_model_dicts = extract_biosample_dicts(submission)
-    biosamples = dicts_to_api_models(biosample_model_dicts, bia_data_model.BioSample, RESULT_SUMMARY[submission.accno])
+    biosamples = dicts_to_api_models(biosample_model_dicts, bia_data_model.BioSample, result_summary[submission.accno])
 
     if persist_artefacts and biosamples:
         persist(biosamples, "biosamples", submission.accno)

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -130,7 +130,6 @@ def get_image_analysis_method(
     submission: Submission,
 ) -> Dict[str, semantic_models.ImageAnalysisMethod]:
     key_mapping = [
-<<<<<<< HEAD
         (
             "protocol_description",
             "Title",
@@ -141,10 +140,6 @@ def get_image_analysis_method(
             "Image analysis overview",
             None,
         ),
-=======
-        ("protocol_description", "Title", None,),
-        ("protocol_description", "Image analysis overview", None,),
->>>>>>> fbaa8c4 (improve ingest error reporting in the terminal)
     ]
 
     return get_generic_section_as_dict(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -13,7 +13,6 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model, semantic_models
 
 
@@ -21,7 +20,7 @@ logger = logging.getLogger('biaingest')
 
 
 def get_experimental_imaging_dataset(
-    submission: Submission, persist_artefacts=False
+    submission: Submission, result_summary: dict, persist_artefacts=False
 ) -> List[bia_data_model.ExperimentalImagingDataset]:
     """
     Map biostudies.Submission study components to bia_data_model.ExperimentalImagingDataset
@@ -33,7 +32,7 @@ def get_experimental_imaging_dataset(
         ],
         [],
     )
-    analysis_method_dict = get_image_analysis_method(submission)
+    analysis_method_dict = get_image_analysis_method(submission, result_summary)
 
     experimental_imaging_dataset = []
     for section in study_components:
@@ -126,6 +125,7 @@ def get_experimental_imaging_dataset(
 
 def get_image_analysis_method(
     submission: Submission,
+    RESULT_SUMMARY: dict
 ) -> Dict[str, semantic_models.ImageAnalysisMethod]:
     key_mapping = [
         (

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -18,7 +18,7 @@ from pydantic import ValidationError
 from bia_shared_datamodels import bia_data_model, semantic_models
 
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_experimental_imaging_dataset(
@@ -113,7 +113,7 @@ def get_experimental_imaging_dataset(
             bia_data_model.ExperimentalImagingDataset.model_validate(model_dict)
         )    
         except(ValidationError):
-            log_failed_model_creation(bia_data_model.Study, result_summary)
+            log_failed_model_creation(bia_data_model.ExperimentalImagingDataset, result_summary)
 
 
     logger.info(
@@ -132,7 +132,7 @@ def get_experimental_imaging_dataset(
 
 def get_image_analysis_method(
     submission: Submission,
-    RESULT_SUMMARY: dict
+    result_summary: dict
 ) -> Dict[str, semantic_models.ImageAnalysisMethod]:
     key_mapping = [
         (
@@ -154,7 +154,7 @@ def get_image_analysis_method(
         ],
         key_mapping,
         semantic_models.ImageAnalysisMethod,
-        RESULT_SUMMARY[submission.accno],
+        result_summary[submission.accno],
     )
 
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -15,8 +15,6 @@ from ..biostudies import (
 )
 from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model, semantic_models
-from pydantic import ValidationError
-import traceback
 
 
 logger = logging.getLogger('biaingest')

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -7,12 +7,14 @@ from .utils import (
     get_generic_section_as_dict,
     persist,
     filter_model_dictionary,
+    log_failed_model_creation
 )
 import bia_ingest_sm.conversion.study as study_conversion
 from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from pydantic import ValidationError
 from bia_shared_datamodels import bia_data_model, semantic_models
 
 
@@ -105,10 +107,15 @@ def get_experimental_imaging_dataset(
             model_dict, bia_data_model.ExperimentalImagingDataset
         )
 
-        experimental_imaging_dataset.append(
+        
+        try:
+            experimental_imaging_dataset.append(
             bia_data_model.ExperimentalImagingDataset.model_validate(model_dict)
-        )
-    
+        )    
+        except(ValidationError):
+            log_failed_model_creation(bia_data_model.Study, result_summary)
+
+
     logger.info(
         f"Ingesting: {submission.accno}. Created bia_data_model.ExperimentalImagingDataset. Count: {len(experimental_imaging_dataset)}"
     )

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -13,10 +13,13 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model, semantic_models
+from pydantic import ValidationError
+import traceback
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+
+logger = logging.getLogger('biaingest')
 
 
 def get_experimental_imaging_dataset(
@@ -108,6 +111,10 @@ def get_experimental_imaging_dataset(
         experimental_imaging_dataset.append(
             bia_data_model.ExperimentalImagingDataset.model_validate(model_dict)
         )
+    
+    logger.info(
+        f"Ingesting: {submission.accno}. Created bia_data_model.ExperimentalImagingDataset. Count: {len(experimental_imaging_dataset)}"
+    )
 
     if persist_artefacts and experimental_imaging_dataset:
         persist(
@@ -123,6 +130,7 @@ def get_image_analysis_method(
     submission: Submission,
 ) -> Dict[str, semantic_models.ImageAnalysisMethod]:
     key_mapping = [
+<<<<<<< HEAD
         (
             "protocol_description",
             "Title",
@@ -133,6 +141,10 @@ def get_image_analysis_method(
             "Image analysis overview",
             None,
         ),
+=======
+        ("protocol_description", "Title", None,),
+        ("protocol_description", "Image analysis overview", None,),
+>>>>>>> fbaa8c4 (improve ingest error reporting in the terminal)
     ]
 
     return get_generic_section_as_dict(
@@ -142,6 +154,7 @@ def get_image_analysis_method(
         ],
         key_mapping,
         semantic_models.ImageAnalysisMethod,
+        RESULT_SUMMARY[submission.accno],
     )
 
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
@@ -10,7 +10,6 @@ from .utils import (
 from ..biostudies import (
     Submission,
     attributes_to_dict,
-    find_file_lists_in_submission,
     flist_from_flist_fname,
     file_uri,
 )

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
@@ -14,7 +14,7 @@ from ..biostudies import (
     file_uri,
 )
 from .. import biostudies  # To make reference to biostudies.File explicit
-from ..config import settings, RESULT_SUMMARY
+from ..config import settings
 from bia_shared_datamodels import bia_data_model
 
 logger = logging.getLogger('biaingest')
@@ -26,6 +26,7 @@ def get_file_reference_by_dataset(
         bia_data_model.ExperimentalImagingDataset
         | bia_data_model.ImageAnnotationDataset
     ],
+    result_summary: dict,
     persist_artefacts: bool = False,
 ) -> Dict[str, List[bia_data_model.FileReference]]:
     """
@@ -74,7 +75,7 @@ def get_file_reference_by_dataset(
             files_in_fl = flist_from_flist_fname(submission.accno, fname)
 
             file_references = get_file_reference_for_submission_dataset(
-                submission.accno, dataset, files_in_fl
+                submission.accno, dataset, files_in_fl, result_summary
             )
 
             if persist_artefacts:
@@ -94,6 +95,7 @@ def get_file_reference_for_submission_dataset(
         bia_data_model.ExperimentalImagingDataset
         | bia_data_model.ImageAnnotationDataset,
     files_in_file_list: List[biostudies.File],
+    result_summary: dict
 ) -> List[bia_data_model.FileReference]:
     """
     Return list of file references for particular submission dataset
@@ -123,6 +125,6 @@ def get_file_reference_for_submission_dataset(
         except(ValidationError):
             logger.warn(f"Failed to create FileReference")
             logger.debug("Pydantic Validation Error:", exc_info=True)
-            RESULT_SUMMARY[accession_id].FileReference_ValidationErrorCount += 1
+            result_summary[accession_id].FileReference_ValidationErrorCount += 1
 
     return file_references

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/file_reference.py
@@ -17,7 +17,7 @@ from .. import biostudies  # To make reference to biostudies.File explicit
 from ..config import settings
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_file_reference_by_dataset(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
@@ -11,10 +11,10 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('biaingest')
 
 
 def get_image_acquisition(
@@ -23,7 +23,7 @@ def get_image_acquisition(
 
     image_acquisition_model_dicts = extract_image_acquisition_dicts(submission)
     image_acquisitions = dicts_to_api_models(
-        image_acquisition_model_dicts, bia_data_model.ImageAcquisition
+        image_acquisition_model_dicts, bia_data_model.ImageAcquisition, RESULT_SUMMARY[submission.accno]
     )
 
     if persist_artefacts and image_acquisitions:
@@ -65,6 +65,9 @@ def extract_image_acquisition_dicts(submission: Submission) -> List[Dict[str, An
         )
         model_dicts.append(model_dict)
 
+    logger.info(
+        f"Ingesting: {submission.accno}. Created bia_data_model.ImageAcquisition. Count: {len(model_dicts)}"
+    )
     return model_dicts
 
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
@@ -11,19 +11,18 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
 logger = logging.getLogger('biaingest')
 
 
 def get_image_acquisition(
-    submission: Submission, persist_artefacts=False
+    submission: Submission, result_summary: dict, persist_artefacts=False
 ) -> List[bia_data_model.ImageAcquisition]:
 
     image_acquisition_model_dicts = extract_image_acquisition_dicts(submission)
     image_acquisitions = dicts_to_api_models(
-        image_acquisition_model_dicts, bia_data_model.ImageAcquisition, RESULT_SUMMARY[submission.accno]
+        image_acquisition_model_dicts, bia_data_model.ImageAcquisition, result_summary[submission.accno]
     )
 
     if persist_artefacts and image_acquisitions:

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
@@ -13,7 +13,7 @@ from ..biostudies import (
 )
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_image_acquisition(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
@@ -14,7 +14,6 @@ from .utils import (
 from ..biostudies import (
     Submission,
 )
-from ..config import RESULT_SUMMARY
 from . import (
     biosample as biosample_conversion,
     specimen_imaging_preparation_protocol as sipp_conversion,
@@ -25,7 +24,7 @@ logger = logging.getLogger('biaingest')
 
 
 def get_specimen(
-    submission: Submission, persist_artefacts: bool = False
+    submission: Submission, result_summary: dict, persist_artefacts: bool = False
 ) -> List[bia_data_model.Specimen]:
     """Create and persist bia_data_model.Specimen and models it depends on
 
@@ -41,7 +40,7 @@ def get_specimen(
     # API first before creating biosample, specimen_growth_protocol and
     # specimen_preparation_protocol?
     # Biosamples
-    biosamples = biosample_conversion.get_biosample(submission, persist_artefacts)
+    biosamples = biosample_conversion.get_biosample(submission, result_summary, persist_artefacts)
 
     # Index biosamples by title_id. Makes linking with associations more
     # straight forward.
@@ -53,7 +52,7 @@ def get_specimen(
 
     # ImagingPreparationProtocol
     imaging_preparation_protocols = sipp_conversion.get_specimen_imaging_preparation_protocol(
-        submission, persist_artefacts
+        submission, result_summary, persist_artefacts
     )
     imaging_preparation_protocol_uuids = object_value_pair_to_dict(
         imaging_preparation_protocols, key_attr="title_id", value_attr="uuid"
@@ -61,7 +60,7 @@ def get_specimen(
 
     # GrowthProtocol
     growth_protocols = sgp_conversion.get_specimen_growth_protocol(
-        submission, persist_artefacts
+        submission, result_summary, persist_artefacts
     )
     growth_protocol_uuids = object_value_pair_to_dict(
         growth_protocols, key_attr="title_id", value_attr="uuid"
@@ -106,7 +105,7 @@ def get_specimen(
         model_dict = filter_model_dictionary(model_dict, bia_data_model.Specimen)
         model_dicts.append(model_dict)
 
-    specimens = dicts_to_api_models(model_dicts, bia_data_model.Specimen, RESULT_SUMMARY[submission.accno])
+    specimens = dicts_to_api_models(model_dicts, bia_data_model.Specimen, result_summary[submission.accno])
 
     if persist_artefacts and specimens:
         persist(specimens, "specimens", submission.accno)

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
@@ -5,7 +5,6 @@ from bia_shared_datamodels import bia_data_model, semantic_models
 
 from .utils import (
     dicts_to_api_models,
-    find_sections_recursive,
     dict_to_uuid,
     persist,
     filter_model_dictionary,
@@ -14,7 +13,6 @@ from .utils import (
 )
 from ..biostudies import (
     Submission,
-    attributes_to_dict,
 )
 from ..config import RESULT_SUMMARY
 from . import (

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
@@ -16,14 +16,14 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from ..config import RESULT_SUMMARY
 from . import (
     biosample as biosample_conversion,
     specimen_imaging_preparation_protocol as sipp_conversion,
     specimen_growth_protocol as sgp_conversion,
 )
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('biaingest')
 
 
 def get_specimen(
@@ -36,7 +36,7 @@ def get_specimen(
     (specimen) GrowthProtocol.
     """
 
-    logger.info(
+    logger.debug(
         f"Starting creation of bia_shared_models.Specimen models for submission: {submission.accno}"
     )
     # ToDo - when API in operation do we attempt to retreive from
@@ -107,7 +107,8 @@ def get_specimen(
 
         model_dict = filter_model_dictionary(model_dict, bia_data_model.Specimen)
         model_dicts.append(model_dict)
-    specimens = dicts_to_api_models(model_dicts, bia_data_model.Specimen)
+
+    specimens = dicts_to_api_models(model_dicts, bia_data_model.Specimen, RESULT_SUMMARY[submission.accno])
 
     if persist_artefacts and specimens:
         persist(specimens, "specimens", submission.accno)
@@ -115,9 +116,9 @@ def get_specimen(
     # ToDo: How should we deal with situation where specimens for a
     # submission are exactly the same? E.g. see associations of S-BIAD1287
     logger.info(
-        f"Finished the creation of bia_shared_models.Specimen models for submission: {submission.accno}. {len(model_dicts)} models created."
+        f"Ingesting: {submission.accno}. Created bia_data_model.Specimen. Count: {len(model_dicts)}"
     )
-    return dicts_to_api_models(model_dicts, bia_data_model.Specimen)
+    return specimens
 
 
 def generate_specimen_uuid(specimen_dict: Dict[str, Any]) -> str:

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
@@ -20,7 +20,7 @@ from . import (
     specimen_growth_protocol as sgp_conversion,
 )
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_specimen(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
@@ -11,10 +11,10 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('biaingest')
 
 
 def get_specimen_growth_protocol(
@@ -24,7 +24,7 @@ def get_specimen_growth_protocol(
         submission
     )
     specimen_growth_protocols = dicts_to_api_models(
-        specimen_growth_protocol_model_dicts, bia_data_model.SpecimenGrowthProtocol
+        specimen_growth_protocol_model_dicts, bia_data_model.SpecimenGrowthProtocol, RESULT_SUMMARY[submission.accno]
     )
 
     if persist_artefacts and specimen_growth_protocols:
@@ -60,6 +60,10 @@ def extract_specimen_growth_protocol_dicts(
         )
 
         model_dicts.append(model_dict)
+
+    logger.info(
+        f"Ingesting: {submission.accno}. Created bia_data_model.SpecimenGrowthProtocol. Count: {len(model_dicts)}"
+    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
@@ -13,7 +13,7 @@ from ..biostudies import (
 )
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_specimen_growth_protocol(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
@@ -11,20 +11,19 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
 logger = logging.getLogger('biaingest')
 
 
 def get_specimen_growth_protocol(
-    submission: Submission, persist_artefacts=False
+    submission: Submission, result_summary: dict, persist_artefacts=False
 ) -> List[bia_data_model.SpecimenGrowthProtocol]:
     specimen_growth_protocol_model_dicts = extract_specimen_growth_protocol_dicts(
         submission
     )
     specimen_growth_protocols = dicts_to_api_models(
-        specimen_growth_protocol_model_dicts, bia_data_model.SpecimenGrowthProtocol, RESULT_SUMMARY[submission.accno]
+        specimen_growth_protocol_model_dicts, bia_data_model.SpecimenGrowthProtocol, result_summary[submission.accno]
     )
 
     if persist_artefacts and specimen_growth_protocols:

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
@@ -11,14 +11,13 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
 logger = logging.getLogger('biaingest')
 
 
 def get_specimen_imaging_preparation_protocol(
-    submission: Submission, persist_artefacts=False
+    submission: Submission, result_summary: dict, persist_artefacts=False
 ) -> List[bia_data_model.SpecimenImagingPreparationProtocol]:
     specimen_preparation_protocol_model_dicts = (
         extract_specimen_preparation_protocol_dicts(submission)
@@ -26,7 +25,7 @@ def get_specimen_imaging_preparation_protocol(
     specimen_preparation_protocols = dicts_to_api_models(
         specimen_preparation_protocol_model_dicts,
         bia_data_model.SpecimenImagingPreparationProtocol,
-        RESULT_SUMMARY[submission.accno],
+        result_summary[submission.accno],
     )
 
     if persist_artefacts and specimen_preparation_protocols:

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
@@ -13,7 +13,7 @@ from ..biostudies import (
 )
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_specimen_imaging_preparation_protocol(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
@@ -11,10 +11,10 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
+from ..config import RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('biaingest')
 
 
 def get_specimen_imaging_preparation_protocol(
@@ -26,6 +26,7 @@ def get_specimen_imaging_preparation_protocol(
     specimen_preparation_protocols = dicts_to_api_models(
         specimen_preparation_protocol_model_dicts,
         bia_data_model.SpecimenImagingPreparationProtocol,
+        RESULT_SUMMARY[submission.accno],
     )
 
     if persist_artefacts and specimen_preparation_protocols:
@@ -66,6 +67,10 @@ def extract_specimen_preparation_protocol_dicts(
         )
 
         model_dicts.append(model_dict)
+    
+    logger.info(
+        f"Ingesting: {submission.accno}. Created bia_data_model.SpecimenImagingPrepartionProtocol. Count: {len(model_dicts)}"
+    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
@@ -17,7 +17,7 @@ from ..biostudies import (
 from ..config import settings
 from bia_shared_datamodels import bia_data_model, semantic_models
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def get_study(
@@ -194,7 +194,7 @@ def get_affiliation(submission: Submission, result_summary: dict) -> Dict[str, s
             model_dict
         )        
         except(ValidationError):
-            log_failed_model_creation(semantic_models.Contributor, result_summary)
+            log_failed_model_creation(semantic_models.Affiliation, result_summary)
         
 
     return affiliation_dict
@@ -219,7 +219,7 @@ def get_publication(submission: Submission, result_summary: dict) -> List[semant
         try:
             publications.append(semantic_models.Publication.model_validate(model_dict))
         except(ValidationError):
-            log_failed_model_creation(semantic_models.Contributor, result_summary)
+            log_failed_model_creation(semantic_models.Publication, result_summary)
 
     return publications
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
@@ -12,22 +12,22 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import settings, RESULT_SUMMARY
+from ..config import settings
 from bia_shared_datamodels import bia_data_model, semantic_models
 
 logger = logging.getLogger('biaingest')
 
 
 def get_study(
-    submission: Submission, persist_artefacts: bool = False
+    submission: Submission, result_summary: dict, persist_artefacts: bool = False
 ) -> bia_data_model.Study:
     """
     Return an API study model populated from the submission
     """
 
     submission_attributes = attributes_to_dict(submission.attributes)
-    contributors = get_contributor(submission)
-    grants = get_grant(submission)
+    contributors = get_contributor(submission, result_summary)
+    grants = get_grant(submission, result_summary)
 
     study_attributes = attributes_to_dict(submission.section.attributes)
 
@@ -108,7 +108,7 @@ def get_licence(study_attributes: Dict[str, Any]) -> semantic_models.LicenceType
 
 
 def get_external_reference(
-    submission: Submission,
+    submission: Submission, RESULT_SUMMARY: dict
 ) -> List[semantic_models.ExternalReference]:
     """
     Map biostudies.Submission.Link to semantic_models.ExternalReference
@@ -132,8 +132,8 @@ def get_external_reference(
 
 
 # TODO: Put comments and docstring
-def get_grant(submission: Submission) -> List[semantic_models.Grant]:
-    funding_body_dict = get_funding_body(submission)
+def get_grant(submission: Submission, RESULT_SUMMARY: dict) -> List[semantic_models.Grant]:
+    funding_body_dict = get_funding_body(submission, RESULT_SUMMARY)
     key_mapping = [
         ("id", "grant_id", None),
     ]
@@ -150,7 +150,7 @@ def get_grant(submission: Submission) -> List[semantic_models.Grant]:
 
 
 # TODO: Put comments and docstring
-def get_funding_body(submission: Submission) -> semantic_models.FundingBody:
+def get_funding_body(submission: Submission, RESULT_SUMMARY: dict) -> semantic_models.FundingBody:
 
     key_mapping = [
         ("display_name", "Agency", None,),
@@ -161,7 +161,7 @@ def get_funding_body(submission: Submission) -> semantic_models.FundingBody:
     return funding_body
 
 
-def get_affiliation(submission: Submission) -> Dict[str, semantic_models.Affiliation]:
+def get_affiliation(submission: Submission, RESULT_SUMMARY: dict) -> Dict[str, semantic_models.Affiliation]:
     """
     Maps biostudies.Submission.Organisation sections to semantic_models.Affiliations
     """
@@ -191,7 +191,7 @@ def get_affiliation(submission: Submission) -> Dict[str, semantic_models.Affilia
     return affiliation_dict
 
 
-def get_publication(submission: Submission) -> List[semantic_models.Publication]:
+def get_publication(submission: Submission, RESULT_SUMMARY: dict) -> List[semantic_models.Publication]:
     publication_sections = find_sections_recursive(
         submission.section, ["publication",], []
     )
@@ -212,11 +212,11 @@ def get_publication(submission: Submission) -> List[semantic_models.Publication]
     return publications
 
 
-def get_contributor(submission: Submission) -> List[semantic_models.Contributor]:
+def get_contributor(submission: Submission, RESULT_SUMMARY: dict) -> List[semantic_models.Contributor]:
     """
     Map authors in submission to semantic_model.Contributors
     """
-    affiliation_dict = get_affiliation(submission)
+    affiliation_dict = get_affiliation(submission, RESULT_SUMMARY)
     key_mapping = [
         ("display_name", "Name", None),
         ("contact_email", "E-mail", "not@supplied.com"),

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
@@ -12,11 +12,10 @@ from ..biostudies import (
     Submission,
     attributes_to_dict,
 )
-from ..config import settings
+from ..config import settings, RESULT_SUMMARY
 from bia_shared_datamodels import bia_data_model, semantic_models
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('biaingest')
 
 
 def get_study(
@@ -139,7 +138,7 @@ def get_grant(submission: Submission) -> List[semantic_models.Grant]:
         ("id", "grant_id", None),
     ]
     grant_dict = get_generic_section_as_dict(
-        submission, ["Funding",], key_mapping, semantic_models.Grant
+        submission, ["Funding",], key_mapping, semantic_models.Grant, RESULT_SUMMARY[submission.accno]
     )
 
     grant_list = []
@@ -157,7 +156,7 @@ def get_funding_body(submission: Submission) -> semantic_models.FundingBody:
         ("display_name", "Agency", None,),
     ]
     funding_body = get_generic_section_as_dict(
-        submission, ["Funding",], key_mapping, semantic_models.FundingBody
+        submission, ["Funding",], key_mapping, semantic_models.FundingBody, RESULT_SUMMARY[submission.accno]
     )
     return funding_body
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
@@ -11,7 +11,8 @@ from ..biostudies import (
     Attribute,
     find_file_lists_in_submission,
 )
-from ..config import settings, ObjectValidationResult
+from ..config import settings
+from ..cli_logging import ObjectValidationResult
 
 logger = logging.getLogger('biaingest')
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
@@ -14,7 +14,7 @@ from ..biostudies import (
 from ..config import settings
 from ..cli_logging import ObjectValidationResult
 
-logger = logging.getLogger('biaingest')
+logger = logging.getLogger('__main__.'+__name__)
 
 
 def log_failed_model_creation(model_class, valdiation_error_tracking) -> None:

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import hashlib
 import uuid
 from typing import List, Any, Dict, Optional, Tuple, Type, Union
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from ..biostudies import (
     Submission,
     attributes_to_dict,
@@ -11,18 +11,16 @@ from ..biostudies import (
     Attribute,
     find_file_lists_in_submission,
 )
-from ..config import settings
+from ..config import settings, ObjectValidationResult
 
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
-
+logger = logging.getLogger('biaingest')
 
 # TODO: Put comments and docstring
 def get_generic_section_as_list(
     root: Submission | Section,
     section_name: List[str],
     key_mapping: List[Tuple[str, str, str | None | List]],
-    mapped_object: Optional[Any] = None,
+    mapped_object: Optional[BaseModel] = None,
     mapped_attrs_dict: Optional[Dict[str, Any]] = None,
 ) -> List[Any | Dict[str, str | List[str]]]:
     """
@@ -52,7 +50,8 @@ def get_generic_section_as_dict(
     root: Submission | Section,
     section_name: List[str],
     key_mapping: List[Tuple[str, str, Union[str, None, List]]],
-    mapped_object: Optional[Any] = None,
+    mapped_object: Optional[BaseModel] = None,
+    valdiation_error_tracking: Optional[ObjectValidationResult] = None,
 ) -> Dict[str, Any | Dict[str, Dict[str, str | List[str]]]]:
     """
     Map biostudies.Submission objects to dict containing either semantic_models or bia_data_model equivalent
@@ -69,7 +68,15 @@ def get_generic_section_as_dict(
         if mapped_object is None:
             return_dict[section.accno] = model_dict
         else:
-            return_dict[section.accno] = mapped_object.model_validate(model_dict)
+            if not valdiation_error_tracking:
+                raise RuntimeError("If a mapped_object is provided, valdiation_error_tracking needs to also be provided.")
+            try:
+                return_dict[section.accno] = mapped_object.model_validate(model_dict)
+            except(ValidationError):
+                logger.warn(f"Failed to create {mapped_object.__name__}")
+                logger.debug("Pydantic Validation Error:", exc_info=True)
+                field_name = f"{mapped_object.__name__}_ValidationErrorCount"
+                valdiation_error_tracking.__setattr__(field_name, valdiation_error_tracking.__getattribute__(field_name) + 1)
     return return_dict
 
 
@@ -77,13 +84,18 @@ def get_generic_section_as_dict(
 # Hence the use of the pydantic BaseModel which all API models
 # are derived from in the type hinting
 def dicts_to_api_models(
-    dicts: List[Dict[str, Any]], api_model_class: Type[BaseModel]
+    dicts: List[Dict[str, Any]], api_model_class: Type[BaseModel], valdiation_error_tracking: ObjectValidationResult
 ) -> BaseModel:
 
     api_models = []
     for model_dict in dicts:
-        api_models.append(api_model_class.model_validate(model_dict))
-
+        try:
+            api_models.append(api_model_class.model_validate(model_dict))
+        except(ValidationError):
+            logger.warn(f"Failed to create {api_model_class.__name__}")
+            logger.debug("Pydantic Validation Error:", exc_info=True)
+            field_name = f"{api_model_class.__name__}_ValidationErrorCount"
+            valdiation_error_tracking.__setattr__(field_name, valdiation_error_tracking.__getattribute__(field_name) + 1)
     return api_models
 
 
@@ -147,11 +159,11 @@ def persist(object_list: List, object_path: str, sumbission_accno: str):
     output_dir = Path(settings.bia_data_dir) / object_path / sumbission_accno
     if not output_dir.is_dir():
         output_dir.mkdir(parents=True)
-        logger.info(f"Created {output_dir}")
+        logger.debug(f"Created {output_dir}")
     for object in object_list:
         output_path = output_dir / f"{object.uuid}.json"
         output_path.write_text(object.model_dump_json(indent=2))
-        logger.info(f"Written {output_path}")
+        logger.debug(f"Written {output_path}")
 
 
 def filter_model_dictionary(dictionary: dict, target_model: Type[BaseModel]):

--- a/bia-ingest-shared-models/test/conftest.py
+++ b/bia-ingest-shared-models/test/conftest.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import json
 import pytest
 from bia_ingest_sm.biostudies import Submission
-
+from .utils import accession_id
+from bia_ingest_sm.cli_logging import ObjectValidationResult
 
 @pytest.fixture
 def base_path() -> Path:
@@ -18,3 +19,8 @@ def test_submission(base_path: Path) -> Submission:
     json_data = json.loads(submission_path.read_text())
     submission = Submission.model_validate(json_data)
     return submission
+
+
+@pytest.fixture
+def result_summary():
+    return {accession_id: ObjectValidationResult()}

--- a/bia-ingest-shared-models/test/test_file_reference.py
+++ b/bia-ingest-shared-models/test/test_file_reference.py
@@ -35,9 +35,9 @@ datasets_in_submission = [
 ]
 
 
-def test_get_file_reference_for_submission_dataset(test_submission):
-    """Test creation of FileReferences for dataset with file list supplied
-
+def test_get_file_reference_for_submission_dataset(test_submission, result_summary):
+    """
+    Test creation of FileReferences for dataset with file list supplied
     """
     file_list_data = utils.get_test_file_list_data("file_list_study_component_2.json")
     files_in_filelist = [File.model_validate(f) for f in file_list_data]
@@ -47,15 +47,17 @@ def test_get_file_reference_for_submission_dataset(test_submission):
         accession_id=test_submission.accno,
         submission_dataset=datasets_in_submission[0],
         files_in_file_list=files_in_filelist,
+        result_summary=result_summary
     )
     assert created == expected
 
 
-def test_create_file_reference_for_study_component(test_submission, caplog):
+def test_create_file_reference_for_study_component(test_submission, caplog, result_summary):
 
     expected = {datasets_in_submission[0].title_id: utils.get_test_file_reference()}
     created = file_reference.get_file_reference_by_dataset(
-        test_submission, datasets_in_submission=datasets_in_submission
+        test_submission, datasets_in_submission=datasets_in_submission, result_summary=result_summary
+
     )
     assert created == expected
 
@@ -64,7 +66,7 @@ def test_create_file_reference_for_study_component(test_submission, caplog):
 
 
 def test_create_file_reference_for_study_component_when_no_matching_sc_in_file_list(
-    test_submission, caplog
+    test_submission, caplog, result_summary
 ):
     """Test attempted creation of study FileReferences when study 
         components in dataset do not match does in file_list
@@ -73,7 +75,7 @@ def test_create_file_reference_for_study_component_when_no_matching_sc_in_file_l
     dataset = utils.get_test_experimental_imaging_dataset()[0]
     dataset.title_id = "Test name not in file list"
     created = file_reference.get_file_reference_by_dataset(
-        test_submission, datasets_in_submission=[dataset,]
+        test_submission, datasets_in_submission=[dataset,], result_summary=result_summary
     )
 
     assert created is None

--- a/bia-ingest-shared-models/test/test_shared_models.py
+++ b/bia-ingest-shared-models/test/test_shared_models.py
@@ -44,7 +44,7 @@ from bia_ingest_sm.conversion import (
         # (bia_data_model.Study, conversion.get_study_from_submission,),
     ),
 )
-def test_create_models(expected_model_func, model_creation_func, test_submission):
+def test_create_models(expected_model_func, model_creation_func, test_submission, result_summary):
     expected = expected_model_func()
-    created = model_creation_func(test_submission)
+    created = model_creation_func(test_submission, result_summary)
     assert expected == created

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -546,7 +546,7 @@ class ImageAnalysisMethod(ProtocolMixin):
     Information about image analysis methods.
     """
 
-    features_analysed: Optional[str] = Field(description="""""")
+    features_analysed: str = Field(description="""""")
 
 
 class ImageCorrelationMethod(ProtocolMixin):

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -546,7 +546,7 @@ class ImageAnalysisMethod(ProtocolMixin):
     Information about image analysis methods.
     """
 
-    features_analysed: str = Field(description="""""")
+    features_analysed: Optional[str] = Field(description="""""")
 
 
 class ImageCorrelationMethod(ProtocolMixin):


### PR DESCRIPTION
This PR adds support for running ingest and export on multiple studies at once.

bia_ingest_sm
- Make ingest CLI accept a list of accession IDs and process them all
- Moved some log statements from info to debug, and added -v option to print debug logs
- Used rich to create colour code CLI output and make a summary table

Example CLI terminal output running `poetry run biaingest ingest S-BIAD978 S-BIAD999`

![Screenshot 2024-08-19 at 12 00 07](https://github.com/user-attachments/assets/9cdc3554-af35-4eb9-b4b4-f52ff7b3ebf8)

bia_export
- create create_studies method that creates dictionary of website study json with the accession id as they keys for use in the website