### PR TITLE
Manually type ambiguous links

### DIFF
--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -173,7 +173,9 @@ class Repository:
         uuid: shared_data_models.UUID,
         doc_type: Type[shared_data_models.DocumentMixin],
     ) -> Any:
-        doc = await self._get_doc_raw(uuid=uuid)
+        doc = await self._get_doc_raw(
+            uuid=uuid, model=doc_type.get_model_metadata().model_dump()
+        )
 
         if doc is None:
             raise exceptions.DocumentNotFound("Document does not exist")
@@ -216,7 +218,8 @@ class Repository:
 
     async def _get_doc_raw(self, **kwargs) -> dict:
         doc = await self.biaint.find_one(kwargs)
-        doc.pop("_id")
+        if doc:
+            doc.pop("_id")
 
         return doc
 

--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -110,12 +110,16 @@ class Repository:
                     for dependency_uuid in getattr(
                         object_to_check, link_attribute_name
                     ):
-                        doc_dependencies.append(
-                            {
-                                "uuid": dependency_uuid,
-                                "model": link_target_type.get_model_metadata().model_dump(),
-                            }
-                        )
+                        new_dependency = {
+                            "uuid": dependency_uuid,
+                            "model": link_target_type.get_model_metadata().model_dump(),
+                        }
+                        if new_dependency in doc_dependencies:
+                            raise exceptions.DocumentNotFound(
+                                f"Field {link_attribute_name} has duplicate dependency {dependency_uuid}"
+                            )
+
+                        doc_dependencies.append(new_dependency)
                 else:
                     doc_dependencies.append(
                         {

--- a/api/api/tests/conftest.py
+++ b/api/api/tests/conftest.py
@@ -224,6 +224,67 @@ def existing_experimentally_captured_image(
 
 
 @pytest.fixture(scope="function")
+def existing_image_annotation_dataset(api_client: TestClient, existing_study: dict):
+    image_annotation_dataset = mock_object_jsonsafe(
+        mock_objects.get_image_annotation_dataset_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+    image_annotation_dataset |= {"submitted_in_study_uuid": existing_study["uuid"]}
+
+    rsp = api_client.post(
+        "private/image_annotation_dataset",
+        json=image_annotation_dataset,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return image_annotation_dataset
+
+
+@pytest.fixture(scope="function")
+def existing_annotaton_file_reference(
+    api_client: TestClient, existing_image_annotation_dataset: dict
+):
+    annotation_file_reference = mock_object_jsonsafe(
+        mock_objects.get_annotation_file_reference_dict,
+        passthrough={"completeness": mock_objects.Completeness.COMPLETE},
+    )
+    annotation_file_reference |= {
+        "submission_dataset_uuid": existing_image_annotation_dataset["uuid"],
+        "source_image_uuid": [],
+        "creation_process_uuid": [],
+    }
+
+    rsp = api_client.post(
+        "private/annotation_file_reference",
+        json=annotation_file_reference,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return annotation_file_reference
+
+
+@pytest.fixture(scope="function")
+def existing_derived_image(
+    api_client: TestClient, existing_image_annotation_dataset: dict
+):
+    derived_image = mock_object_jsonsafe(
+        mock_objects.get_derived_image_dict,
+        passthrough={"completeness": mock_objects.Completeness.MINIMAL},
+    )
+    derived_image |= {
+        "submission_dataset_uuid": existing_image_annotation_dataset["uuid"]
+    }
+
+    rsp = api_client.post(
+        "private/derived_image",
+        json=derived_image,
+    )
+    assert rsp.status_code == 201, rsp.json()
+
+    return derived_image
+
+
+@pytest.fixture(scope="function")
 def existing_image_representation(
     api_client: TestClient,
     existing_experimentally_captured_image: dict,

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -156,7 +156,7 @@ def test_known_bug_should_not_pass_but_does_union_reference_typed_lists_not_excl
     assert rsp.status_code == 201, "Fixed the bug!"
 
 
-def test_known_bug_should_not_pass_but_does_can_resolve_reverse_link_from_mistyped_parent(
+def test_cannot_resolve_reverse_union_link_from_mistyped_parent(
     api_client: TestClient,
     existing_annotaton_file_reference: dict,
     existing_experimentally_captured_image: dict,
@@ -175,11 +175,10 @@ def test_known_bug_should_not_pass_but_does_can_resolve_reverse_link_from_mistyp
     assert rsp.status_code == 201
 
     rsp = api_client.get(
-        # BUG: using an existing experimentally captured image as a derived_image (annotation_file_reference can't tell the difference)
+        # existing_experimentally_captured_image exists but is not a derived_image
         f"derived_image/{existing_experimentally_captured_image['uuid']}/annotation_file_reference",
     )
-    assert rsp.status_code == 200
-    assert rsp.json() == [existing_annotaton_file_reference]
+    assert rsp.status_code == 404
 
 
 #   TODO - When we add indices


### PR DESCRIPTION
For https://app.clickup.com/t/8695ft0bh

Ended up adding a `workaround_*` attribute to ObjectReference instead of adding manually (like in 1st commit) because that made referenced object validation a lot messier. It's relatively isolated / easy to change when we disambiguate the models (we can just search for the field)

Not sure if I should put the example in `test_known_bug_should_not_pass_but_does_union_reference_typed_lists_not_exclusive` down as a "known issue" or if it's worth fixing. I thing it also came up yesterday that we might have a usecase where we do actually want to mix the union types