### PR TITLE
Remove / fix api v1 tests failing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 **/.git
 **/.venv
 .venv
+api/src

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -38,6 +38,7 @@ jobs:
         run: |
           docker compose up -d --build 
       - name: Run tests
+        # api moved to api/ , src left in as a reference as we transition. All tests there are failing and that directory will be deleted anyway
         run: |
           docker compose run -T bia-integrator-api poetry run pytest --ignore src
       # Always cleanup - even for cancelled jobs

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -39,7 +39,7 @@ jobs:
           docker compose up -d --build 
       - name: Run tests
         run: |
-          docker compose run -T bia-integrator-api poetry run pytest
+          docker compose run -T bia-integrator-api poetry run pytest --ignore src
       # Always cleanup - even for cancelled jobs
       - name: Docker Compose Down
         run: |

--- a/.github/workflows/api_kube.yaml
+++ b/.github/workflows/api_kube.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Publish Docker"]
+    branches: [main]
+    types: 
+      - completed
 
 jobs:
   helm-lint:

--- a/api/helm-chart/Chart.yaml
+++ b/api/helm-chart/Chart.yaml
@@ -7,9 +7,9 @@ maintainers:
 
 type: application
 
-version: 0.1.0
+version: 0.2.0
 
-appVersion: "0.1.0"
+appVersion: "0.2.0"
 
 dependencies:
   - name: mongodb

--- a/api/helm-chart/templates/deployment.yaml
+++ b/api/helm-chart/templates/deployment.yaml
@@ -25,16 +25,18 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /v1/search/studies?limit=1
-              port: http
-            initialDelaySeconds: 10
-            failureThreshold: 10
-            periodSeconds: 60
+          #livenessProbe:
+          #   @TODO: Can't use a dummy uuid (404). Re-add when we have an endpoint that lists objects + pagination
+          #     this should touch the db
+          #  httpGet:
+          #    path: /v2/study/00000000-0000-0000-0000-000000000000
+          #    port: http
+          #  initialDelaySeconds: 10
+          #  failureThreshold: 10
+          #  periodSeconds: 60
           readinessProbe:
             httpGet:
-              path: /v1/openapi.json
+              path: /v2/openapi.json
               port: http
             initialDelaySeconds: 10
             failureThreshold: 10

--- a/api/helm-chart/templates/deployment.yaml
+++ b/api/helm-chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           #  periodSeconds: 60
           readinessProbe:
             httpGet:
-              path: /v2/openapi.json
+              path: /openapi.json
               port: http
             initialDelaySeconds: 10
             failureThreshold: 10

--- a/api/helm-chart/templates/tests/api_tests.yaml
+++ b/api/helm-chart/templates/tests/api_tests.yaml
@@ -16,8 +16,8 @@ spec:
   containers:
     - name: run-api-tests
       image: ghcr.io/bioimage-archive/bia-integrator-api:{{ .Values.image.tag }}
-      command: ["poetry", "run", "pytest"]
-      workingDir: /integrator-api
+      command: ["poetry", "run", "pytest", "--ignore", "src"]
+      workingDir: /bia-integrator/api
       env:
         - name: DB_NAME
           value: {{ .Values.api_env.dbName }}

--- a/api/helm-chart/templates/tests/api_tests.yaml
+++ b/api/helm-chart/templates/tests/api_tests.yaml
@@ -16,6 +16,7 @@ spec:
   containers:
     - name: run-api-tests
       image: ghcr.io/bioimage-archive/bia-integrator-api:{{ .Values.image.tag }}
+      # api moved to api/ , src left in as a reference as we transition. All tests there are failing and that directory will be deleted anyway
       command: ["poetry", "run", "pytest", "--ignore", "src"]
       workingDir: /bia-integrator/api
       env:

--- a/api/helm-chart/values.yaml
+++ b/api/helm-chart/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  tag: "0.1.0"
+  tag: "0.2.0"
   pullPolicy: IfNotPresent
 
 service:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bia-integrator-api"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = []
 readme = "README.md"


### PR DESCRIPTION
https://app.clickup.com/t/8695g4xcg

To remove the failing api tests that we have been ignoring since starting api v2 (should have probably been part of the first PR there)

So for the api now, we only run `test_minimal.py` (the tests for the new api)