### PR TITLE
added logging of creation count

### DIFF
--- a/bia-ingest-shared-models/bia_ingest_sm/cli.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli.py
@@ -14,7 +14,7 @@ from bia_ingest_sm.conversion.annotation_method import get_annotation_method
 import logging
 from rich import print
 from rich.logging import RichHandler
-from .cli_logging import tabulate_errors, ObjectValidationResult
+from .cli_logging import tabulate_errors, IngestionResult
 
 app = typer.Typer()
 
@@ -41,7 +41,7 @@ def ingest(accession_id_list: Annotated[List[str], typer.Argument()],
         print(f"[blue]-------- Starting ingest of {accession_id} --------[/blue]")
         logger.debug(f"starting ingest of {accession_id}")
 
-        result_summary[accession_id] = ObjectValidationResult()
+        result_summary[accession_id] = IngestionResult()
 
         submission = load_submission(accession_id)
 

--- a/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
@@ -61,11 +61,16 @@ def tabulate_errors(dict_of_results: dict[str, IngestionResult]) -> Table:
         if result.ExperimentalImagingDataset_CreationCount == 0 & result.ImageAnnotationDataset_CreationCount == 0:
             error_message += "No datasets were created; "
         
-        if not (result.BioSample_CreationCount == 0 & result.SpecimenImagingPreparationProtocol_CreationCount == 0 & result.ImageAcquisition_CreationCount):
-            if (result.BioSample_CreationCount == 0 | result.SpecimenImagingPreparationProtocol_CreationCount == 0 | result.ImageAcquisition_CreationCount):
-                error_message += "Incomplete REMBI objects created; "
-        else:
-            error_message += "No REMBI objects created; "
+        if result.ExperimentalImagingDataset_CreationCount > 0:
+            if not (result.BioSample_CreationCount == 0 & result.SpecimenImagingPreparationProtocol_CreationCount == 0 & result.ImageAcquisition_CreationCount):
+                if (result.BioSample_CreationCount == 0 | result.SpecimenImagingPreparationProtocol_CreationCount == 0 | result.ImageAcquisition_CreationCount):
+                    error_message += "Incomplete REMBI objects created; "
+            else:
+                error_message += "No REMBI objects associated with Dataset; "
+
+        if result.ImageAnnotationDataset_CreationCount > 0:
+            if result.AnnotationMethod_CreationCount == 0:
+                error_message += "No Annotation Method associated with Dataset; "
 
         if error_message == "":
             status = Text("Success")

--- a/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
@@ -46,6 +46,7 @@ class IngestionResult(BaseModel):
     Contributor_ValidationErrorCount: int = Field(default=0)
     Organisation_CreationCount: int = Field(default=0)
     Organisation_ValidationErrorCount: int = Field(default=0)
+    ExperimentallyCapturedImage_CreationCount: int = Field(default=0)
     ExperimentallyCapturedImage_ValidationErrorCount: int = Field(default=0)
 
 

--- a/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/cli_logging.py
@@ -3,38 +3,69 @@ from rich.text import Text
 from pydantic import BaseModel, Field
 
 
-class ObjectValidationResult(BaseModel):
-    StudyValidation_ErrorCount: int = Field(default=0)
-    ExperimentalImagingDataseta_ValidationErrorCount: int = Field(default=0)
-    AnnotationDataseta_ValidationErrorCount: int = Field(default=0)
+class IngestionResult(BaseModel):
+    Study_CreationCount: int = Field(default=0)
+    Study_ValidationErrorCount: int = Field(default=0)
+    ExperimentalImagingDataset_CreationCount: int = Field(default=0)
+    ExperimentalImagingDataset_ValidationErrorCount: int = Field(default=0)
+    AnnotationDataset_CreationCount: int = Field(default=0)
+    AnnotationDataset_ValidationErrorCount: int = Field(default=0)
+    FileReference_CreationCount: int = Field(default=0)
     FileReferenceValidation_ErrorCount: int = Field(default=0)
+    BioSample_CreationCount: int = Field(default=0)
     BioSample_ValidationErrorCount: int = Field(default=0)
+    SpecimenGrowthProtocol_CreationCount: int = Field(default=0)
     SpecimenGrowthProtocol_ValidationErrorCount: int = Field(default=0)
+    SpecimenImagingPreparationProtocol_CreationCount: int = Field(default=0)
     SpecimenImagingPreparationProtocol_ValidationErrorCount: int = Field(default=0)
+    Specimen_CreationCount: int = Field(default=0)
     Specimen_ValidationErrorCount: int = Field(default=0)
+    ImageAcquisition_CreationCount: int = Field(default=0)
+    ImageAcquisition_ValidationErrorCount: int = Field(default=0)
+    DerivedImage_CreationCount: int = Field(default=0)
     DerivedImage_ValidationErrorCount: int = Field(default=0)
+    AnnotationMethod_CreationCount: int = Field(default=0)
     AnnotationMethod_ValidationErrorCount: int = Field(default=0)
+    ImageAnnotationDataset_CreationCount: int = Field(default=0)
     ImageAnnotationDataset_ValidationErrorCount: int = Field(default=0)
+    AnnotationFile_CreationCount: int = Field(default=0)
     AnnotationFile_ValidationErrorCount: int = Field(default=0)
+    ImageAnalysisMethod_CreationCount: int = Field(default=0)
     ImageAnalysisMethod_ValidationErrorCount: int = Field(default=0)
+    ImageCorrelationMethod_CreationCount: int = Field(default=0)
     ImageCorrelationMethod_ValidationErrorCount: int = Field(default=0)
+    RenderedView_CreationCount: int = Field(default=0)
     RenderedView_ValidationErrorCount: int = Field(default=0)
+    Channel_CreationCount: int = Field(default=0)
     Channel_ValidationErrorCount: int = Field(default=0)
+    Organism_CreationCount: int = Field(default=0)
     Organism_ValidationErrorCount: int = Field(default=0)
+    ExternalLink_CreationCount: int = Field(default=0)
     ExternalLink_ValidationErrorCount: int = Field(default=0)
+    Contributor_CreationCount: int = Field(default=0)
     Contributor_ValidationErrorCount: int = Field(default=0)
+    Organisation_CreationCount: int = Field(default=0)
     Organisation_ValidationErrorCount: int = Field(default=0)
     ExperimentallyCapturedImage_ValidationErrorCount: int = Field(default=0)
 
 
-def tabulate_errors(dict_of_results: dict[str, ObjectValidationResult]) -> Table:
+def tabulate_errors(dict_of_results: dict[str, IngestionResult]) -> Table:
     table = Table("Accession ID", "Status", "Error: Count;")
-    for accession_id_key, validation_result in dict_of_results.items():
+    for accession_id_key, result in dict_of_results.items():
         error_message = ""
-        errors = validation_result.model_dump()
-        for field, value in errors.items():
-            if value > 0:
+        result_dict = result.model_dump()
+        for field, value in result_dict.items():
+            if field.endswith('ValidationErrorCount') & value > 0:
                 error_message += f"{field}: {value}; "
+
+        if result.ExperimentalImagingDataset_CreationCount == 0 & result.ImageAnnotationDataset_CreationCount == 0:
+            error_message += "No datasets were created; "
+        
+        if not (result.BioSample_CreationCount == 0 & result.SpecimenImagingPreparationProtocol_CreationCount == 0 & result.ImageAcquisition_CreationCount):
+            if (result.BioSample_CreationCount == 0 | result.SpecimenImagingPreparationProtocol_CreationCount == 0 | result.ImageAcquisition_CreationCount):
+                error_message += "Incomplete REMBI objects created; "
+        else:
+            error_message += "No REMBI objects created; "
 
         if error_message == "":
             status = Text("Success")

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
@@ -6,6 +6,7 @@ from .utils import (
     dict_to_uuid,
     persist,
     filter_model_dictionary,
+    log_model_creation_count
 )
 from ..biostudies import (
     Submission,
@@ -24,6 +25,8 @@ def get_annotation_method(
     annotation_methods = dicts_to_api_models(
         annotation_method_model_dicts, bia_data_model.AnnotationMethod, result_summary[submission.accno]
     )
+
+    log_model_creation_count(bia_data_model.AnnotationMethod, len(annotation_methods), result_summary[submission.accno])
 
     if persist_artefacts and annotation_methods:
         persist(annotation_methods, "annotation_methods", submission.accno)
@@ -73,11 +76,6 @@ def extract_annotation_method_dicts(submission: Submission) -> List[Dict[str, An
         )
 
         model_dicts.append(model_dict)
-
-
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.AnnotationMethod. Count: {len(model_dicts)}"
-    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/biosample.py
@@ -6,6 +6,7 @@ from .utils import (
     dict_to_uuid,
     persist,
     filter_model_dictionary,
+    log_model_creation_count
 )
 from ..biostudies import (
     Submission,
@@ -22,6 +23,8 @@ def get_biosample(
 
     biosample_model_dicts = extract_biosample_dicts(submission)
     biosamples = dicts_to_api_models(biosample_model_dicts, bia_data_model.BioSample, result_summary[submission.accno])
+
+    log_model_creation_count(bia_data_model.BioSample, len(biosamples), result_summary[submission.accno])
 
     if persist_artefacts and biosamples:
         persist(biosamples, "biosamples", submission.accno)
@@ -77,11 +80,6 @@ def extract_biosample_dicts(submission: Submission) -> List[Dict[str, Any]]:
         model_dict["version"] = 1
         model_dict = filter_model_dictionary(model_dict, bia_data_model.BioSample)
         model_dicts.append(model_dict)
-
-
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.BioSample. Count: {len(model_dicts)}"
-    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimental_imaging_dataset.py
@@ -7,7 +7,8 @@ from .utils import (
     get_generic_section_as_dict,
     persist,
     filter_model_dictionary,
-    log_failed_model_creation
+    log_failed_model_creation,
+    log_model_creation_count
 )
 import bia_ingest_sm.conversion.study as study_conversion
 from ..biostudies import (
@@ -116,9 +117,7 @@ def get_experimental_imaging_dataset(
             log_failed_model_creation(bia_data_model.ExperimentalImagingDataset, result_summary[submission.accno])
 
 
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.ExperimentalImagingDataset. Count: {len(experimental_imaging_dataset)}"
-    )
+    log_model_creation_count(bia_data_model.ExperimentalImagingDataset, len(experimental_imaging_dataset), result_summary[submission.accno])
 
     if persist_artefacts and experimental_imaging_dataset:
         persist(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/experimentally_captured_image.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/experimentally_captured_image.py
@@ -78,7 +78,7 @@ def get_all_experimentally_captured_images(
 
         # TODO: revisit this once API up
         subject_uuid = get_specimen_for_association(
-            submission, dataset.attribute["associations"][0]
+            submission, dataset.attribute["associations"][0], result_summary
         ).uuid
 
         for file_in_fl in files_in_fl:
@@ -136,7 +136,7 @@ def get_experimentally_captured_image(
         ia.uuid for ia in image_acquisitions if ia.title_id in image_acquisition_title
     ]
     subject_uuid = get_specimen_for_association(
-        submission, dataset.attribute["associations"][0]
+        submission, dataset.attribute["associations"][0], result_summary
     ).uuid
 
     model_dict = prepare_experimentally_captured_image_dict(

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/image_acquisition.py
@@ -6,6 +6,7 @@ from .utils import (
     dict_to_uuid,
     persist,
     filter_model_dictionary,
+    log_model_creation_count
 )
 from ..biostudies import (
     Submission,
@@ -24,6 +25,8 @@ def get_image_acquisition(
     image_acquisitions = dicts_to_api_models(
         image_acquisition_model_dicts, bia_data_model.ImageAcquisition, result_summary[submission.accno]
     )
+    
+    log_model_creation_count(bia_data_model.ImageAcquisition, len(image_acquisitions), result_summary[submission.accno])
 
     if persist_artefacts and image_acquisitions:
         persist(image_acquisitions, "image_acquisitions", submission.accno)
@@ -64,9 +67,6 @@ def extract_image_acquisition_dicts(submission: Submission) -> List[Dict[str, An
         )
         model_dicts.append(model_dict)
 
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.ImageAcquisition. Count: {len(model_dicts)}"
-    )
     return model_dicts
 
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/image_annotation_dataset.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/image_annotation_dataset.py
@@ -6,6 +6,7 @@ from .utils import (
     dict_to_uuid,
     persist,
     filter_model_dictionary,
+    log_model_creation_count
 )
 import bia_ingest_sm.conversion.study as study_conversion
 from ..biostudies import (
@@ -26,6 +27,8 @@ def get_image_annotation_dataset(
     image_annotation_datasets = dicts_to_api_models(
         iad_model_dicts, bia_data_model.ImageAnnotationDataset, result_summary[submission.accno]
     )
+
+    log_model_creation_count(bia_data_model.ImageAnnotationDataset, len(image_annotation_datasets), result_summary[submission.accno])
 
     if persist_artefacts and image_annotation_datasets:
         persist(image_annotation_datasets, "image_annotation_datasets", submission.accno)
@@ -62,11 +65,6 @@ def extract_image_annotation_dataset_method_dicts(submission: Submission) -> Lis
         )
 
         model_dicts.append(model_dict)
-
-
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.ImageAnnotationDataset. Count: {len(model_dicts)}"
-    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
@@ -27,11 +27,10 @@ logger = logging.getLogger("__main__." + __name__)
 # TODO: Should we make this per image?
 # TODO: Need to change according to https://app.clickup.com/t/8695fqxpy
 def get_specimen_for_association(
-    submission: Submission, association: Dict[str, str]
+    submission: Submission, association: Dict[str, str],  result_summary: dict 
 ) -> bia_data_model.Specimen:
     """Return bia_data_model.Specimen for a particular dataset"""
 
-    result_summary = {submission.accno: []}
     specimen_title = association["specimen"]
 
     biosamples = biosample_conversion.get_biosample(submission, result_summary)
@@ -186,7 +185,7 @@ def get_specimen(
         model_dicts, bia_data_model.Specimen, result_summary[submission.accno]
     )
 
-    log_model_creation_count(bia_data_model.SpecimenImagingPreparationProtocol, len(specimens), result_summary[submission.accno])
+    log_model_creation_count(bia_data_model.Specimen, len(specimens), result_summary[submission.accno])
 
     if persist_artefacts and specimens:
         persist(specimens, "specimens", submission.accno)

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen.py
@@ -10,6 +10,7 @@ from .utils import (
     filter_model_dictionary,
     get_generic_section_as_list,
     object_value_pair_to_dict,
+    log_model_creation_count
 )
 from ..biostudies import (
     Submission,
@@ -185,14 +186,14 @@ def get_specimen(
         model_dicts, bia_data_model.Specimen, result_summary[submission.accno]
     )
 
+    log_model_creation_count(bia_data_model.SpecimenImagingPreparationProtocol, len(specimens), result_summary[submission.accno])
+
     if persist_artefacts and specimens:
         persist(specimens, "specimens", submission.accno)
 
     # ToDo: How should we deal with situation where specimens for a
     # submission are exactly the same? E.g. see associations of S-BIAD1287
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.Specimen. Count: {len(model_dicts)}"
-    )
+
     return specimens
 
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_growth_protocol.py
@@ -6,6 +6,7 @@ from .utils import (
     dict_to_uuid,
     persist,
     filter_model_dictionary,
+    log_model_creation_count
 )
 from ..biostudies import (
     Submission,
@@ -25,6 +26,8 @@ def get_specimen_growth_protocol(
     specimen_growth_protocols = dicts_to_api_models(
         specimen_growth_protocol_model_dicts, bia_data_model.SpecimenGrowthProtocol, result_summary[submission.accno]
     )
+
+    log_model_creation_count(bia_data_model.SpecimenGrowthProtocol, len(specimen_growth_protocols), result_summary[submission.accno])
 
     if persist_artefacts and specimen_growth_protocols:
         persist(
@@ -59,10 +62,6 @@ def extract_specimen_growth_protocol_dicts(
         )
 
         model_dicts.append(model_dict)
-
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.SpecimenGrowthProtocol. Count: {len(model_dicts)}"
-    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/specimen_imaging_preparation_protocol.py
@@ -6,6 +6,7 @@ from .utils import (
     dict_to_uuid,
     persist,
     filter_model_dictionary,
+    log_model_creation_count
 )
 from ..biostudies import (
     Submission,
@@ -27,6 +28,8 @@ def get_specimen_imaging_preparation_protocol(
         bia_data_model.SpecimenImagingPreparationProtocol,
         result_summary[submission.accno],
     )
+
+    log_model_creation_count(bia_data_model.SpecimenImagingPreparationProtocol, len(specimen_preparation_protocols), result_summary[submission.accno])
 
     if persist_artefacts and specimen_preparation_protocols:
         persist(
@@ -66,10 +69,6 @@ def extract_specimen_preparation_protocol_dicts(
         )
 
         model_dicts.append(model_dict)
-    
-    logger.info(
-        f"Ingesting: {submission.accno}. Created bia_data_model.SpecimenImagingPrepartionProtocol. Count: {len(model_dicts)}"
-    )
 
     return model_dicts
 

--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/study.py
@@ -66,12 +66,10 @@ def get_study(
         "attribute": study_attributes,
         "version": 1,
     }
-    # study_uuid = dict_to_uuid(study_dict, ["accession_id",])
-    # study_dict["uuid"] = study_uuid
     try:
         study = bia_data_model.Study.model_validate(study_dict)
     except(ValidationError):
-            log_failed_model_creation(bia_data_model.Study, result_summary[submission.accno])
+        log_failed_model_creation(bia_data_model.Study, result_summary[submission.accno])
 
     if persist_artefacts:
         output_dir = Path(settings.bia_data_dir) / "studies"

--- a/bia-ingest-shared-models/test/conftest.py
+++ b/bia-ingest-shared-models/test/conftest.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from bia_ingest_sm.biostudies import Submission, requests
 from .utils import accession_id
-from bia_ingest_sm.cli_logging import ObjectValidationResult
+from bia_ingest_sm.cli_logging import IngestionResult
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def test_submission(base_path: Path) -> Submission:
 
 @pytest.fixture
 def result_summary():
-    return {accession_id: ObjectValidationResult()}
+    return {accession_id: IngestionResult()}
 
 
 @pytest.fixture


### PR DESCRIPTION
We currently only tabulate errors when some object fails pydantic model validation. If we e.g. just don't create any dataset objects this counts as a success.

I thought it would be useful to track how many objects get created, and flag when unexpected values crop up.

E.g. run:
```
poetry run biaingest ingest S-BIAD534   
```

And you should get: 


```
-------- Starting ingest of S-BIAD534 --------
INFO     Fetching submission from https://www.ebi.ac.uk/biostudies/api/v1/studies/S-BIAD534                                                                            biostudies.py:140
INFO     Written /Users/fsherwood/.cache/bia-integrator-data-sm/studies/S-BIAD534.json                                                                                       study.py:81
INFO     Created ExperimentalImagingDataset. Count: 2                                                                                                                        utils.py:27
INFO     Created ImageAnnotationDataset. Count: 0                                                                                                                            utils.py:27
INFO     Fetching file list from https://www.ebi.ac.uk/biostudies/files/S-BIAD534/ImageData_FileList.json                                                              biostudies.py:218
INFO     Fetching file list from https://www.ebi.ac.uk/biostudies/files/S-BIAD534/2DProjections_FileList.json                                                          biostudies.py:218
INFO     Created ImageAcquisition. Count: 0                                                                                                                                  utils.py:27
INFO     Created BioSample. Count: 0                                                                                                                                         utils.py:27
INFO     Created SpecimenImagingPreparationProtocol. Count: 0                                                                                                                utils.py:27
INFO     Created SpecimenGrowthProtocol. Count: 0                                                                                                                            utils.py:27
INFO     Created SpecimenImagingPreparationProtocol. Count: 0                                                                                                                utils.py:27
INFO     Created AnnotationMethod. Count: 0                                                                                                                                  utils.py:27
-------- Completed ingest of S-BIAD534 --------
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Accession ID ┃ Status   ┃ Error: Count;                              ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ S-BIAD534    │ Failures │ No REMBI objects associated with Dataset;  │
└──────────────┴──────────┴────────────────────────────────────────────┘


```