### PR TITLE
None defaults for optional annotation fields

### DIFF
--- a/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/conversion/annotation_method.py
@@ -38,8 +38,8 @@ def extract_annotation_method_dicts(submission: Submission) -> List[Dict[str, An
 
     key_mapping = [
         ("title_id", "Title", ""),
-        ("annotation_criteria", "Annotation Criteria", ""),
-        ("annotation_coverage", "Annotation Coverage", ""),
+        ("annotation_criteria", "Annotation Criteria", None),
+        ("annotation_coverage", "Annotation Coverage", None),
     ]
 
     model_dicts = []

--- a/bia-ingest-shared-models/test/utils.py
+++ b/bia-ingest-shared-models/test/utils.py
@@ -142,7 +142,7 @@ def get_test_annotation_method() -> List[bia_data_model.AnnotationMethod]:
             "title_id": "Segmentation masks",
             "protocol_description": "Test annotation overview 1",
             "annotation_criteria": "Test annotation criteria 1",
-            "annotation_coverage": "",
+            "annotation_coverage": None,
             "method_type": "other",
             "source_dataset": [],
             "version": 1,


### PR DESCRIPTION
Changed the default to None for some optional fields since we should always return 'null' in json for these and never "" 