### PR TITLE
Fix db params exposed through api

### DIFF
--- a/api/api/app.py
+++ b/api/api/app.py
@@ -4,18 +4,9 @@ from api import auth
 
 from api.models.repository import repository_create, Repository
 
-from fastapi import FastAPI
-from typing import AsyncGenerator
+from fastapi import FastAPI, Depends
 
 from api.api_logging import log_info
-
-
-async def repository_dependency() -> AsyncGenerator[Repository, None]:
-    db = await repository_create(init=False)
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 app = FastAPI(
@@ -41,5 +32,12 @@ def on_start():
     log_info("App stopped")
 
 
-app.include_router(public.make_router(), prefix="/v2")
-app.include_router(private.make_router(), prefix="/v2")
+app.include_router(
+    public.make_router(),
+    prefix="/v2",
+)
+app.include_router(
+    private.make_router(),
+    prefix="/v2",
+    dependencies=[Depends(auth.get_current_user)],
+)

--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -12,7 +12,7 @@ from typing import Optional
 import uuid
 
 from api import constants
-from api.models.repository import Repository
+from api.models.repository import Repository, get_db
 from api.models.persistence import User
 from api.models.api import AuthenticationToken, TokenData, AuthResult
 import os
@@ -88,7 +88,8 @@ def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None
 
 
 async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)], db: Repository = Depends()
+    token: Annotated[str, Depends(oauth2_scheme)],
+    db: Annotated[Repository, Depends(get_db)],
 ):
     validate_secret_token(JWT_SECRET_KEY)
 
@@ -115,7 +116,7 @@ async def get_current_user(
 @router.post("/token", response_model=AuthenticationToken)
 async def login_for_access_token(
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
-    db: Repository = Depends(),
+    db: Annotated[Repository, Depends(get_db)],
 ) -> AuthResult:
     user = await authenticate_user(db, form_data.username, form_data.password)
     if not user:
@@ -138,7 +139,7 @@ async def register_user(
     email: Annotated[str, Body()],
     password_plain: Annotated[str, Body()],
     secret_token: Annotated[str, Body()],
-    db: Repository = Depends(),
+    db: Annotated[Repository, Depends(get_db)],
 ) -> None:
     user_create_token = os.environ["USER_CREATE_SECRET_TOKEN"]
     validate_secret_token(user_create_token)

--- a/api/api/private.py
+++ b/api/api/private.py
@@ -2,16 +2,12 @@ from fastapi import APIRouter
 from pydantic.alias_generators import to_snake
 
 import bia_shared_datamodels.bia_data_model as shared_data_models
-from api.models.repository import Repository
-from api import constants, auth
+from api.models.repository import Repository, get_db
+from api import constants
 from fastapi import APIRouter, Depends, status
-from typing import List, Type
+from typing import List, Type, Annotated
 
-router = APIRouter(
-    prefix="/private",
-    dependencies=[Depends(auth.get_current_user)],
-    tags=[constants.OPENAPI_TAG_PRIVATE],
-)
+router = APIRouter(prefix="/private", tags=[constants.OPENAPI_TAG_PRIVATE])
 models_private: List[shared_data_models.DocumentMixin] = [
     shared_data_models.Study,
     shared_data_models.FileReference,
@@ -31,7 +27,7 @@ models_private: List[shared_data_models.DocumentMixin] = [
 
 
 def make_post_item(t: Type[shared_data_models.DocumentMixin]):
-    async def post_item(doc: t, db: Repository = Depends()) -> None:
+    async def post_item(doc: t, db: Annotated[Repository, Depends(get_db)]) -> None:
         if doc.version < 0:
             raise ValueError("Bad doc version")
 

--- a/api/api/public.py
+++ b/api/api/public.py
@@ -3,9 +3,9 @@ from pydantic.alias_generators import to_snake
 
 # ?
 import bia_shared_datamodels.bia_data_model as shared_data_models
-from api.models.repository import Repository
+from api.models.repository import Repository, get_db
 from api import constants
-from typing import List, Type
+from typing import List, Type, Annotated
 
 router = APIRouter(
     prefix="",
@@ -34,7 +34,9 @@ def make_get_item(t: Type[shared_data_models.DocumentMixin]):
     # https://eev.ee/blog/2011/04/24/gotcha-python-scoping-closures/
 
     # @TODO: nicer wrapper?
-    async def get_item(uuid: shared_data_models.UUID, db: Repository = Depends()) -> t:
+    async def get_item(
+        uuid: shared_data_models.UUID, db: Annotated[Repository, Depends(get_db)]
+    ) -> t:
         return await db.get_doc(uuid, t)
 
     return get_item
@@ -46,7 +48,7 @@ def make_reverse_link_handler(
     target_type: Type[shared_data_models.DocumentMixin],
 ):
     async def get_descendents(
-        uuid: shared_data_models.UUID, db: Repository = Depends()
+        uuid: shared_data_models.UUID, db: Annotated[Repository, Depends(get_db)]
     ) -> List[source_type]:
         # Check target document actually exists (and is typed correctly - esp. important for union-typed links)
         #   see workaround_union_reference_types

--- a/api/api/tests/test_minimal.py
+++ b/api/api/tests/test_minimal.py
@@ -264,7 +264,8 @@ def test_db_timeout():
     loop = asyncio.get_event_loop()
 
     async def large_query():
-        db = Repository(db_timeout_ms=5)
+        db = Repository()
+        db.configure(db_timeout_ms=5)
 
         await db._get_docs_raw()
 


### PR DESCRIPTION
https://app.clickup.com/t/8695mu9k9

Looks like get_db defined previously was never actually used, and fastapi was DI-ing a new instance of Repository (-> the exposed params). Changed how we request db instances in handlers + small change&comment to Repository to make this harder to misconfigure in the future