### PR TITLE
Export to use Client Models

### DIFF
--- a/bia-export/bia_export/website_export/datasets_for_images/models.py
+++ b/bia-export/bia_export/website_export/datasets_for_images/models.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-from bia_shared_datamodels import bia_data_model
+from bia_integrator_api import models
 from pydantic import Field
 
 
-class ExperimentalImagingDataset(bia_data_model.ExperimentalImagingDataset):
-    submitted_in_study: bia_data_model.Study = Field()
-
-
-class ExperimentalImagingDataset(bia_data_model.ExperimentalImagingDataset):
-    submitted_in_study: bia_data_model.Study = Field()
+class ExperimentalImagingDataset(models.ExperimentalImagingDataset):
+    submitted_in_study: models.Study = Field()

--- a/bia-export/bia_export/website_export/datasets_for_images/retrieve.py
+++ b/bia-export/bia_export/website_export/datasets_for_images/retrieve.py
@@ -1,7 +1,8 @@
 from bia_export.website_export.utils import read_all_json, read_api_json_file
 from bia_export.website_export.website_models import CLIContext
 from bia_export.bia_client import api_client
-from bia_shared_datamodels import bia_data_model
+from bia_integrator_api import models as api_models
+
 from typing import List
 import logging
 
@@ -10,13 +11,13 @@ logger = logging.getLogger("__main__." + __name__)
 
 def retrieve_datasets(
     context: CLIContext,
-) -> List[bia_data_model.ExperimentalImagingDataset]:
+) -> List[api_models.ExperimentalImagingDataset]:
     if context.root_directory:
         dataset_path = context.root_directory.joinpath(
             f"experimental_imaging_datasets/{context.accession_id}/*.json"
         )
         api_datasets = read_all_json(
-            dataset_path, bia_data_model.ExperimentalImagingDataset
+            dataset_path, api_models.ExperimentalImagingDataset
         )
     else:
         api_datasets = api_client.get_experimental_imaging_dataset_in_study(
@@ -26,12 +27,12 @@ def retrieve_datasets(
     return api_datasets
 
 
-def retrieve_study(context: CLIContext) -> bia_data_model.Study:
+def retrieve_study(context: CLIContext) -> api_models.Study:
     if context.root_directory:
         study_path = context.root_directory.joinpath(
             f"studies/{context.accession_id}.json"
         )
-        study = read_api_json_file(study_path, bia_data_model.Study)
+        study = read_api_json_file(study_path, api_models.Study)
     else:
         study = api_client.get_study(str(context.study_uuid))
 

--- a/bia-export/bia_export/website_export/datasets_for_images/transform.py
+++ b/bia-export/bia_export/website_export/datasets_for_images/transform.py
@@ -1,5 +1,3 @@
-from typing import List, Type
-from bia_shared_datamodels import bia_data_model
 from bia_export.website_export.images.models import (
     ExperimentalImagingDataset,
 )

--- a/bia-export/bia_export/website_export/images/models.py
+++ b/bia-export/bia_export/website_export/images/models.py
@@ -1,37 +1,43 @@
 from __future__ import annotations
 
-from bia_shared_datamodels import bia_data_model
+from bia_integrator_api import models
 from pydantic import Field
-from ..website_models import CLIContext
+from ..website_models import (
+    CLIContext,
+    SpecimenGrowthProtocol,
+    SpecimenImagingPreparationProtocol,
+    BioSample,
+    ImageAcquisition,
+)
 from typing import List, Optional
 
 
-class ExperimentalImagingDataset(bia_data_model.ExperimentalImagingDataset):
-    submitted_in_study: bia_data_model.Study = Field(
+class ExperimentalImagingDataset(models.ExperimentalImagingDataset):
+    submitted_in_study: models.Study = Field(
         description="""The study the dataset was submitted in."""
     )
 
 
-class Specimen(bia_data_model.Specimen):
-    imaging_preparation_protocol: List[
-        bia_data_model.SpecimenImagingPreparationProtocol
-    ] = Field(description="""How the biosample was prepared for imaging.""")
-    sample_of: List[bia_data_model.BioSample] = Field(
+class Specimen(models.Specimen):
+    imaging_preparation_protocol: List[SpecimenImagingPreparationProtocol] = Field(
+        description="""How the biosample was prepared for imaging."""
+    )
+    sample_of: List[BioSample] = Field(
         description="""The biological matter that sampled to create the specimen."""
     )
-    growth_protocol: List[bia_data_model.SpecimenGrowthProtocol] = Field(
+    growth_protocol: List[SpecimenGrowthProtocol] = Field(
         description="""How the specimen was grown, e.g. cell line cultures, crosses or plant growth.""",
     )
 
 
-class ExperimentallyCapturedImage(bia_data_model.ExperimentallyCapturedImage):
-    acquisition_process: List[bia_data_model.ImageAcquisition] = Field(
+class ExperimentallyCapturedImage(models.ExperimentallyCapturedImage):
+    acquisition_process: List[ImageAcquisition] = Field(
         description="""The processes involved in the creation of the image."""
     )
     subject: Specimen = Field(
         description="""The specimen that was prepared for and captured in the field of view of the image."""
     )
-    representation: Optional[List[bia_data_model.ImageRepresentation]] = Field(
+    representation: Optional[List[models.ImageRepresentation]] = Field(
         default_factory=list,
         description="""The concrete image representations of the image.""",
     )

--- a/bia-export/bia_export/website_export/images/transform.py
+++ b/bia-export/bia_export/website_export/images/transform.py
@@ -1,5 +1,5 @@
 from typing import List, Type
-from bia_shared_datamodels import bia_data_model
+from bia_integrator_api import models as api_models
 from pydantic import BaseModel
 from bia_export.website_export.images.models import (
     ExperimentallyCapturedImage,
@@ -39,11 +39,11 @@ def transform_ec_images(context: ImageCLIContext) -> ExperimentallyCapturedImage
 
 
 def transform_image(
-    api_image: bia_data_model.ExperimentallyCapturedImage, context: ImageCLIContext
+    api_image: api_models.ExperimentallyCapturedImage, context: ImageCLIContext
 ) -> ExperimentallyCapturedImage:
     website_fields = {}
     api_image_acquisitions = retrieve_object_list(
-        api_image.acquisition_process_uuid, bia_data_model.ImageAcquisition, context
+        api_image.acquisition_process_uuid, api_models.ImageAcquisition, context
     )
 
     website_fields["acquisition_process"] = transform_details_object_list(
@@ -52,16 +52,16 @@ def transform_image(
 
     api_specimen = retrieve_specimen(api_image.subject_uuid, context)
     api_biosamples = retrieve_object_list(
-        api_specimen.sample_of_uuid, bia_data_model.BioSample, context
+        api_specimen.sample_of_uuid, api_models.BioSample, context
     )
     api_specimen_growth_protocols = retrieve_object_list(
         api_specimen.growth_protocol_uuid,
-        bia_data_model.SpecimenGrowthProtocol,
+        api_models.SpecimenGrowthProtocol,
         context,
     )
     api_specimen_imaging_preparation_protocols = retrieve_object_list(
         api_specimen.imaging_preparation_protocol_uuid,
-        bia_data_model.SpecimenImagingPreparationProtocol,
+        api_models.SpecimenImagingPreparationProtocol,
         context,
     )
 

--- a/bia-export/bia_export/website_export/studies/models.py
+++ b/bia-export/bia_export/website_export/studies/models.py
@@ -7,8 +7,8 @@ from bia_export.website_export.website_models import (
     SpecimenImagingPreparationProtocol,
     CLIContext,
 )
+from bia_integrator_api import models
 
-from bia_shared_datamodels import bia_data_model
 from pydantic import BaseModel, Field
 
 
@@ -24,7 +24,7 @@ class ImageDataset(BaseModel):
 
 
 class ExperimentalImagingDataset(
-    bia_data_model.ExperimentalImagingDataset, ImageDataset
+    models.ExperimentalImagingDataset, ImageDataset
 ):
     acquisition_process: List[ImageAcquisition] = Field(
         description="""Processes involved in the creation of the images and files in this dataset."""
@@ -41,23 +41,23 @@ class ExperimentalImagingDataset(
         default_factory=list,
         description="""Processes involved in the growth of the samples that were then imaged.""",
     )
-    image: List[bia_data_model.ExperimentallyCapturedImage] = Field(
+    image: List[models.ExperimentallyCapturedImage] = Field(
         default_factory=list,
         description="List of image associated with the dataset.",
     )
 
 
-class ImageAnnotationDataset(bia_data_model.ImageAnnotationDataset, ImageDataset):
-    annotation_method: List[bia_data_model.AnnotationMethod] = Field(
+class ImageAnnotationDataset(models.ImageAnnotationDataset, ImageDataset):
+    annotation_method: List[models.AnnotationMethod] = Field(
         description="""The process(es) that were performed to create the annotated data."""
     )
-    image: List[bia_data_model.DerivedImage] = Field(
+    image: List[models.DerivedImage] = Field(
         default_factory=list,
         description="List of image associated with the dataset.",
     )
 
 
-class Study(bia_data_model.Study):
+class Study(models.Study):
     experimental_imaging_component: Optional[List[ExperimentalImagingDataset]] = Field(
         default_factory=list,
         description="""An experimental imaging dataset of that is associated with the study.""",

--- a/bia-export/bia_export/website_export/studies/transform.py
+++ b/bia-export/bia_export/website_export/studies/transform.py
@@ -23,9 +23,7 @@ from bia_export.website_export.website_models import (
     SpecimenGrowthProtocol,
     SpecimenImagingPreparationProtocol,
 )
-
-
-from bia_shared_datamodels import bia_data_model
+from bia_integrator_api import models as api_models
 import logging
 
 logger = logging.getLogger("__main__." + __name__)
@@ -68,7 +66,7 @@ def transform_experimental_imaging_datasets(
 
 
 def transform_experimental_imaging_dataset(
-    api_dataset: bia_data_model.ExperimentalImagingDataset,
+    api_dataset: api_models.ExperimentalImagingDataset,
     context: StudyCLIContext,
 ) -> ExperimentalImagingDataset:
 
@@ -80,7 +78,7 @@ def transform_experimental_imaging_dataset(
     dataset_dict = dataset_dict | retrieve_aggregation_fields(api_dataset, context)
 
     dataset_api_images = retrieve_dataset_images(
-        api_dataset.uuid, bia_data_model.ExperimentallyCapturedImage, context
+        api_dataset.uuid, api_models.ExperimentallyCapturedImage, context
     )
     dataset_dict = dataset_dict | {"image": dataset_api_images}
 
@@ -89,32 +87,32 @@ def transform_experimental_imaging_dataset(
 
 
 def transform_dataset_detail_objects(
-    dataset: bia_data_model.ExperimentalImagingDataset, context: StudyCLIContext
+    dataset: api_models.ExperimentalImagingDataset, context: StudyCLIContext
 ):
 
     detail_map = {
         "acquisition_process": {
             "source_directory": "image_acquisitions",
             "association_field": "image_acquisition",
-            "bia_type": bia_data_model.ImageAcquisition,
+            "bia_type": api_models.ImageAcquisition,
             "website_type": ImageAcquisition,
         },
         "biological_entity": {
             "source_directory": "biosamples",
             "association_field": "biosample",
-            "bia_type": bia_data_model.BioSample,
+            "bia_type": api_models.BioSample,
             "website_type": BioSample,
         },
         "specimen_imaging_preparation_protocol": {
             "source_directory": "specimen_imaging_preparation_protocols",
             "association_field": "specimen",
-            "bia_type": bia_data_model.SpecimenImagingPreparationProtocol,
+            "bia_type": api_models.SpecimenImagingPreparationProtocol,
             "website_type": SpecimenImagingPreparationProtocol,
         },
         "specimen_growth_protocol": {
             "source_directory": "specimen_growth_protocols",
             "association_field": "specimen",
-            "bia_type": bia_data_model.SpecimenGrowthProtocol,
+            "bia_type": api_models.SpecimenGrowthProtocol,
             "website_type": SpecimenGrowthProtocol,
         },
     }
@@ -163,7 +161,7 @@ def transform_image_annotation_datasets(
 
 
 def transform_image_annotatation_dataset(
-    api_dataset: bia_data_model.ImageAnnotationDataset, context: StudyCLIContext
+    api_dataset: api_models.ImageAnnotationDataset, context: StudyCLIContext
 ) -> ImageAnnotationDataset:
     dataset_dict = api_dataset.model_dump()
 
@@ -172,7 +170,7 @@ def transform_image_annotatation_dataset(
     dataset_dict = dataset_dict | retrieve_aggregation_fields(api_dataset, context)
 
     dataset_api_images = retrieve_dataset_images(
-        api_dataset.uuid, bia_data_model.DerivedImage, context
+        api_dataset.uuid, api_models.DerivedImage, context
     )
     dataset_dict = dataset_dict | {"image": dataset_api_images}
 

--- a/bia-export/test/input_data/experimental_imaging_datasets/S-BIADTEST/47a4ab60-c76d-4424-bfaa-c2a024de720c.json
+++ b/bia-export/test/input_data/experimental_imaging_datasets/S-BIADTEST/47a4ab60-c76d-4424-bfaa-c2a024de720c.json
@@ -25,5 +25,9 @@
     "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71",
     "correlation_method": [],
     "example_image_uri": [],
-    "version": 1
+    "version": 1,
+    "model": {
+        "type_name": "ExperimentalImagingDataset",
+        "version": 1
+    }
 }

--- a/bia-export/test/output_data/bia_image_export.json
+++ b/bia-export/test/output_data/bia_image_export.json
@@ -14,6 +14,7 @@
         "subject_uuid": "dcc18482-fa1a-468f-878f-c00f9cd46376",
         "acquisition_process": [
             {
+                "default_open": true,
                 "title_id": "Test Primary Screen Image Acquisition",
                 "uuid": "c2e44a1b-a43c-476e-8ddf-8587f4c955b3",
                 "version": 1,
@@ -47,6 +48,7 @@
             ],
             "imaging_preparation_protocol": [
                 {
+                    "default_open": true,
                     "title_id": "Test specimen 1",
                     "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
                     "version": 1,
@@ -60,6 +62,7 @@
             ],
             "sample_of": [
                 {
+                    "default_open": true,
                     "title_id": "Test Biosample 1",
                     "uuid": "64a67727-4e7c-469a-91c4-6219ae072e99",
                     "version": 1,
@@ -88,6 +91,7 @@
             ],
             "growth_protocol": [
                 {
+                    "default_open": true,
                     "title_id": "Test specimen 1",
                     "uuid": "a2ce3950-3b28-40b3-a6a5-23c4f7864912",
                     "version": 1,
@@ -108,14 +112,13 @@
                     "version": 1
                 },
                 "image_format": "Template image format",
-                "use_type": "INTERACTIVE_DISPLAY",
                 "file_uri": [
                     "https://dummy.uri.org"
                 ],
                 "total_size_in_bytes": 0,
-                "physical_size_x": 1.0,
-                "physical_size_y": 1.0,
-                "physical_size_z": 1.0,
+                "physical_size_x": 1,
+                "physical_size_y": 1,
+                "physical_size_z": 1,
                 "size_x": 1,
                 "size_y": 1,
                 "size_z": 1,
@@ -134,14 +137,13 @@
                     "version": 1
                 },
                 "image_format": "Template image format",
-                "use_type": "UPLOADED_BY_SUBMITTER",
                 "file_uri": [
                     "https://dummy.uri.org"
                 ],
                 "total_size_in_bytes": 0,
-                "physical_size_x": 1.0,
-                "physical_size_y": 1.0,
-                "physical_size_z": 1.0,
+                "physical_size_x": 1,
+                "physical_size_y": 1,
+                "physical_size_z": 1,
                 "size_x": 1,
                 "size_y": 1,
                 "size_z": 1,
@@ -160,7 +162,6 @@
                     "version": 1
                 },
                 "image_format": "png",
-                "use_type": "THUMBNAIL",
                 "file_uri": [],
                 "total_size_in_bytes": 0,
                 "physical_size_x": null,


### PR DESCRIPTION
Pydantic was compaining when trying to create objects due to a model mis-match, despite them functionally being the same e.g.
```
class Specimen (BaseModel)
   sample_of: List[bia_shared_models.BioSample] = Field(
        description="""The biological matter that sampled to create the specimen."""
    )
```
will fail validation for a dictionary of the form:
```
{
  sample_of: [
     (api_client.BioSample( ...))
  ]
}
```

I switched to using client models as much as possible (except for a few type hits where i deal with higher level classes that aren't in the clients).

I could have instead called .model_dump() in a bunch of places, but i'm not sure that's that helpful, and i think it's better that the file version of the export code uses the same models as the api version.

Changes ended up added the default_open to the image models, which is fine - it's not strictly needed - i would rather find a longer term solution in Astro for working out which details sections have been displayed & get rid of this extra field everywhere. 

Also fixed copy-paste errors that came up with Annotated vs Experimental related differences.