### PR TITLE
Clarify docs

### DIFF
--- a/api/api/public.py
+++ b/api/api/public.py
@@ -133,8 +133,3 @@ def make_router() -> APIRouter:
         )
 
     return router
-
-
-@router.get("/placeholder")
-def example_custom_handler():
-    pass

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -85,26 +85,6 @@
         }
       }
     },
-    "/v2/placeholder": {
-      "get": {
-        "tags": [
-          "public",
-          "private"
-        ],
-        "summary": "Example Custom Handler",
-        "operationId": "example_custom_handler",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
     "/v2/study/{uuid}": {
       "get": {
         "tags": [
@@ -1784,7 +1764,7 @@
           "private"
         ],
         "summary": "Getstudies",
-        "description": "@TODO: Filters?",
+        "description": "@TODO: Filters?\n\n@TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?",
         "operationId": "getStudies",
         "responses": {
           "200": {

--- a/clients/python/Readme.md
+++ b/clients/python/Readme.md
@@ -4,25 +4,34 @@ This is the client module for using the BIA integrator [api](../../api/). This p
 
 The API is intended to facilitate the use of the [bia-shared-datamodels](../../bia-shared-datamodels/), which act as a domain model. Concepts in the API are build on top of the models, so for reference docs for the models themselves please see the linked project. This covers details that are exclusively relevant to the API.
 
+## Client reference
+
+API functionality closely follows the [bia-shared-datamodels](../../bia-shared-datamodels/). Use the docs there for domain model info and an overview of the BIA models and field docs.
+
+Use of IDE autocomplete is encouraged. In general, method names for this client follow a regular structure (Note: Uppercase sections are placeholders for the respective model class, in snake_case):
+
+* <pre>get_<i>MODELNAME</i></pre> gets an object by UUID
+* <pre>get_<i>MODELCHILD</i>_in_<i>MODELPARENT</i></pre> gets a list of all "child" objects with the same "parent". child/parent relationship is defined in the shared data models. Example: `ExperimentalImagingDataset` has an attribute `study_uuid`. The `get_experimental_imaging_dataset_in_study(study_uuid)` method of the client retrieves a list of all experimental imaging datasets that reference the uuid in the `study_uuid` parameter
+* <pre>post_<i>MODELNAME</i></pre> creates (if `version==0`) or updates (if `version>0`) an object
+
+Naming exceptions / non-generated endpoints:
+* `get_studies() -> List[Study]` - returns a list of all studies in the database
+
 ## Summary
 * Only use this Readme and the [examples](./example/) for docs.
-* API functionality closely follows the [bia-shared-datamodels](../../bia-shared-datamodels/). Use the docs there for domain model info and an overview of the BIA models and field docs. Use of IDE autocomplete is encouraged. In general, method names for this client follow a regular structure:
-    * <pre>get_<i>MODELNAME</i></pre> gets an object by UUID
-    * <pre>get_<i>MODELCHILD</i>_in_<i>MODELPARENT</i></pre> gets a list of all "child" objects with the same "parent". child/parent relationship is defined in the shared data models. Example: `ExperimentalImagingDataset` has an attribute `study_uuid`. The `getExperimentalImagingDatasetInStudy(study_uuid)` method of the client retrieves a list of all experimental imaging datasets that reference the uuid passed in as `study_uuid`
-    * <pre>post_<i>MODELNAME</i></pre> creates (if `version==0`) or updates (otherwise) an object
 * Only authenticated users can perform writes. 
-* Client sets `uuid` when creating objects
-* `version` is set by the client, at 0 and needs to be incremented for updates
+* Client sets `uuid` when creating objects.
+* `version` is set by the client, starts at 0 to create the object and needs to be incremented for every update.
 
 ### `read` and `write` operations
 
-All reads can be done by unauthenticated users. Authentication is **required** for any write operation.
+All reads can be done by unauthenticated users. Authentication is **required** for any write (`post_*`) operation.
 
 ### `version` and `model`
 
 `version` is used to distinguish between create and update operations. New objects **must** have the version field set to 0, and updates to an object **must** increment the version number. The general way to update an object is to fetch it, change attributes on the fetched object to the desired values, bump `version` and then POST it.
 
-⚠️ Only the latest version of an object is known, so please be careful with writes. Maintaining a full object history is planned, but not supported yet.
+⚠️ Only the latest version of an object is persisted in the database, so please be careful with writes. Maintaining full object history is planned, but not supported yet.
 
 `model` is intended to keep track of the data model type and version of the object. It is considered internal to the API and might change.
 
@@ -30,8 +39,10 @@ All reads can be done by unauthenticated users. Authentication is **required** f
 
 When creating new objects, the clients need to set a `uuid`. The only constraint on the API side is that they are unique.
 
-To derive a uuid, use a "pure" function that only depends on other values of the object to be created, which should be required and distinctive enough to uniquely identify it. The reason for this is that only individual operations are atomic, so to resume from a failed partial ingest the client would just re-generate the data to find the last write.
+To derive a uuid, use a "pure" function that only depends on attributes of the object to be created, which should be **required** and **distinctive enough** to uniquely identify it. The reason for this is that only individual operations are atomic, so to resume from a failed partial ingest the client would just re-generate the data to find the last write.
+
+⚠️ `uuid` should is an **opaque identifier** for all clients other than the writer of the object. The uuid derivation function is highly model-specific and writer-specific, so objects should only be found by searching or traversing the model.
 
 ### Users and authentication
 
-If you need a user, please e-mail the BIA team.
+If you plan on writing to the API and need a user, please e-mail the BIA team.

--- a/clients/python/bia_integrator_api/api/private_api.py
+++ b/clients/python/bia_integrator_api/api/private_api.py
@@ -55,246 +55,6 @@ class PrivateApi:
 
 
     @validate_call
-    def example_custom_handler(
-        self,
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            Tuple[
-                Annotated[StrictFloat, Field(gt=0)],
-                Annotated[StrictFloat, Field(gt=0)]
-            ]
-        ] = None,
-        _request_auth: Optional[Dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[Dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> object:
-        """Example Custom Handler
-
-
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """ # noqa: E501
-
-        _param = self._example_custom_handler_serialize(
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index
-        )
-
-        _response_types_map: Dict[str, Optional[str]] = {
-            '200': "object",
-        }
-        response_data = self.api_client.call_api(
-            *_param,
-            _request_timeout=_request_timeout
-        )
-        response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        ).data
-
-
-    @validate_call
-    def example_custom_handler_with_http_info(
-        self,
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            Tuple[
-                Annotated[StrictFloat, Field(gt=0)],
-                Annotated[StrictFloat, Field(gt=0)]
-            ]
-        ] = None,
-        _request_auth: Optional[Dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[Dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[object]:
-        """Example Custom Handler
-
-
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """ # noqa: E501
-
-        _param = self._example_custom_handler_serialize(
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index
-        )
-
-        _response_types_map: Dict[str, Optional[str]] = {
-            '200': "object",
-        }
-        response_data = self.api_client.call_api(
-            *_param,
-            _request_timeout=_request_timeout
-        )
-        response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        )
-
-
-    @validate_call
-    def example_custom_handler_without_preload_content(
-        self,
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            Tuple[
-                Annotated[StrictFloat, Field(gt=0)],
-                Annotated[StrictFloat, Field(gt=0)]
-            ]
-        ] = None,
-        _request_auth: Optional[Dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[Dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> RESTResponseType:
-        """Example Custom Handler
-
-
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """ # noqa: E501
-
-        _param = self._example_custom_handler_serialize(
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index
-        )
-
-        _response_types_map: Dict[str, Optional[str]] = {
-            '200': "object",
-        }
-        response_data = self.api_client.call_api(
-            *_param,
-            _request_timeout=_request_timeout
-        )
-        return response_data.response
-
-
-    def _example_custom_handler_serialize(
-        self,
-        _request_auth,
-        _content_type,
-        _headers,
-        _host_index,
-    ) -> RequestSerialized:
-
-        _host = None
-
-        _collection_formats: Dict[str, str] = {
-        }
-
-        _path_params: Dict[str, str] = {}
-        _query_params: List[Tuple[str, str]] = []
-        _header_params: Dict[str, Optional[str]] = _headers or {}
-        _form_params: List[Tuple[str, str]] = []
-        _files: Dict[str, Union[str, bytes]] = {}
-        _body_params: Optional[bytes] = None
-
-        # process the path parameters
-        # process the query parameters
-        # process the header parameters
-        # process the form parameters
-        # process the body parameter
-
-
-        # set the HTTP header `Accept`
-        if 'Accept' not in _header_params:
-            _header_params['Accept'] = self.api_client.select_header_accept(
-                [
-                    'application/json'
-                ]
-            )
-
-
-        # authentication setting
-        _auth_settings: List[str] = [
-        ]
-
-        return self.api_client.param_serialize(
-            method='GET',
-            resource_path='/v2/placeholder',
-            path_params=_path_params,
-            query_params=_query_params,
-            header_params=_header_params,
-            body=_body_params,
-            post_params=_form_params,
-            files=_files,
-            auth_settings=_auth_settings,
-            collection_formats=_collection_formats,
-            _host=_host,
-            _request_auth=_request_auth
-        )
-
-
-
-
-    @validate_call
     def get_annotation_file_reference(
         self,
         uuid: StrictStr,
@@ -9342,7 +9102,7 @@ class PrivateApi:
     ) -> List[Study]:
         """Getstudies
 
-        @TODO: Filters?
+        @TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -9405,7 +9165,7 @@ class PrivateApi:
     ) -> ApiResponse[List[Study]]:
         """Getstudies
 
-        @TODO: Filters?
+        @TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -9468,7 +9228,7 @@ class PrivateApi:
     ) -> RESTResponseType:
         """Getstudies
 
-        @TODO: Filters?
+        @TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request

--- a/clients/python/bia_integrator_api/api/public_api.py
+++ b/clients/python/bia_integrator_api/api/public_api.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import StrictStr
-from typing import Any, List
+from typing import List
 from bia_integrator_api.models.annotation_file_reference import AnnotationFileReference
 from bia_integrator_api.models.annotation_method import AnnotationMethod
 from bia_integrator_api.models.bio_sample import BioSample
@@ -49,246 +49,6 @@ class PublicApi:
         if api_client is None:
             api_client = ApiClient.get_default()
         self.api_client = api_client
-
-
-    @validate_call
-    def example_custom_handler(
-        self,
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            Tuple[
-                Annotated[StrictFloat, Field(gt=0)],
-                Annotated[StrictFloat, Field(gt=0)]
-            ]
-        ] = None,
-        _request_auth: Optional[Dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[Dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> object:
-        """Example Custom Handler
-
-
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """ # noqa: E501
-
-        _param = self._example_custom_handler_serialize(
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index
-        )
-
-        _response_types_map: Dict[str, Optional[str]] = {
-            '200': "object",
-        }
-        response_data = self.api_client.call_api(
-            *_param,
-            _request_timeout=_request_timeout
-        )
-        response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        ).data
-
-
-    @validate_call
-    def example_custom_handler_with_http_info(
-        self,
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            Tuple[
-                Annotated[StrictFloat, Field(gt=0)],
-                Annotated[StrictFloat, Field(gt=0)]
-            ]
-        ] = None,
-        _request_auth: Optional[Dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[Dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[object]:
-        """Example Custom Handler
-
-
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """ # noqa: E501
-
-        _param = self._example_custom_handler_serialize(
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index
-        )
-
-        _response_types_map: Dict[str, Optional[str]] = {
-            '200': "object",
-        }
-        response_data = self.api_client.call_api(
-            *_param,
-            _request_timeout=_request_timeout
-        )
-        response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        )
-
-
-    @validate_call
-    def example_custom_handler_without_preload_content(
-        self,
-        _request_timeout: Union[
-            None,
-            Annotated[StrictFloat, Field(gt=0)],
-            Tuple[
-                Annotated[StrictFloat, Field(gt=0)],
-                Annotated[StrictFloat, Field(gt=0)]
-            ]
-        ] = None,
-        _request_auth: Optional[Dict[StrictStr, Any]] = None,
-        _content_type: Optional[StrictStr] = None,
-        _headers: Optional[Dict[StrictStr, Any]] = None,
-        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> RESTResponseType:
-        """Example Custom Handler
-
-
-        :param _request_timeout: timeout setting for this request. If one
-                                 number provided, it will be total request
-                                 timeout. It can also be a pair (tuple) of
-                                 (connection, read) timeouts.
-        :type _request_timeout: int, tuple(int, int), optional
-        :param _request_auth: set to override the auth_settings for an a single
-                              request; this effectively ignores the
-                              authentication in the spec for a single request.
-        :type _request_auth: dict, optional
-        :param _content_type: force content-type for the request.
-        :type _content_type: str, Optional
-        :param _headers: set to override the headers for a single
-                         request; this effectively ignores the headers
-                         in the spec for a single request.
-        :type _headers: dict, optional
-        :param _host_index: set to override the host_index for a single
-                            request; this effectively ignores the host_index
-                            in the spec for a single request.
-        :type _host_index: int, optional
-        :return: Returns the result object.
-        """ # noqa: E501
-
-        _param = self._example_custom_handler_serialize(
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index
-        )
-
-        _response_types_map: Dict[str, Optional[str]] = {
-            '200': "object",
-        }
-        response_data = self.api_client.call_api(
-            *_param,
-            _request_timeout=_request_timeout
-        )
-        return response_data.response
-
-
-    def _example_custom_handler_serialize(
-        self,
-        _request_auth,
-        _content_type,
-        _headers,
-        _host_index,
-    ) -> RequestSerialized:
-
-        _host = None
-
-        _collection_formats: Dict[str, str] = {
-        }
-
-        _path_params: Dict[str, str] = {}
-        _query_params: List[Tuple[str, str]] = []
-        _header_params: Dict[str, Optional[str]] = _headers or {}
-        _form_params: List[Tuple[str, str]] = []
-        _files: Dict[str, Union[str, bytes]] = {}
-        _body_params: Optional[bytes] = None
-
-        # process the path parameters
-        # process the query parameters
-        # process the header parameters
-        # process the form parameters
-        # process the body parameter
-
-
-        # set the HTTP header `Accept`
-        if 'Accept' not in _header_params:
-            _header_params['Accept'] = self.api_client.select_header_accept(
-                [
-                    'application/json'
-                ]
-            )
-
-
-        # authentication setting
-        _auth_settings: List[str] = [
-        ]
-
-        return self.api_client.param_serialize(
-            method='GET',
-            resource_path='/v2/placeholder',
-            path_params=_path_params,
-            query_params=_query_params,
-            header_params=_header_params,
-            body=_body_params,
-            post_params=_form_params,
-            files=_files,
-            auth_settings=_auth_settings,
-            collection_formats=_collection_formats,
-            _host=_host,
-            _request_auth=_request_auth
-        )
-
-
 
 
     @validate_call
@@ -9339,7 +9099,7 @@ class PublicApi:
     ) -> List[Study]:
         """Getstudies
 
-        @TODO: Filters?
+        @TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -9402,7 +9162,7 @@ class PublicApi:
     ) -> ApiResponse[List[Study]]:
         """Getstudies
 
-        @TODO: Filters?
+        @TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -9465,7 +9225,7 @@ class PublicApi:
     ) -> RESTResponseType:
         """Getstudies
 
-        @TODO: Filters?
+        @TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request

--- a/clients/python/bia_integrator_api/docs/PrivateApi.md
+++ b/clients/python/bia_integrator_api/docs/PrivateApi.md
@@ -4,7 +4,6 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**example_custom_handler**](PrivateApi.md#example_custom_handler) | **GET** /v2/placeholder | Example Custom Handler
 [**get_annotation_file_reference**](PrivateApi.md#get_annotation_file_reference) | **GET** /v2/annotation_file_reference/{uuid} | Get AnnotationFileReference
 [**get_annotation_file_reference_in_annotation_method**](PrivateApi.md#get_annotation_file_reference_in_annotation_method) | **GET** /v2/annotation_method/{uuid}/annotation_file_reference | Get AnnotationFileReference In AnnotationMethod
 [**get_annotation_file_reference_in_derived_image**](PrivateApi.md#get_annotation_file_reference_in_derived_image) | **GET** /v2/derived_image/{uuid}/annotation_file_reference | Get AnnotationFileReference In DerivedImage
@@ -59,67 +58,6 @@ Method | HTTP request | Description
 [**post_study**](PrivateApi.md#post_study) | **POST** /v2/private/study | Create Study
 [**register_user**](PrivateApi.md#register_user) | **POST** /v2/auth/user/register | Register User
 
-
-# **example_custom_handler**
-> object example_custom_handler()
-
-Example Custom Handler
-
-### Example
-
-
-```python
-import bia_integrator_api
-from bia_integrator_api.rest import ApiException
-from pprint import pprint
-
-# Defining the host is optional and defaults to http://localhost
-# See configuration.py for a list of all supported configuration parameters.
-configuration = bia_integrator_api.Configuration(
-    host = "http://localhost"
-)
-
-
-# Enter a context with an instance of the API client
-with bia_integrator_api.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
-    api_instance = bia_integrator_api.PrivateApi(api_client)
-
-    try:
-        # Example Custom Handler
-        api_response = api_instance.example_custom_handler()
-        print("The response of PrivateApi->example_custom_handler:\n")
-        pprint(api_response)
-    except Exception as e:
-        print("Exception when calling PrivateApi->example_custom_handler: %s\n" % e)
-```
-
-
-
-### Parameters
-
-This endpoint does not need any parameter.
-
-### Return type
-
-**object**
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-### HTTP response details
-
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | Successful Response |  -  |
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_annotation_file_reference**
 > AnnotationFileReference get_annotation_file_reference(uuid)
@@ -2471,7 +2409,7 @@ No authorization required
 
 Getstudies
 
-@TODO: Filters?
+@TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
 ### Example
 

--- a/clients/python/bia_integrator_api/docs/PublicApi.md
+++ b/clients/python/bia_integrator_api/docs/PublicApi.md
@@ -4,7 +4,6 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**example_custom_handler**](PublicApi.md#example_custom_handler) | **GET** /v2/placeholder | Example Custom Handler
 [**get_annotation_file_reference**](PublicApi.md#get_annotation_file_reference) | **GET** /v2/annotation_file_reference/{uuid} | Get AnnotationFileReference
 [**get_annotation_file_reference_in_annotation_method**](PublicApi.md#get_annotation_file_reference_in_annotation_method) | **GET** /v2/annotation_method/{uuid}/annotation_file_reference | Get AnnotationFileReference In AnnotationMethod
 [**get_annotation_file_reference_in_derived_image**](PublicApi.md#get_annotation_file_reference_in_derived_image) | **GET** /v2/derived_image/{uuid}/annotation_file_reference | Get AnnotationFileReference In DerivedImage
@@ -43,67 +42,6 @@ Method | HTTP request | Description
 [**get_studies**](PublicApi.md#get_studies) | **GET** /v2/study | Getstudies
 [**get_study**](PublicApi.md#get_study) | **GET** /v2/study/{uuid} | Get Study
 
-
-# **example_custom_handler**
-> object example_custom_handler()
-
-Example Custom Handler
-
-### Example
-
-
-```python
-import bia_integrator_api
-from bia_integrator_api.rest import ApiException
-from pprint import pprint
-
-# Defining the host is optional and defaults to http://localhost
-# See configuration.py for a list of all supported configuration parameters.
-configuration = bia_integrator_api.Configuration(
-    host = "http://localhost"
-)
-
-
-# Enter a context with an instance of the API client
-with bia_integrator_api.ApiClient(configuration) as api_client:
-    # Create an instance of the API class
-    api_instance = bia_integrator_api.PublicApi(api_client)
-
-    try:
-        # Example Custom Handler
-        api_response = api_instance.example_custom_handler()
-        print("The response of PublicApi->example_custom_handler:\n")
-        pprint(api_response)
-    except Exception as e:
-        print("Exception when calling PublicApi->example_custom_handler: %s\n" % e)
-```
-
-
-
-### Parameters
-
-This endpoint does not need any parameter.
-
-### Return type
-
-**object**
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-### HTTP response details
-
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-**200** | Successful Response |  -  |
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_annotation_file_reference**
 > AnnotationFileReference get_annotation_file_reference(uuid)
@@ -2455,7 +2393,7 @@ No authorization required
 
 Getstudies
 
-@TODO: Filters?
+@TODO: Filters?  @TODO: Not pluralizing clashes with getStudy(study_uuid) - non-pluralised convention?
 
 ### Example
 

--- a/clients/python/bia_integrator_api_README.md
+++ b/clients/python/bia_integrator_api_README.md
@@ -45,14 +45,15 @@ configuration = bia_integrator_api.Configuration(
 with bia_integrator_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = bia_integrator_api.PrivateApi(api_client)
+    uuid = 'uuid_example' # str | 
 
     try:
-        # Example Custom Handler
-        api_response = api_instance.example_custom_handler()
-        print("The response of PrivateApi->example_custom_handler:\n")
+        # Get AnnotationFileReference
+        api_response = api_instance.get_annotation_file_reference(uuid)
+        print("The response of PrivateApi->get_annotation_file_reference:\n")
         pprint(api_response)
     except ApiException as e:
-        print("Exception when calling PrivateApi->example_custom_handler: %s\n" % e)
+        print("Exception when calling PrivateApi->get_annotation_file_reference: %s\n" % e)
 
 ```
 
@@ -62,7 +63,6 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PrivateApi* | [**example_custom_handler**](bia_integrator_api/docs/PrivateApi.md#example_custom_handler) | **GET** /v2/placeholder | Example Custom Handler
 *PrivateApi* | [**get_annotation_file_reference**](bia_integrator_api/docs/PrivateApi.md#get_annotation_file_reference) | **GET** /v2/annotation_file_reference/{uuid} | Get AnnotationFileReference
 *PrivateApi* | [**get_annotation_file_reference_in_annotation_method**](bia_integrator_api/docs/PrivateApi.md#get_annotation_file_reference_in_annotation_method) | **GET** /v2/annotation_method/{uuid}/annotation_file_reference | Get AnnotationFileReference In AnnotationMethod
 *PrivateApi* | [**get_annotation_file_reference_in_derived_image**](bia_integrator_api/docs/PrivateApi.md#get_annotation_file_reference_in_derived_image) | **GET** /v2/derived_image/{uuid}/annotation_file_reference | Get AnnotationFileReference In DerivedImage
@@ -116,7 +116,6 @@ Class | Method | HTTP request | Description
 *PrivateApi* | [**post_specimen_imaging_preparation_protocol**](bia_integrator_api/docs/PrivateApi.md#post_specimen_imaging_preparation_protocol) | **POST** /v2/private/specimen_imaging_preparation_protocol | Create SpecimenImagingPreparationProtocol
 *PrivateApi* | [**post_study**](bia_integrator_api/docs/PrivateApi.md#post_study) | **POST** /v2/private/study | Create Study
 *PrivateApi* | [**register_user**](bia_integrator_api/docs/PrivateApi.md#register_user) | **POST** /v2/auth/user/register | Register User
-*PublicApi* | [**example_custom_handler**](bia_integrator_api/docs/PublicApi.md#example_custom_handler) | **GET** /v2/placeholder | Example Custom Handler
 *PublicApi* | [**get_annotation_file_reference**](bia_integrator_api/docs/PublicApi.md#get_annotation_file_reference) | **GET** /v2/annotation_file_reference/{uuid} | Get AnnotationFileReference
 *PublicApi* | [**get_annotation_file_reference_in_annotation_method**](bia_integrator_api/docs/PublicApi.md#get_annotation_file_reference_in_annotation_method) | **GET** /v2/annotation_method/{uuid}/annotation_file_reference | Get AnnotationFileReference In AnnotationMethod
 *PublicApi* | [**get_annotation_file_reference_in_derived_image**](bia_integrator_api/docs/PublicApi.md#get_annotation_file_reference_in_derived_image) | **GET** /v2/derived_image/{uuid}/annotation_file_reference | Get AnnotationFileReference In DerivedImage


### PR DESCRIPTION
Minor changes to client docs, `get_studies` was missing

Removed placeholder example custom endpoint (because we have `get_studies` now)