### PR TITLE
make value of file reference optional and update tests to check

### DIFF
--- a/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
+++ b/bia-ingest-shared-models/bia_ingest_sm/biostudies.py
@@ -26,7 +26,7 @@ class AttributeDetail(BaseModel):
 
 class Attribute(BaseModel):
     name: str
-    value: Optional[str]
+    value: Optional[str] = None
     reference: bool = False
     nmqual: List[AttributeDetail] = []
     valqual: List[AttributeDetail] = []

--- a/bia-ingest-shared-models/test/data/file_list_study_component_2.json
+++ b/bia-ingest-shared-models/test/data/file_list_study_component_2.json
@@ -27,6 +27,9 @@
         "value": "ann06-10.json"
       },
       {
+        "name": "metadata1_key"
+      },
+      {
         "name": "metadata3_key",
         "value": "metadata3_value"
       },

--- a/bia-ingest-shared-models/test/test_bia_ingest_cli.py
+++ b/bia-ingest-shared-models/test/test_bia_ingest_cli.py
@@ -4,12 +4,15 @@ from bia_ingest_sm.conversion.utils import settings
 from bia_ingest_sm import biostudies
 from . import utils
 from bia_shared_datamodels import bia_data_model
+import pytest
 
 runner = CliRunner()
 
 accession_id = "S-BIADTEST"
 
-expected_objects_dict = {
+@pytest.fixture
+def expected_objects():
+    expected_objects_dict = {
     "studies": utils.get_test_study(),
     "experimental_imaging_dataset": utils.get_test_experimental_imaging_dataset(),
     "specimens": utils.get_test_specimen(),
@@ -19,26 +22,30 @@ expected_objects_dict = {
     "specimen_imaging_protocol": utils.get_test_specimen_imaging_preparation_protocol(),
     "annotation_method": utils.get_test_annotation_method(),
     "image_annotation_dataset": utils.get_test_image_annotation_dataset(),
-}
+    }
 
-# File references are a special case as they depend on experimental dataset
-expected_file_references = utils.get_test_file_reference(
+    # File references are a special case as they depend on experimental dataset
+    expected_file_references = utils.get_test_file_reference(
     ["file_list_study_component_1.json", "file_list_study_component_2.json"]
-)
-expected_objects_dict["file_references"] = expected_file_references
+    )
+    expected_objects_dict["file_references"] = expected_file_references
 
-n_expected_objects = 0
-for expected_objects in expected_objects_dict.values():
-    if isinstance(expected_objects, list):
-        n_expected_objects += len(expected_objects)
-    else:
-        n_expected_objects += 1
+    n_expected_objects = 0
+    for expected_objects in expected_objects_dict.values():
+        if isinstance(expected_objects, list):
+            n_expected_objects += len(expected_objects)
+        else:
+            n_expected_objects += 1
+    
+    return expected_objects_dict, n_expected_objects
 
 
 def test_cli_writes_expected_files(
-    monkeypatch, tmp_path, test_submission, mock_request_get
+    monkeypatch, tmp_path, test_submission, mock_request_get, expected_objects
 ):
     monkeypatch.setattr(settings, "bia_data_dir", str(tmp_path))
+
+    expected_objects_dict, n_expected_objects = expected_objects
 
     def _load_submission(accession_id: str) -> biostudies.Submission:
         return test_submission

--- a/bia-ingest-shared-models/test/utils.py
+++ b/bia-ingest-shared-models/test/utils.py
@@ -478,7 +478,7 @@ def get_test_file_reference_data(filelist: str) -> List[Dict[str, str]]:
                 "uri": uri_template.format(
                     accession_id=accession_id, file_path=fl_data["path"]
                 ),
-                "attribute": {a["name"]: a["value"] for a in fl_data["attributes"]},
+                "attribute": {a["name"]: a.get("value", None) for a in fl_data["attributes"]},
                 "submission_dataset_uuid": submission_dataset_uuids[1],
             }
         )


### PR DESCRIPTION
Pydantic requires a default value to be set for a field in order for it to actually be optional.

When BioStudies returns file lists they can return file objects with an attribute that has a name but no value key if the column is empty.

Updated the tests to have an example of this, and updated bia_ingest_cli to use a fixture so that pydantic doesn't error when loading the tests, only a run time.
