### PR TITLE
Fix ingest errors

### DIFF
--- a/bia-ingest/bia_ingest/biostudies.py
+++ b/bia-ingest/bia_ingest/biostudies.py
@@ -26,7 +26,7 @@ class AttributeDetail(BaseModel):
 
 class Attribute(BaseModel):
     name: str
-    value: Optional[str]
+    value: Optional[str] = None
     reference: bool = False
     nmqual: List[AttributeDetail] = []
     valqual: List[AttributeDetail] = []

--- a/bia-ingest/bia_ingest/cli_logging.py
+++ b/bia-ingest/bia_ingest/cli_logging.py
@@ -60,22 +60,21 @@ def tabulate_errors(dict_of_results: dict[str, IngestionResult]) -> Table:
                 error_message += f"{field}: {value}; "
 
         if (
-            result.ExperimentalImagingDataset_CreationCount
-            == 0 & result.ImageAnnotationDataset_CreationCount
-            == 0
+            result.ExperimentalImagingDataset_CreationCount == 0 
+            & result.ImageAnnotationDataset_CreationCount == 0
         ):
             error_message += "No datasets were created; "
 
         if result.ExperimentalImagingDataset_CreationCount > 0:
             if not (
-                result.BioSample_CreationCount
-                == 0 & result.SpecimenImagingPreparationProtocol_CreationCount
-                == 0 & result.ImageAcquisition_CreationCount
+                result.BioSample_CreationCount == 0 
+                & result.SpecimenImagingPreparationProtocol_CreationCount == 0
+                & result.ImageAcquisition_CreationCount == 0
             ):
                 if (
-                    result.BioSample_CreationCount
-                    == 0 | result.SpecimenImagingPreparationProtocol_CreationCount
-                    == 0 | result.ImageAcquisition_CreationCount
+                    result.BioSample_CreationCount == 0 
+                    | result.SpecimenImagingPreparationProtocol_CreationCount == 0
+                    | result.ImageAcquisition_CreationCount == 0
                 ):
                     error_message += "Incomplete REMBI objects created; "
             else:

--- a/bia-ingest/test/test_bia_ingest_cli.py
+++ b/bia-ingest/test/test_bia_ingest_cli.py
@@ -4,41 +4,48 @@ from bia_ingest.conversion.utils import settings
 from bia_ingest import biostudies
 from . import utils
 from bia_shared_datamodels import bia_data_model
+import pytest
 
 runner = CliRunner()
 
 accession_id = "S-BIADTEST"
 
-expected_objects_dict = {
-    "studies": utils.get_test_study(),
-    "experimental_imaging_dataset": utils.get_test_experimental_imaging_dataset(),
-    "specimens": utils.get_test_specimen(),
-    "biosamples": utils.get_test_biosample(),
-    "image_acquisitions": utils.get_test_image_acquisition(),
-    "specimen_growth_protocol": utils.get_test_specimen_growth_protocol(),
-    "specimen_imaging_protocol": utils.get_test_specimen_imaging_preparation_protocol(),
-    "annotation_method": utils.get_test_annotation_method(),
-    "image_annotation_dataset": utils.get_test_image_annotation_dataset(),
-}
+@pytest.fixture
+def expected_objects():
+    expected_objects_dict = {
+        "studies": utils.get_test_study(),
+        "experimental_imaging_dataset": utils.get_test_experimental_imaging_dataset(),
+        "specimens": utils.get_test_specimen(),
+        "biosamples": utils.get_test_biosample(),
+        "image_acquisitions": utils.get_test_image_acquisition(),
+        "specimen_growth_protocol": utils.get_test_specimen_growth_protocol(),
+        "specimen_imaging_protocol": utils.get_test_specimen_imaging_preparation_protocol(),
+        "annotation_method": utils.get_test_annotation_method(),
+        "image_annotation_dataset": utils.get_test_image_annotation_dataset(),
+    }
 
-# File references are a special case as they depend on experimental dataset
-expected_file_references = utils.get_test_file_reference(
-    ["file_list_study_component_1.json", "file_list_study_component_2.json"]
-)
-expected_objects_dict["file_references"] = expected_file_references
+    # File references are a special case as they depend on experimental dataset
+    expected_file_references = utils.get_test_file_reference(
+        ["file_list_study_component_1.json", "file_list_study_component_2.json"]
+    )
+    expected_objects_dict["file_references"] = expected_file_references
 
-n_expected_objects = 0
-for expected_objects in expected_objects_dict.values():
-    if isinstance(expected_objects, list):
-        n_expected_objects += len(expected_objects)
-    else:
-        n_expected_objects += 1
+    n_expected_objects = 0
+    for expected_objects in expected_objects_dict.values():
+        if isinstance(expected_objects, list):
+            n_expected_objects += len(expected_objects)
+        else:
+            n_expected_objects += 1
+    
+    return expected_objects_dict, n_expected_objects
 
 
 def test_cli_writes_expected_files(
-    monkeypatch, tmp_path, test_submission, mock_request_get
+    monkeypatch, tmp_path, test_submission, mock_request_get, expected_objects
 ):
     monkeypatch.setattr(settings, "bia_data_dir", str(tmp_path))
+
+    expected_objects_dict, n_expected_objects = expected_objects
 
     def _load_submission(accession_id: str) -> biostudies.Submission:
         return test_submission

--- a/bia-ingest/test/utils.py
+++ b/bia-ingest/test/utils.py
@@ -584,7 +584,7 @@ def get_test_file_reference_data(filelist: str) -> List[Dict[str, str]]:
                 "uri": uri_template.format(
                     accession_id=accession_id, file_path=fl_data["path"]
                 ),
-                "attribute": {a["name"]: a["value"] for a in fl_data["attributes"]},
+                "attribute": {a["name"]: a.get("value", None) for a in fl_data["attributes"]},
                 "submission_dataset_uuid": submission_dataset_uuids[1],
             }
         )


### PR DESCRIPTION
Pydantic requires a default value to be set for a field in order for it to actually be optional.

When BioStudies returns file lists they can return file objects with an attribute that has a name but no value key if the column is empty.

Updated the tests to have an example of this, and updated bia_ingest_cli to use a fixture so that pydantic doesn't error when loading the tests, only a run time.

According to the results spreadsheet, this might allow us to ingest another ~40-90 studies.