### PR TITLE
Print summary of models created/errors when creating image representations

### DIFF
--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -48,7 +48,7 @@ app.add_typer(
 @app.command(help="Ingest from biostudies and echo json of bia_data_model.Study")
 def ingest(
     accession_id_list: Annotated[List[str], typer.Argument()],
-    verbose: Annotated[bool, typer.Option("-v")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     if verbose:
         logger.setLevel(logging.DEBUG)
@@ -110,8 +110,14 @@ def create(
         ImageRepresentationUseType.THUMBNAIL,
         ImageRepresentationUseType.INTERACTIVE_DISPLAY,
     ],
+    verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     """Create representations for specified file reference(s)"""
+
+    if verbose:
+        logger.setLevel(logging.DEBUG)
+
+    result_summary = {}
 
     persister = persistence_strategy_factory(
         persistence_mode,
@@ -123,7 +129,14 @@ def create(
     submission = load_submission(accession_id)
     result_summary = {accession_id: IngestionResult()}
     for file_reference_uuid in file_reference_uuid_list:
+        print(
+            f"[blue]-------- Starting creation of image representations for file reference {file_reference_uuid} of {accession_id} --------[/blue]"
+        )
+
         for representation_use_type in reps_to_create:
+            logger.debug(
+                f"starting creation of {representation_use_type.value} for file reference {file_reference_uuid}"
+            )
             create_image_representation(
                 submission,
                 [
@@ -133,6 +146,25 @@ def create(
                 result_summary=result_summary,
                 persister=persister,
             )
+
+    logger.debug(
+        f"COMPLETED: Creation of image representations for file reference(s) {file_reference_uuid_list} of {accession_id}"
+    )
+    print(
+        f"[green]-------- Completed creation of image representations for file reference(s) {file_reference_uuid_list} of {accession_id} --------[/green]"
+    )
+
+    result_summary = result_summary[submission.accno]
+    successes = ""
+    errors = ""
+    for item_name in result_summary.__fields__:
+        item_value = getattr(result_summary, item_name)
+        if item_name.endswith("CreationCount") and item_value > 0:
+            successes += f"{item_name}: {item_value}\n"
+        elif item_name.endswith("ErrorCount") and item_value > 0:
+            errors += f"{item_name}: {item_value}\n"
+    print(f"[green]--------- Successes ---------\n{successes}[/green]")
+    print(f"[red]--------- Errors ---------\n{errors}[/red]")
 
 
 @app.callback()

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -137,7 +137,7 @@ def create(
             logger.debug(
                 f"starting creation of {representation_use_type.value} for file reference {file_reference_uuid}"
             )
-            create_image_representation(
+            image_representation = create_image_representation(
                 submission,
                 [
                     file_reference_uuid,
@@ -146,13 +146,11 @@ def create(
                 result_summary=result_summary,
                 persister=persister,
             )
-
-    logger.debug(
-        f"COMPLETED: Creation of image representations for file reference(s) {file_reference_uuid_list} of {accession_id}"
-    )
-    print(
-        f"[green]-------- Completed creation of image representations for file reference(s) {file_reference_uuid_list} of {accession_id} --------[/green]"
-    )
+            if image_representation:
+                message = f"COMPLETED: Creation of image representation {representation_use_type.value} for file reference {file_reference_uuid} of {accession_id}"
+            else:
+                message = f"WARNING: Could NOT create image representation {representation_use_type.value} for file reference {file_reference_uuid} of {accession_id}"
+            logger.debug(message)
 
     result_summary = result_summary[submission.accno]
     successes = ""
@@ -163,8 +161,8 @@ def create(
             successes += f"{item_name}: {item_value}\n"
         elif item_name.endswith("ErrorCount") and item_value > 0:
             errors += f"{item_name}: {item_value}\n"
-    print(f"[green]--------- Successes ---------\n{successes}[/green]")
-    print(f"[red]--------- Errors ---------\n{errors}[/red]")
+    print(f"\n\n[green]--------- Successes ---------\n{successes}[/green]")
+    print(f"\n\n[red]--------- Errors ---------\n{errors}[/red]")
 
 
 @app.callback()

--- a/bia-ingest/bia_ingest/cli_logging.py
+++ b/bia-ingest/bia_ingest/cli_logging.py
@@ -48,6 +48,8 @@ class IngestionResult(BaseModel):
     Organisation_ValidationErrorCount: int = Field(default=0)
     ExperimentallyCapturedImage_CreationCount: int = Field(default=0)
     ExperimentallyCapturedImage_ValidationErrorCount: int = Field(default=0)
+    ImageRepresentation_CreationCount: int = Field(default=0)
+    ImageRepresentation_ValidationErrorCount: int = Field(default=0)
 
 
 def tabulate_errors(dict_of_results: dict[str, IngestionResult]) -> Table:
@@ -60,21 +62,24 @@ def tabulate_errors(dict_of_results: dict[str, IngestionResult]) -> Table:
                 error_message += f"{field}: {value}; "
 
         if (
-            result.ExperimentalImagingDataset_CreationCount == 0 
-            & result.ImageAnnotationDataset_CreationCount == 0
+            result.ExperimentalImagingDataset_CreationCount
+            == 0 & result.ImageAnnotationDataset_CreationCount
+            == 0
         ):
             error_message += "No datasets were created; "
 
         if result.ExperimentalImagingDataset_CreationCount > 0:
             if not (
-                result.BioSample_CreationCount == 0 
-                & result.SpecimenImagingPreparationProtocol_CreationCount == 0
-                & result.ImageAcquisition_CreationCount == 0
+                result.BioSample_CreationCount
+                == 0 & result.SpecimenImagingPreparationProtocol_CreationCount
+                == 0 & result.ImageAcquisition_CreationCount
+                == 0
             ):
                 if (
-                    result.BioSample_CreationCount == 0 
-                    | result.SpecimenImagingPreparationProtocol_CreationCount == 0
-                    | result.ImageAcquisition_CreationCount == 0
+                    result.BioSample_CreationCount
+                    == 0 | result.SpecimenImagingPreparationProtocol_CreationCount
+                    == 0 | result.ImageAcquisition_CreationCount
+                    == 0
                 ):
                     error_message += "Incomplete REMBI objects created; "
             else:

--- a/bia-ingest/bia_ingest/conversion/experimentally_captured_image.py
+++ b/bia-ingest/bia_ingest/conversion/experimentally_captured_image.py
@@ -26,7 +26,7 @@ def get_experimentally_captured_image(
     file_references: List[bia_data_model.FileReference],
     result_summary: dict,
     persister: PersistenceStrategy,
-) -> bia_data_model.ExperimentallyCapturedImage:
+) -> bia_data_model.ExperimentallyCapturedImage | None:
     """Get the ExperimentallyCapturedImage corresponding to the dataset/file_reference(s) combination"""
 
     dataset = persister.fetch_by_uuid(

--- a/bia-ingest/bia_ingest/conversion/image_representation.py
+++ b/bia-ingest/bia_ingest/conversion/image_representation.py
@@ -28,7 +28,7 @@ def create_image_representation(
     result_summary: dict,
     persister: PersistenceStrategy,
     representation_location: Optional[str] = None,
-) -> bia_data_model.ImageRepresentation:
+) -> bia_data_model.ImageRepresentation | None:
     """Create ImageRepresentation for specified FileReference(s)"""
 
     logger.debug(f"Fetching file reference with uuid(s) {file_reference_uuids}")


### PR DESCRIPTION
This PR attempts to print a summary of models created and/or errors encountered when creating image representations. However, the output generated is not strictly correct - as only one Experimentally Captured Image (ECI) is created for all representations of the same file reference uuid(s). However, the current code logs creation of an ECI for each representation - thus overstating the number of ECIs created.