### PR TITLE
added check for count of files and dryrun mode

### DIFF
--- a/bia-ingest/bia_ingest/biostudies.py
+++ b/bia-ingest/bia_ingest/biostudies.py
@@ -13,6 +13,9 @@ logger = logging.getLogger("__main__." + __name__)
 
 
 STUDY_URL_TEMPLATE = "https://www.ebi.ac.uk/biostudies/api/v1/studies/{accession}"
+STUDY_TABLE_INFO_URL_TEMPLATE = (
+    "https://www.ebi.ac.uk/biostudies/api/v1/studies/{accession}/info"
+)
 FLIST_URI_TEMPLATE = (
     "https://www.ebi.ac.uk/biostudies/files/{accession_id}/{flist_fname}"
 )
@@ -132,7 +135,46 @@ class QueryResult(BaseModel):
     hits: List[StudyResult]
 
 
+# API table structure
+
+
+class Columns(BaseModel):
+    name: str
+    title: str
+    visible: bool
+    searchable: bool
+    data: str
+    defaultContent: str
+
+
+class SubmissionTable(BaseModel):
+    columns: List[Columns]
+    files: int
+    httpLink: str
+    ftpLink: str
+    globusLink: str
+    isPublic: bool
+    relPath: str
+    hasZippedFolders: bool
+    views: int
+    released: int
+    modified: int
+    sections: List[str]
+
+
 # API functions
+
+
+def load_submission_table_info(accession_id: str) -> SubmissionTable:
+    url = STUDY_TABLE_INFO_URL_TEMPLATE.format(accession=accession_id)
+    logger.debug(f"Fetching table information from {url}")
+    headers = {
+        "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36"
+    }
+    r = requests.get(url, headers=headers)
+    assert r.status_code == 200
+    table_info = SubmissionTable.model_validate_json(r.content)
+    return table_info
 
 
 def load_submission(accession_id: str) -> Submission:

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -204,7 +204,6 @@ def create(
 def determine_file_processing(
     process_files_mode: ProcessFilelistMode, file_count_limit: int, file_count: int
 ) -> bool:
-    file_count_limit = 200000
     if process_files_mode == ProcessFilelistMode.always:
         process_files = True
     elif process_files_mode == ProcessFilelistMode.skip:

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -1,7 +1,8 @@
 import typer
 from typing import List
+from enum import Enum
 from typing_extensions import Annotated
-from bia_ingest.biostudies import load_submission
+from bia_ingest.biostudies import load_submission, load_submission_table_info
 from bia_ingest.config import settings, api_client
 from bia_ingest.conversion.study import get_study
 from bia_ingest.conversion.experimental_imaging_dataset import (
@@ -45,6 +46,14 @@ app.add_typer(
 )
 
 
+class ProcessFilelistMode(str, Enum):
+    """Wether to process all file references, ask if there are a lot of files, or always skip."""
+
+    always = "always"
+    ask = "ask"
+    skip = "skip"
+
+
 @app.command(help="Ingest from biostudies and echo json of bia_data_model.Study")
 def ingest(
     accession_id_list: Annotated[List[str], typer.Argument()],
@@ -52,6 +61,10 @@ def ingest(
         PersistenceMode, typer.Option(case_sensitive=False)
     ] = PersistenceMode.disk,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
+    process_filelist: Annotated[
+        ProcessFilelistMode, typer.Option(case_sensitive=False)
+    ] = ProcessFilelistMode.ask,
+    dryrun: Annotated[bool, typer.Option()] = False,
 ) -> None:
     if verbose:
         logger.setLevel(logging.DEBUG)
@@ -63,14 +76,19 @@ def ingest(
         logger.debug(f"starting ingest of {accession_id}")
 
         result_summary[accession_id] = IngestionResult()
-        persister = persistence_strategy_factory(
-            persistence_mode,
-            output_dir_base=settings.bia_data_dir,
-            accession_id=accession_id,
-            api_client=api_client,
-        )
+
+        persister = None
+        if not dryrun:
+            persister = persistence_strategy_factory(
+                persistence_mode,
+                output_dir_base=settings.bia_data_dir,
+                accession_id=accession_id,
+                api_client=api_client,
+            )
 
         submission = load_submission(accession_id)
+
+        submission_table = load_submission_table_info(accession_id)
 
         get_study(submission, result_summary, persister=persister)
 
@@ -82,12 +100,20 @@ def ingest(
             submission, result_summary, persister=persister
         )
 
-        get_file_reference_by_dataset(
-            submission,
-            experimental_imaging_datasets + image_annotation_datasets,
-            result_summary,
-            persister=persister,
+        process_files = determine_file_processing(
+            process_filelist,
+            file_count_limit=200000,
+            file_count=submission_table.files,
         )
+        if process_files:
+            get_file_reference_by_dataset(
+                submission,
+                experimental_imaging_datasets + image_annotation_datasets,
+                result_summary,
+                persister=persister,
+            )
+        else:
+            logger.info("Skipping file reference creation.")
 
         get_image_acquisition(submission, result_summary, persister=persister)
 
@@ -119,6 +145,7 @@ def create(
         ImageRepresentationUseType.THUMBNAIL,
         ImageRepresentationUseType.INTERACTIVE_DISPLAY,
     ],
+    dryrun: Annotated[bool, typer.Option()] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     """Create representations for specified file reference(s)"""
@@ -128,12 +155,14 @@ def create(
 
     result_summary = {}
 
-    persister = persistence_strategy_factory(
-        persistence_mode,
-        output_dir_base=settings.bia_data_dir,
-        accession_id=accession_id,
-        api_client=api_client,
-    )
+    persister = None
+    if not dryrun:
+        persister = persistence_strategy_factory(
+            persistence_mode,
+            output_dir_base=settings.bia_data_dir,
+            accession_id=accession_id,
+            api_client=api_client,
+        )
 
     submission = load_submission(accession_id)
     result_summary = {accession_id: IngestionResult()}
@@ -172,6 +201,23 @@ def create(
             errors += f"{item_name}: {item_value}\n"
     print(f"\n\n[green]--------- Successes ---------\n{successes}[/green]")
     print(f"\n\n[red]--------- Errors ---------\n{errors}[/red]")
+
+
+def determine_file_processing(
+    process_files_mode: ProcessFilelistMode, file_count_limit: int, file_count: int
+) -> bool:
+    file_count_limit = 200000
+    if process_files_mode == ProcessFilelistMode.always:
+        process_files = True
+    elif process_files_mode == ProcessFilelistMode.skip:
+        process_files = False
+    elif process_files_mode == ProcessFilelistMode.ask and file_count > file_count_limit:
+        process_files = typer.confirm(
+            f"The submission has {int(file_count):,} files, which is above the recommended limit of {int(file_count_limit):,}.\n Do you wish to attempt to process them?"
+        )
+    else:
+        process_files = True
+    return process_files
 
 
 @app.callback()

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -145,7 +145,6 @@ def create(
         ImageRepresentationUseType.THUMBNAIL,
         ImageRepresentationUseType.INTERACTIVE_DISPLAY,
     ],
-    dryrun: Annotated[bool, typer.Option()] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     """Create representations for specified file reference(s)"""
@@ -155,14 +154,13 @@ def create(
 
     result_summary = {}
 
-    persister = None
-    if not dryrun:
-        persister = persistence_strategy_factory(
-            persistence_mode,
-            output_dir_base=settings.bia_data_dir,
-            accession_id=accession_id,
-            api_client=api_client,
-        )
+
+    persister = persistence_strategy_factory(
+        persistence_mode,
+        output_dir_base=settings.bia_data_dir,
+        accession_id=accession_id,
+        api_client=api_client,
+    )
 
     submission = load_submission(accession_id)
     result_summary = {accession_id: IngestionResult()}

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -3,7 +3,7 @@ from typing import Dict
 from pathlib import Path
 import json
 import pytest
-from bia_ingest.biostudies import Submission, requests
+from bia_ingest.biostudies import Submission, SubmissionTable, requests
 from .utils import accession_id
 from bia_ingest.cli_logging import IngestionResult
 
@@ -19,6 +19,14 @@ def test_submission(base_path: Path) -> Submission:
     submission_path = base_path / "data" / "S-BIADTEST.json"
     json_data = json.loads(submission_path.read_text())
     submission = Submission.model_validate(json_data)
+    return submission
+
+
+@pytest.fixture
+def test_submission_table(base_path: Path) -> SubmissionTable:
+    submission_path = base_path / "data" / "S-BIADTEST_INFO.json"
+    json_data = json.loads(submission_path.read_text())
+    submission = SubmissionTable.model_validate(json_data)
     return submission
 
 

--- a/bia-ingest/test/data/S-BIADTEST_INFO.json
+++ b/bia-ingest/test/data/S-BIADTEST_INFO.json
@@ -1,0 +1,115 @@
+{
+    "columns": [
+      {
+        "name": "Name",
+        "title": "Name",
+        "visible": true,
+        "searchable": true,
+        "data": "Name",
+        "defaultContent": ""
+      },
+      {
+        "name": "Size",
+        "title": "Size",
+        "visible": true,
+        "searchable": false,
+        "data": "Size",
+        "defaultContent": ""
+      },
+      {
+        "name": "Section",
+        "title": "Section",
+        "visible": true,
+        "searchable": true,
+        "data": "Section",
+        "defaultContent": ""
+      },
+      {
+        "name": "AnnotationsIn",
+        "title": "AnnotationsIn",
+        "visible": true,
+        "searchable": true,
+        "data": "AnnotationsIn",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata1 key",
+        "title": "metadata1 key",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata1_key",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata2 key",
+        "title": "metadata2 key",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata2_key",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata3 key",
+        "title": "metadata3 key",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata3_key",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata4 key",
+        "title": "metadata4 key",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata4_key",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata5 key",
+        "title": "metadata5 key",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata5_key",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata6 key",
+        "title": "metadata6 key",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata6_key",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata1",
+        "title": "metadata1",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata1",
+        "defaultContent": ""
+      },
+      {
+        "name": "metadata2",
+        "title": "metadata2",
+        "visible": true,
+        "searchable": true,
+        "data": "metadata2",
+        "defaultContent": ""
+      }
+    ],
+    "files": 7,
+    "httpLink": "https://ftp.ebi.ac.uk/biostudies/fire/S-BIAD/TEST/S-BIADTEST",
+    "ftpLink": "ftp://ftp.ebi.ac.uk/biostudies/fire/S-BIAD/TEST/S-BIADTEST",
+    "globusLink": "https://app.globus.org/file-manager?origin_id=47772002-3e5b-4fd3-b97c-18cee38d6df2&origin_path=/biostudies/fire/S-BIAD/TEST/S-BIADTEST",
+    "isPublic": true,
+    "relPath": "S-BIAD/TEST/S-BIADTEST",
+    "hasZippedFolders": true,
+    "views": 0,
+    "released": 1717977600000,
+    "modified": 1719178151723,
+    "sections": [
+      "Study_Component-1",
+      "Study_Component-2",
+      "Annotations-29"
+    ]
+  }

--- a/bia-ingest/test/test_bia_ingest_cli.py
+++ b/bia-ingest/test/test_bia_ingest_cli.py
@@ -42,7 +42,7 @@ def expected_objects():
 
 
 def test_cli_writes_expected_files(
-    monkeypatch, tmp_path, test_submission, mock_request_get, expected_objects
+    monkeypatch, tmp_path, test_submission, test_submission_table, mock_request_get, expected_objects
 ):
     monkeypatch.setattr(settings, "bia_data_dir", str(tmp_path))
 
@@ -51,7 +51,12 @@ def test_cli_writes_expected_files(
     def _load_submission(accession_id: str) -> biostudies.Submission:
         return test_submission
 
+    def _load_submission_table_info(accession_id: str):
+        return test_submission_table
+    
     monkeypatch.setattr(cli, "load_submission", _load_submission)
+    monkeypatch.setattr(cli, "load_submission_table_info", _load_submission_table_info)
+
 
     result = runner.invoke(
         cli.app,
@@ -60,6 +65,8 @@ def test_cli_writes_expected_files(
             accession_id,
             "--persistence-mode",
             "disk",
+            "--process-filelist",
+            "always",
         ],
     )
     assert result.exit_code == 0


### PR DESCRIPTION
https://app.clickup.com/t/8695y91m7

Added check using the biostudies info tables before trying to process filelists

check has a y/N question for any studies with more than 200k files.

Example command to test:

poetry run biaingest ingest  S-BIAD1069 --process-filelist=skip --dryrun