### PR TITLE
add try-except and log for specimen creation

### DIFF
--- a/bia-ingest/bia_ingest/conversion/experimental_imaging_dataset.py
+++ b/bia-ingest/bia_ingest/conversion/experimental_imaging_dataset.py
@@ -151,10 +151,11 @@ def get_experimental_imaging_dataset(
         subject = get_specimen_for_dataset(
             submission, experimental_imaging_dataset, result_summary
         )
-        experimental_imaging_dataset.attribute["subject_uuid"] = str(subject.uuid)
-        experimental_imaging_dataset.attribute["biosample_uuid"] = str(
-            subject.sample_of_uuid
-        )
+        if subject:
+            experimental_imaging_dataset.attribute["subject_uuid"] = str(subject.uuid)
+            experimental_imaging_dataset.attribute["biosample_uuid"] = str(
+                subject.sample_of_uuid
+            )
 
         experimental_imaging_datasets.append(experimental_imaging_dataset)
 


### PR DESCRIPTION
While testing ingest i noticed i was getting uncaught exceptions for specimen creation. This change adds try-except and then log. e.g. for S-BIAD1006 (not this has a lot files)
```
INFO     Created SpecimenImagingPreparationProtocol. Count: 0                                                                                                    utils.py:37
INFO     Created SpecimenGrowthProtocol. Count: 0                                                                                                                utils.py:37
ERROR    Failed to create Specimen                                                                                                                               utils.py:26
INFO     Created ExperimentalImagingDataset. Count: 1                                                                                                            utils.py:37
INFO     Created ImageAnnotationDataset. Count: 0     
```