### PR TITLE
Pylance complaining about variables used in type hints

### DIFF
--- a/api/api/private.py
+++ b/api/api/private.py
@@ -27,11 +27,18 @@ models_private: List[shared_data_models.DocumentMixin] = [
 
 
 def make_post_item(t: Type[shared_data_models.DocumentMixin]):
-    async def post_item(doc: t, db: Annotated[Repository, Depends(get_db)]) -> None:
+    async def post_item(
+        doc: Type[shared_data_models.DocumentMixin],
+        db: Annotated[Repository, Depends(get_db)],
+    ) -> None:
         if doc.version < 0:
             raise ValueError("Bad doc version")
 
         await db.persist_doc(doc)
+
+    # Setting the annotation for the client to generate correctly.
+    # Variable type annotations are currently not allowed in python typing spec, so setting it manually after creating the function.
+    post_item.__annotations__["doc"] = t
 
     return post_item
 

--- a/api/api/public.py
+++ b/api/api/public.py
@@ -36,8 +36,12 @@ def make_get_item(t: Type[shared_data_models.DocumentMixin]):
     # @TODO: nicer wrapper?
     async def get_item(
         uuid: shared_data_models.UUID, db: Annotated[Repository, Depends(get_db)]
-    ) -> t:
+    ) -> Type[shared_data_models.DocumentMixin]:
         return await db.get_doc(uuid, t)
+
+    # Setting the annotation for the client to generate correctly.
+    # Variable type annotations are currently not allowed in python typing spec, so setting it manually after creating the function.
+    get_item.__annotations__["return"] = t
 
     return get_item
 
@@ -49,7 +53,7 @@ def make_reverse_link_handler(
 ):
     async def get_descendents(
         uuid: shared_data_models.UUID, db: Annotated[Repository, Depends(get_db)]
-    ) -> List[source_type]:
+    ) -> List[Type[shared_data_models.DocumentMixin]]:
         # Check target document actually exists (and is typed correctly - esp. important for union-typed links)
         #   see workaround_union_reference_types
         await db.get_doc(uuid, target_type)
@@ -59,6 +63,10 @@ def make_reverse_link_handler(
             link_attribute_value=uuid,
             source_type=source_type,
         )
+
+    # Setting the annotation for the client to generate correctly.
+    # Variable type annotations are currently not allowed in python typing spec, so setting it manually after creating the function.
+    get_descendents.__annotations__["return"] = List[source_type]
 
     return get_descendents
 


### PR DESCRIPTION
My Pylance currently complains:

Variable not allowed in type expressionPylance[reportInvalidTypeForm](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportInvalidTypeForm)

I don't know that we want to make this change, but i checked that the openapi.json generated by this and the one currently generated by main are the same (neither are the same as the one currently in the client). In any case this was useful to me to better understand how the api works.