### PR TITLE
Make accessing values of dicts created from sections during ingest insensitive to case of keys

### DIFF
--- a/bia-ingest/bia_ingest/ingest/annotation_method.py
+++ b/bia-ingest/bia_ingest/ingest/annotation_method.py
@@ -11,6 +11,7 @@ from ..cli_logging import log_model_creation_count
 from .biostudies.submission_parsing_utils import (
     find_sections_recursive,
     attributes_to_dict,
+    case_insensitive_get,
 )
 from .biostudies.api import (
     Submission,
@@ -62,7 +63,10 @@ def extract_annotation_method_dicts(submission: Submission) -> List[Dict[str, An
     for section in annotation_sections:
         attr_dict = attributes_to_dict(section.attributes)
 
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
 
         # TODO: change template to get source dataset information
         model_dict["source_dataset"] = []

--- a/bia-ingest/bia_ingest/ingest/biosample.py
+++ b/bia-ingest/bia_ingest/ingest/biosample.py
@@ -11,6 +11,7 @@ from ..cli_logging import log_model_creation_count
 from .biostudies.submission_parsing_utils import (
     find_sections_recursive,
     attributes_to_dict,
+    case_insensitive_get,
 )
 from .biostudies.api import (
     Submission,
@@ -57,7 +58,10 @@ def extract_biosample_dicts(submission: Submission) -> List[Dict[str, Any]]:
     for section in biosample_sections:
         attr_dict = attributes_to_dict(section.attributes)
 
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
 
         model_dict["accno"] = section.__dict__.get("accno", "")
 

--- a/bia-ingest/bia_ingest/ingest/biostudies/submission_parsing_utils.py
+++ b/bia-ingest/bia_ingest/ingest/biostudies/submission_parsing_utils.py
@@ -1,5 +1,4 @@
-from bia_ingest.ingest.biostudies.api import Section, Submission
-from .api import (
+from bia_ingest.ingest.biostudies.api import (
     Attribute,
     File,
     Section,
@@ -194,3 +193,21 @@ def find_datasets_with_file_lists(
             datasets_with_file_lists[fld["Title"]].append(fld)
 
     return datasets_with_file_lists
+
+
+def case_insensitive_get(d: dict, key: str, default: Any = "") -> Any:
+    """Access dict values with case insensitive keys
+
+    i.e. get value from {"Key": value} using "Key", "key", "KEY", etc.
+    """
+    if key in d:
+        return d[key]
+
+    # Line below assumes dict keys are unique when converted to lcase.
+    mapping_dict = {k.lower(): k for k in d.keys()}
+
+    key = key.lower()
+    if key in mapping_dict:
+        return d[mapping_dict[key]]
+    else:
+        return default

--- a/bia-ingest/bia_ingest/ingest/generic_conversion_utils.py
+++ b/bia-ingest/bia_ingest/ingest/generic_conversion_utils.py
@@ -7,6 +7,7 @@ from bia_ingest.ingest.biostudies.submission_parsing_utils import (
     find_sections_recursive,
     mattributes_to_dict,
     attributes_to_dict,
+    case_insensitive_get,
 )
 from .biostudies.api import (
     Submission,
@@ -42,7 +43,10 @@ def get_generic_section_as_list(
             attr_dict = attributes_to_dict(section.attributes)
         else:
             attr_dict = mattributes_to_dict(section.attributes, mapped_attrs_dict)
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
         if mapped_object is None:
             return_list.append(model_dict)
         else:

--- a/bia-ingest/bia_ingest/ingest/image_acquisition.py
+++ b/bia-ingest/bia_ingest/ingest/image_acquisition.py
@@ -12,6 +12,7 @@ from ..bia_object_creation_utils import (
 from ..cli_logging import log_model_creation_count
 from .biostudies.submission_parsing_utils import (
     find_sections_recursive,
+    case_insensitive_get,
 )
 from .biostudies.api import (
     Submission,
@@ -64,7 +65,10 @@ def extract_image_acquisition_dicts(submission: Submission) -> List[Dict[str, An
     for section in acquisition_sections:
         attr_dict = attributes_to_dict(section.attributes)
 
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
 
         if isinstance(model_dict["imaging_method_name"], str):
             model_dict["imaging_method_name"] = [

--- a/bia-ingest/bia_ingest/ingest/specimen_growth_protocol.py
+++ b/bia-ingest/bia_ingest/ingest/specimen_growth_protocol.py
@@ -12,6 +12,7 @@ from ..cli_logging import log_model_creation_count
 from .biostudies.submission_parsing_utils import (
     find_sections_recursive,
     attributes_to_dict,
+    case_insensitive_get,
 )
 from .biostudies.api import (
     Submission,
@@ -62,7 +63,10 @@ def extract_specimen_growth_protocol_dicts(
     for section in specimen_sections:
         attr_dict = attributes_to_dict(section.attributes)
 
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
 
         model_dict["accno"] = section.__dict__.get("accno", "")
         model_dict["accession_id"] = submission.accno

--- a/bia-ingest/bia_ingest/ingest/specimen_imaging_preparation_protocol.py
+++ b/bia-ingest/bia_ingest/ingest/specimen_imaging_preparation_protocol.py
@@ -11,6 +11,7 @@ from ..cli_logging import log_model_creation_count
 from .biostudies.submission_parsing_utils import (
     find_sections_recursive,
     attributes_to_dict,
+    case_insensitive_get,
 )
 from .biostudies.api import (
     Submission,
@@ -61,7 +62,10 @@ def extract_specimen_preparation_protocol_dicts(
     for section in specimen_sections:
         attr_dict = attributes_to_dict(section.attributes)
 
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
 
         # Currently generates empty list as we need to change the submission template
         model_dict["signal_channel_information"] = []

--- a/bia-ingest/bia_ingest/ingest/study.py
+++ b/bia-ingest/bia_ingest/ingest/study.py
@@ -7,6 +7,7 @@ from .biostudies.submission_parsing_utils import (
     attributes_to_dict,
     find_sections_recursive,
     mattributes_to_dict,
+    case_insensitive_get,
 )
 
 from ..bia_object_creation_utils import dict_to_uuid
@@ -139,7 +140,10 @@ def get_external_reference(
     return_list = []
     for section in sections:
         attr_dict = attributes_to_dict(section.attributes)
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
         try:
             return_list.append(
                 semantic_models.ExternalReference.model_validate(model_dict)
@@ -224,7 +228,10 @@ def get_affiliation(
     for section in organisation_sections:
         attr_dict = attributes_to_dict(section.attributes)
 
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
         try:
             affiliation_dict[section.accno] = (
                 semantic_models.Affiliation.model_validate(model_dict)
@@ -258,7 +265,10 @@ def get_publication(
     for section in publication_sections:
         attr_dict = attributes_to_dict(section.attributes)
 
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
         try:
             publications.append(semantic_models.Publication.model_validate(model_dict))
         except ValidationError:
@@ -293,7 +303,10 @@ def get_contributor(
     contributors = []
     for section in author_sections:
         attr_dict = mattributes_to_dict(section.attributes, affiliation_dict)
-        model_dict = {k: attr_dict.get(v, default) for k, v, default in key_mapping}
+        model_dict = {
+            k: case_insensitive_get(attr_dict, v, default)
+            for k, v, default in key_mapping
+        }
         # TODO: Find out if authors can have more than one organisation ->
         #       what are the implications for mattributes_to_dict?
         if model_dict["affiliation"] is None:


### PR DESCRIPTION
Fix to bug arising from difference in cases of names of some sections in submission tool forms and BIA yaml template. E.g.
`Sample preparation protocol` in [S-BIAD1327](https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BIAD1327) submitted using submission tool and `Sample Preparation Protocol` in [S-BIAD1117](https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BIAD1117) submitted using yaml template.

This fix creates a function to access dictionaries using case insensitive keys and is applied to all instances in ingest where mapping occurs using names from biostudies sections.