### PR TITLE
Logging features fixes

### DIFF
--- a/bia-ingest/README.md
+++ b/bia-ingest/README.md
@@ -46,3 +46,17 @@ To run ingest without either saving to disk or writing to the api run with --dry
 ```sh
 $ poetry run biaingest ingest --dryrun S-BIAD1285
 ```
+
+### Filelist processing settings
+
+Some studies have huge filelists, which can cause issues when running locally. Therefore, there is a --process-filelist setting to control how file lists are handled (and therefore whether FileReferences get generated). The default value, "ask", will prompt the user with a y/n question for studies that have more than 200,000 files. "skip" avoids attempting to even download or process the filelist. "always" processes the filelist regardless of number of files in the study. An example of skipping, e.g. for debugging, alongside the dryrun option would be:
+```sh
+$ poetry run biaingest ingest --dryrun --process-filelist skip S-BIAD1285
+```
+
+### Results table
+When ingest finishes a table of results is printed out. To also get this table written to a csv (which can be useful when running ingest on a lot of studies), add the --write-csv option with the path of where to write out the file.
+
+```sh
+$ poetry run biaingest ingest S-BIAD1285 S-BIAD1385 --write-csv output_table.csv
+```

--- a/bia-ingest/bia_ingest/ingest/biosample.py
+++ b/bia-ingest/bia_ingest/ingest/biosample.py
@@ -148,11 +148,12 @@ def get_biosample_by_study_component(
     for biosample_list in biosample_by_study_component.values():
         biosamples |= {biosample.uuid: biosample for biosample in biosample_list}
     biosamples = list(biosamples.values())
+    log_model_creation_count(
+        bia_data_model.BioSample, len(biosamples), result_summary[submission.accno]
+    )
     if persister and biosamples:
         persister.persist(biosamples)
-        log_model_creation_count(
-            bia_data_model.BioSample, len(biosamples), result_summary[submission.accno]
-        )
+
     return biosample_by_study_component
 
 

--- a/bia-ingest/pyproject.toml
+++ b/bia-ingest/pyproject.toml
@@ -16,6 +16,7 @@ bia-integrator-api = { path = "../clients/python", develop = true }
 typer = "^0.12.3"
 typing-extensions = "^4.12.2"
 pydantic-settings = "^2.3.4"
+rich-tools = "^0.5.1"
 
 [tool.poetry.scripts]
 biaingest = "bia_ingest.cli:app"


### PR DESCRIPTION
- Fix to biosample logic so that creation of biosamples is logged regardless of persistence strategy (was causing a bug with the --dryrun option)
- Added generic error catching which get logged in the output table, as well as an option to write the table to a csv for easier analysis of results.