### PR TITLE
allow empty urls or empty objects from biostudies submission

### DIFF
--- a/bia-ingest/bia_ingest/biostudies/api.py
+++ b/bia-ingest/bia_ingest/biostudies/api.py
@@ -66,6 +66,10 @@ class Link(BaseModel):
 
 
 class Empty(BaseModel):
+    """
+    A class for empty objects, i.e. { } in a json document, that can come up in biostudies responses (e.g. some submission links).
+    """
+
     model_config = ConfigDict(extra="forbid")
 
 

--- a/bia-ingest/bia_ingest/biostudies/api.py
+++ b/bia-ingest/bia_ingest/biostudies/api.py
@@ -6,7 +6,7 @@ from typing import List, Union, Dict, Optional, Any
 from copy import deepcopy
 
 import requests
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, TypeAdapter, ConfigDict
 
 
 logger = logging.getLogger("__main__." + __name__)
@@ -54,7 +54,7 @@ class File(BaseModel):
 
 
 class Link(BaseModel):
-    url: str
+    url: Optional[str] = None
     attributes: List[Attribute] = []
 
     def as_tsv(self) -> str:
@@ -65,12 +65,16 @@ class Link(BaseModel):
         return tsv_rep
 
 
+class Empty(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
 class Section(BaseModel):
     type: str
     accno: Optional[str] = ""
     attributes: List[Attribute] = []
     subsections: List[Union["Section", List["Section"]]] = []
-    links: Union[List[Link], List[List[Link]]] = []
+    links: List[Union[Link, List[Link], Empty]] = []
     files: List[Union[File, List[File]]] = []
 
     def as_tsv(self, parent_accno: Optional[str] = None) -> str:

--- a/bia-ingest/bia_ingest/biostudies/v4/study.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/study.py
@@ -259,8 +259,6 @@ def get_affiliation(
             for k, v, default in key_mapping
         }
 
-        result_summary_for_accession_if = result_summary[submission.accno]
-
         affiliation = dict_to_api_model(
             model_dict, semantic_models.Affiliation, result_summary[submission.accno]
         )

--- a/bia-ingest/bia_ingest/cli_logging.py
+++ b/bia-ingest/bia_ingest/cli_logging.py
@@ -86,11 +86,12 @@ def tabulate_ingestion_errors(
             if field.endswith("ValidationErrorCount") and (value > 0):
                 error_message += f"{field}: {value}; "
 
-        if result.Dataset_CreationCount == 0:
-            error_message += "No datasets were created; "
+        if result.ProcessingVersion == BioStudiesProcessingVersion.V4:
 
-        if result.Dataset_CreationCount > 0:
-            if result.ProcessingVersion == BioStudiesProcessingVersion.V4:
+            if result.Dataset_CreationCount == 0:
+                error_message += "No datasets were created; "
+
+            if result.Dataset_CreationCount > 0:
                 if not (
                     result.BioSample_CreationCount
                     == 0 & result.SpecimenImagingPreparationProtocol_CreationCount
@@ -106,11 +107,6 @@ def tabulate_ingestion_errors(
                         error_message += "Incomplete REMBI objects created; "
                 else:
                     error_message += "No REMBI objects associated with Dataset; "
-            elif (
-                result.ProcessingVersion
-                == BioStudiesProcessingVersion.BIOSTUDIES_DEFAULT
-            ):
-                pass
 
         if result.Uncaught_Exception:
             error_message += f"Uncaught exception: {result.Uncaught_Exception}"

--- a/bia-ingest/bia_ingest/cli_logging.py
+++ b/bia-ingest/bia_ingest/cli_logging.py
@@ -87,26 +87,25 @@ def tabulate_ingestion_errors(
                 error_message += f"{field}: {value}; "
 
         if result.ProcessingVersion == BioStudiesProcessingVersion.V4:
-
             if result.Dataset_CreationCount == 0:
                 error_message += "No datasets were created; "
 
-            if result.Dataset_CreationCount > 0:
-                if not (
-                    result.BioSample_CreationCount
-                    == 0 & result.SpecimenImagingPreparationProtocol_CreationCount
-                    == 0 & result.ImageAcquisitionProtocol_CreationCount
-                    == 0
-                ):
-                    if (
-                        result.BioSample_CreationCount
-                        == 0 | result.SpecimenImagingPreparationProtocol_CreationCount
-                        == 0 | result.ImageAcquisitionProtocol_CreationCount
-                        == 0
-                    ):
-                        error_message += "Incomplete REMBI objects created; "
-                else:
-                    error_message += "No REMBI objects associated with Dataset; "
+            rembi_object_creation_count = [
+                result.BioSample_CreationCount,
+                result.SpecimenImagingPreparationProtocol_CreationCount,
+                result.ImageAcquisitionProtocol_CreationCount,
+            ]
+            if any(rembi_object_creation_count) and not all(
+                rembi_object_creation_count
+            ):
+                error_message += "Incomplete REMBI objects created; "
+
+            if (
+                not any(rembi_object_creation_count)
+                and not result.AnnotationMethod_CreationCount
+                and not result.Protocol_CreationCount
+            ):
+                error_message += "No creation protocols created; "
 
         if result.Uncaught_Exception:
             error_message += f"Uncaught exception: {result.Uncaught_Exception}"


### PR DESCRIPTION
Also fixes failure check in logging for non-v4 studies

to test with empty link object:

poetry run biaingest ingest --process-filelist skip --dryrun S-BSST310 -v    

to test with link object without url field, only attributes:

poetry run biaingest ingest --process-filelist skip --dryrun S-BSST229 -v    

ticket: https://app.clickup.com/t/8696v7cvz
