### PR TITLE
deal with ontology values in subsections of protocols/biosample

### DIFF
--- a/bia-ingest/bia_ingest/bia_object_creation_utils.py
+++ b/bia-ingest/bia_ingest/bia_object_creation_utils.py
@@ -57,6 +57,10 @@ def dicts_to_api_models(
             api_models.append(api_model_class.model_validate(model_dict))
         except ValidationError:
             log_failed_model_creation(api_model_class, valdiation_error_tracking)
+
+    log_model_creation_count(
+        api_model_class, len(api_models), valdiation_error_tracking
+    )
     return api_models
 
 
@@ -75,7 +79,7 @@ def dict_map_to_api_models(
             api_models[reference_id] = api_model_class.model_validate(model_dict)
         except ValidationError:
             log_failed_model_creation(api_model_class, valdiation_error_tracking)
-    
+
     log_model_creation_count(
         api_model_class, len(api_models), valdiation_error_tracking
     )

--- a/bia-ingest/bia_ingest/biostudies/v4/dataset.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/dataset.py
@@ -50,12 +50,6 @@ def get_dataset(
         result_summary[submission.accno],
     )
 
-    log_model_creation_count(
-        bia_data_model.Dataset,
-        len(datasets),
-        result_summary[submission.accno],
-    )
-
     if persister and datasets:
         persister.persist(datasets)
 

--- a/bia-ingest/bia_ingest/biostudies/v4/growth_protocol.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/growth_protocol.py
@@ -4,7 +4,6 @@ from typing import Any, Optional
 
 from ...bia_object_creation_utils import (
     dict_to_uuid,
-    dicts_to_api_models,
     dict_map_to_api_models,
     filter_model_dictionary,
 )

--- a/bia-ingest/bia_ingest/biostudies/v4/study.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/study.py
@@ -352,9 +352,6 @@ def get_contributor(
     contributors = dicts_to_api_models(
         contributor_dicts, semantic_models.Contributor, result_summary[submission.accno]
     )
-    log_model_creation_count(
-        semantic_models.Contributor, len(contributors), result_summary[submission.accno]
-    )
 
     return contributors
 

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -150,6 +150,21 @@ def determine_biostudies_processing_version(submission: Submission):
     override_map = {
         "S-BIAD43": BioStudiesProcessingVersion.V4,
         "S-BIAD44": BioStudiesProcessingVersion.V4,
+        "S-BIAD590": BioStudiesProcessingVersion.V4,
+        "S-BIAD599": BioStudiesProcessingVersion.V4,
+        "S-BIAD628": BioStudiesProcessingVersion.V4,
+        "S-BIAD677": BioStudiesProcessingVersion.V4,
+        "S-BIAD686": BioStudiesProcessingVersion.V4,
+        "S-BIAD822": BioStudiesProcessingVersion.V4,
+        "S-BIAD843": BioStudiesProcessingVersion.V4,
+        "S-BIAD887": BioStudiesProcessingVersion.V4,
+        "S-BIAD916": BioStudiesProcessingVersion.V4,
+        "S-BIAD970": BioStudiesProcessingVersion.V4,
+        "S-BIAD1021": BioStudiesProcessingVersion.V4,
+        "S-BIAD1070": BioStudiesProcessingVersion.V4,
+        "S-BIAD1076": BioStudiesProcessingVersion.V4,
+        "S-BIAD1244": BioStudiesProcessingVersion.V4,
+        "S-BIAD650": BioStudiesProcessingVersion.FALLBACK,  # Uses v4 template but doesn't actually have rembi components
     }
     accession_id = submission.accno
     if accession_id in override_map:

--- a/bia-ingest/bia_ingest/cli_logging.py
+++ b/bia-ingest/bia_ingest/cli_logging.py
@@ -23,44 +23,48 @@ class IngestionResult(CLIResult):
     )
     Study_CreationCount: int = Field(default=0)
     Study_ValidationErrorCount: int = Field(default=0)
-    Dataset_CreationCount: int = Field(default=0)
-    Dataset_ValidationErrorCount: int = Field(default=0)
+    Contributor_CreationCount: int = Field(default=0)
+    Contributor_ValidationErrorCount: int = Field(default=0)
     Affiliation_CreationCount: int = Field(default=0)
     Affiliation_ValidationErrorCount: int = Field(default=0)
-    Contributor_CreationCount: int = Field(default=0)
-    Contributor_ValidationErrorCount: int = Field(default=0)
+    # TODO: start ingesting these from biostudies
+    # ExternalLink_CreationCount: int = Field(default=0)
+    # ExternalLink_ValidationErrorCount: int = Field(default=0)
+    # Publication_CreationCount: int = Field(default=0)
+    # Publication_ValidationErrorCount: int = Field(default=0)
+
+    Dataset_CreationCount: int = Field(default=0)
+    Dataset_ValidationErrorCount: int = Field(default=0)
+
     FileReference_CreationCount: int = Field(default=0)
     FileReferenceValidation_ErrorCount: int = Field(default=0)
-    BioSample_CreationCount: int = Field(default=0)
-    BioSample_ValidationErrorCount: int = Field(default=0)
-    SpecimenImagingPreparationProtocol_CreationCount: int = Field(default=0)
-    SpecimenImagingPreparationProtocol_ValidationErrorCount: int = Field(default=0)
-    Specimen_CreationCount: int = Field(default=0)
-    Specimen_ValidationErrorCount: int = Field(default=0)
-    ImageAcquisitionProtocol_CreationCount: int = Field(default=0)
-    ImageAcquisitionProtocol_ValidationErrorCount: int = Field(default=0)
-    AnnotationMethod_CreationCount: int = Field(default=0)
-    AnnotationMethod_ValidationErrorCount: int = Field(default=0)
+
     AnnotationFile_CreationCount: int = Field(default=0)
     AnnotationFile_ValidationErrorCount: int = Field(default=0)
-    ImageAnalysisMethod_CreationCount: int = Field(default=0)
-    ImageAnalysisMethod_ValidationErrorCount: int = Field(default=0)
-    ImageCorrelationMethod_CreationCount: int = Field(default=0)
-    ImageCorrelationMethod_ValidationErrorCount: int = Field(default=0)
-    RenderedView_CreationCount: int = Field(default=0)
-    RenderedView_ValidationErrorCount: int = Field(default=0)
-    Channel_CreationCount: int = Field(default=0)
-    Channel_ValidationErrorCount: int = Field(default=0)
-    Organism_CreationCount: int = Field(default=0)
-    Organism_ValidationErrorCount: int = Field(default=0)
+
     Protocol_CreationCount: int = Field(default=0)
     Protocol_ValidationErrorCount: int = Field(default=0)
-    ExternalLink_CreationCount: int = Field(default=0)
-    ExternalLink_ValidationErrorCount: int = Field(default=0)
-    Contributor_CreationCount: int = Field(default=0)
-    Contributor_ValidationErrorCount: int = Field(default=0)
-    Organisation_CreationCount: int = Field(default=0)
-    Organisation_ValidationErrorCount: int = Field(default=0)
+
+    BioSample_CreationCount: int = Field(default=0)
+    BioSample_ValidationErrorCount: int = Field(default=0)
+    Taxon_CreationCount: int = Field(default=0)
+    Taxon_ValidationErrorCount: int = Field(default=0)
+
+    SpecimenImagingPreparationProtocol_CreationCount: int = Field(default=0)
+    SpecimenImagingPreparationProtocol_ValidationErrorCount: int = Field(default=0)
+
+    ImageAcquisitionProtocol_CreationCount: int = Field(default=0)
+    ImageAcquisitionProtocol_ValidationErrorCount: int = Field(default=0)
+
+    AnnotationMethod_CreationCount: int = Field(default=0)
+    AnnotationMethod_ValidationErrorCount: int = Field(default=0)
+
+    ImageAnalysisMethod_CreationCount: int = Field(default=0)
+    ImageAnalysisMethod_ValidationErrorCount: int = Field(default=0)
+
+    ImageCorrelationMethod_CreationCount: int = Field(default=0)
+    ImageCorrelationMethod_ValidationErrorCount: int = Field(default=0)
+
     Uncaught_Exception: str = Field(default="")
 
 

--- a/bia-ingest/test/data/biad_v4/S-BIADTEST.json
+++ b/bia-ingest/test/data/biad_v4/S-BIADTEST.json
@@ -179,9 +179,6 @@
         "name" : "Title",
         "value" : "Test Biosample 1"
       }, {
-        "name" : "Organism",
-        "value" : "Homo sapiens (human)"
-      }, {
         "name" : "Description",
         "value" : "Test description 1 (\"with some escaped chars\") "
       }, {
@@ -196,7 +193,20 @@
       }, {
         "name" : "Intrinsic variable",
         "value" : "Test intrinsic variable 1\nwith escaped character"
-      } ]
+      } ],
+      "subsections": [
+        {
+          "accno" : "Organism-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name": "Common name",
+            "value" : "human"
+          }, {
+            "name": "Scientific name",
+            "value" : "Homo sapiens"
+          } ]
+        } 
+      ]
     }, {
       "accno" : "Biosample-2",
       "type" : "Biosample",


### PR DESCRIPTION
Update to deal with ontology structured subsections in image acquisitions and biosamples a good study to test with is:

`poetry run biaingest ingest --process-filelist skip S-BIAD43 -v -c`

https://app.clickup.com/t/8696v7mpx

Also updated the study -> processing mode list to cover some of the bia-agent ingested studies. We could alternatively try to map on other keys in the submission.

https://app.clickup.com/t/8696v7zke