### PR TITLE
updated export to use new association structure in attributes

### DIFF
--- a/bia-export/README.md
+++ b/bia-export/README.md
@@ -46,7 +46,7 @@ This will create `bia-image-export.json` using the example test data.
 Image Dataset Export
 Run:
     `poetry run bia-export datasets-for-website-image S-BIADTEST -o bia-dataset-export.json -r test/input_data`
-This will create `bia-dataset-exportt.json` using the example test data.
+This will create `bia-dataset-export.json` using the example test data.
 
 
 Commands to generate the current BIA data

--- a/bia-export/bia_export/website_export/studies/models.py
+++ b/bia-export/bia_export/website_export/studies/models.py
@@ -4,6 +4,8 @@ from bia_export.website_export.website_models import (
     BioSample,
     ImageAcquisitionProtocol,
     SpecimenImagingPreparationProtocol,
+    AnnotationMethod,
+    Protocol,
     CLIContext,
 )
 from bia_integrator_api import models
@@ -22,11 +24,19 @@ class Dataset(models.Dataset):
     specimen_imaging_preparation_protocol: Optional[
         List[SpecimenImagingPreparationProtocol]
     ] = Field(
-        description="""Processes involved in the preprapartion of the samples for imaged.""",
+        description="""Processes involved in the preprapartion of the samples for imaging.""",
         default_factory=list,
     )
     biological_entity: Optional[List[BioSample]] = Field(
         description="""The biological entity or entities that were imaged.""",
+        default_factory=list,
+    )
+    annotation_process: Optional[List[AnnotationMethod]] = Field(
+        description="""Methods used to create the annotated image.""",
+        default_factory=list,
+    )
+    other_creation_process: Optional[List[Protocol]] = Field(
+        description="""Other protocols followed in order to create the images in this dataset.""",
         default_factory=list,
     )
     image: List[models.Image] = Field(
@@ -57,6 +67,8 @@ class StudyCLIContext(CLIContext):
             ImageAcquisitionProtocol: set(),
             BioSample: set(),
             SpecimenImagingPreparationProtocol: set(),
+            AnnotationMethod: set(),
+            Protocol: set(),
         },
         description="""Tracks e.g. which BioSamples have been displayed in previous dataset sections to 
         determine whether details should default to open or closed.""",

--- a/bia-export/test/input_data/dataset/S-BIADTEST/21999a9f-6f16-45d4-91c9-ed46cbfe015c.json
+++ b/bia-export/test/input_data/dataset/S-BIADTEST/21999a9f-6f16-45d4-91c9-ed46cbfe015c.json
@@ -7,7 +7,15 @@
     "version": 1
   },
   "description": null,
-  "attribute": [],
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "annotation_method_uuid",
+      "value": {
+          "annotation_method_uuid": ["ef019f5d-d3e0-4122-89ae-1d1d07d2830f"]
+      }
+    }
+  ],
   "example_image_uri": [],
   "submitted_in_study_uuid": "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71"
 }

--- a/bia-export/test/input_data/dataset/S-BIADTEST/47a4ab60-c76d-4424-bfaa-c2a024de720c.json
+++ b/bia-export/test/input_data/dataset/S-BIADTEST/47a4ab60-c76d-4424-bfaa-c2a024de720c.json
@@ -4,6 +4,27 @@
     "description": "Description of study component 1",
     "attribute": [
         {
+            "provenance": "bia_ingest",
+            "name": "image_acquisition_protocol_uuid",
+            "value": {
+                "image_acquisition_protocol_uuid": ["c2e44a1b-a43c-476e-8ddf-8587f4c955b3"]
+            }
+        },
+        {
+            "provenance": "bia_ingest",
+            "name": "specimen_imaging_preparation_protocol_uuid",
+            "value": {
+                "specimen_imaging_preparation_protocol_uuid": ["7199d730-29f1-4ad8-b599-e9089cbb2d7b"]
+            }
+        },
+        {
+            "provenance": "bia_ingest",
+            "name": "bio_sample_uuid",
+            "value": {
+                "bio_sample_uuid": ["64a67727-4e7c-469a-91c4-6219ae072e99", "6950718c-4917-47a1-a807-11b874e80a23"]
+            }
+        },
+        {
             "value": {
                 "image_analysis": "Test image analysis",
                 "image_correlation": null,

--- a/bia-export/test/input_data/dataset/S-BIADTEST/850a1ca3-9681-4a8a-b625-477936fcb954.json
+++ b/bia-export/test/input_data/dataset/S-BIADTEST/850a1ca3-9681-4a8a-b625-477936fcb954.json
@@ -9,6 +9,27 @@
     "description": "Description of study component 2",
     "attribute": [
         {
+            "provenance": "bia_ingest",
+            "name": "image_acquisition_protocol_uuid",
+            "value": {
+                "image_acquisition_protocol_uuid": ["c2e44a1b-a43c-476e-8ddf-8587f4c955b3"]
+            }
+        },
+        {
+            "provenance": "bia_ingest",
+            "name": "specimen_imaging_preparation_protocol_uuid",
+            "value": {
+                "specimen_imaging_preparation_protocol_uuid": ["7199d730-29f1-4ad8-b599-e9089cbb2d7b"]
+            }
+        },
+        {
+            "provenance": "bia_ingest",
+            "name": "bio_sample_uuid",
+            "value": {
+                "bio_sample_uuid": ["64a67727-4e7c-469a-91c4-6219ae072e99"]
+            }
+        },
+        {
             "value": {
                 "image_analysis": "Test image analysis",
                 "image_correlation": null,

--- a/bia-export/test/output_data/bia_dataset_export.json
+++ b/bia-export/test/output_data/bia_dataset_export.json
@@ -7,7 +7,17 @@
             "type_name": "Dataset",
             "version": 1
         },
-        "attribute": [],
+        "attribute": [
+            {
+                "provenance": "bia_ingest",
+                "name": "annotation_method_uuid",
+                "value": {
+                    "annotation_method_uuid": [
+                        "ef019f5d-d3e0-4122-89ae-1d1d07d2830f"
+                    ]
+                }
+            }
+        ],
         "description": null,
         "analysis_method": null,
         "correlation_method": null,
@@ -102,6 +112,34 @@
             "version": 1
         },
         "attribute": [
+            {
+                "provenance": "bia_ingest",
+                "name": "image_acquisition_protocol_uuid",
+                "value": {
+                    "image_acquisition_protocol_uuid": [
+                        "c2e44a1b-a43c-476e-8ddf-8587f4c955b3"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "specimen_imaging_preparation_protocol_uuid",
+                "value": {
+                    "specimen_imaging_preparation_protocol_uuid": [
+                        "7199d730-29f1-4ad8-b599-e9089cbb2d7b"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "bio_sample_uuid",
+                "value": {
+                    "bio_sample_uuid": [
+                        "64a67727-4e7c-469a-91c4-6219ae072e99",
+                        "6950718c-4917-47a1-a807-11b874e80a23"
+                    ]
+                }
+            },
             {
                 "provenance": "bia_ingest",
                 "name": "associations",
@@ -225,6 +263,33 @@
             "version": 1
         },
         "attribute": [
+            {
+                "provenance": "bia_ingest",
+                "name": "image_acquisition_protocol_uuid",
+                "value": {
+                    "image_acquisition_protocol_uuid": [
+                        "c2e44a1b-a43c-476e-8ddf-8587f4c955b3"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "specimen_imaging_preparation_protocol_uuid",
+                "value": {
+                    "specimen_imaging_preparation_protocol_uuid": [
+                        "7199d730-29f1-4ad8-b599-e9089cbb2d7b"
+                    ]
+                }
+            },
+            {
+                "provenance": "bia_ingest",
+                "name": "bio_sample_uuid",
+                "value": {
+                    "bio_sample_uuid": [
+                        "64a67727-4e7c-469a-91c4-6219ae072e99"
+                    ]
+                }
+            },
             {
                 "provenance": "bia_ingest",
                 "name": "associations",

--- a/bia-export/test/output_data/bia_study_export.json
+++ b/bia-export/test/output_data/bia_study_export.json
@@ -86,7 +86,17 @@
                     "type_name": "Dataset",
                     "version": 1
                 },
-                "attribute": [],
+                "attribute": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "annotation_method_uuid",
+                        "value": {
+                            "annotation_method_uuid": [
+                                "ef019f5d-d3e0-4122-89ae-1d1d07d2830f"
+                            ]
+                        }
+                    }
+                ],
                 "description": null,
                 "analysis_method": null,
                 "correlation_method": null,
@@ -95,6 +105,29 @@
                 "acquisition_process": [],
                 "specimen_imaging_preparation_protocol": [],
                 "biological_entity": [],
+                "annotation_process": [
+                    {
+                        "default_open": true,
+                        "title_id": "Annotations and segmentation masks",
+                        "uuid": "ef019f5d-d3e0-4122-89ae-1d1d07d2830f",
+                        "version": 1,
+                        "model": {
+                            "type_name": "AnnotationMethod",
+                            "version": 1
+                        },
+                        "attribute": [],
+                        "protocol_description": "Test protocol description",
+                        "annotation_criteria": "Test annotation criteria.",
+                        "annotation_coverage": "Test annotation coverage.",
+                        "transformation_description": null,
+                        "spatial_information": null,
+                        "method_type": [
+                            "other"
+                        ],
+                        "annotation_source_indicator": null
+                    }
+                ],
+                "other_creation_process": [],
                 "image": [
                     {
                         "uuid": "7966aa52-e3db-4ce3-801e-44c524b73ee3",
@@ -125,6 +158,34 @@
                     "version": 1
                 },
                 "attribute": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "image_acquisition_protocol_uuid",
+                        "value": {
+                            "image_acquisition_protocol_uuid": [
+                                "c2e44a1b-a43c-476e-8ddf-8587f4c955b3"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "specimen_imaging_preparation_protocol_uuid",
+                        "value": {
+                            "specimen_imaging_preparation_protocol_uuid": [
+                                "7199d730-29f1-4ad8-b599-e9089cbb2d7b"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "bio_sample_uuid",
+                        "value": {
+                            "bio_sample_uuid": [
+                                "64a67727-4e7c-469a-91c4-6219ae072e99",
+                                "6950718c-4917-47a1-a807-11b874e80a23"
+                            ]
+                        }
+                    },
                     {
                         "provenance": "bia_ingest",
                         "name": "associations",
@@ -223,7 +284,17 @@
                             "Test intrinsic variable 1\\nwith escaped character"
                         ],
                         "growth_protocol_uuid": "a2ce3950-3b28-40b3-a6a5-23c4f7864912",
-                        "growth_protocol": null
+                        "growth_protocol": {
+                            "title_id": "Test specimen 1",
+                            "uuid": "a2ce3950-3b28-40b3-a6a5-23c4f7864912",
+                            "version": 2,
+                            "model": {
+                                "type_name": "Protocol",
+                                "version": 1
+                            },
+                            "attribute": [],
+                            "protocol_description": "Test sample growth protocol 1"
+                        }
                     },
                     {
                         "default_open": true,
@@ -254,9 +325,21 @@
                             "Test intrinsic variable 2"
                         ],
                         "growth_protocol_uuid": "a2ce3950-3b28-40b3-a6a5-23c4f7864912",
-                        "growth_protocol": null
+                        "growth_protocol": {
+                            "title_id": "Test specimen 1",
+                            "uuid": "a2ce3950-3b28-40b3-a6a5-23c4f7864912",
+                            "version": 2,
+                            "model": {
+                                "type_name": "Protocol",
+                                "version": 1
+                            },
+                            "attribute": [],
+                            "protocol_description": "Test sample growth protocol 1"
+                        }
                     }
                 ],
+                "annotation_process": [],
+                "other_creation_process": [],
                 "image": [
                     {
                         "uuid": "e7322131-8e27-455d-b9fc-8add0719af70",
@@ -287,6 +370,33 @@
                     "version": 1
                 },
                 "attribute": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "image_acquisition_protocol_uuid",
+                        "value": {
+                            "image_acquisition_protocol_uuid": [
+                                "c2e44a1b-a43c-476e-8ddf-8587f4c955b3"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "specimen_imaging_preparation_protocol_uuid",
+                        "value": {
+                            "specimen_imaging_preparation_protocol_uuid": [
+                                "7199d730-29f1-4ad8-b599-e9089cbb2d7b"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "bio_sample_uuid",
+                        "value": {
+                            "bio_sample_uuid": [
+                                "64a67727-4e7c-469a-91c4-6219ae072e99"
+                            ]
+                        }
+                    },
                     {
                         "provenance": "bia_ingest",
                         "name": "associations",
@@ -329,8 +439,66 @@
                         ]
                     }
                 ],
-                "specimen_imaging_preparation_protocol": [],
-                "biological_entity": [],
+                "specimen_imaging_preparation_protocol": [
+                    {
+                        "default_open": false,
+                        "title_id": "Test specimen 1",
+                        "uuid": "7199d730-29f1-4ad8-b599-e9089cbb2d7b",
+                        "version": 1,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "Test sample preparation protocol 1",
+                        "signal_channel_information": []
+                    }
+                ],
+                "biological_entity": [
+                    {
+                        "default_open": false,
+                        "title_id": "Test Biosample 1",
+                        "uuid": "64a67727-4e7c-469a-91c4-6219ae072e99",
+                        "version": 1,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 3
+                        },
+                        "attribute": [],
+                        "organism_classification": [
+                            {
+                                "attribute": null,
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Test biological entity 1",
+                        "experimental_variable_description": [
+                            "Test experimental entity 1"
+                        ],
+                        "extrinsic_variable_description": [
+                            "Test extrinsic variable 1"
+                        ],
+                        "intrinsic_variable_description": [
+                            "Test intrinsic variable 1\\nwith escaped character"
+                        ],
+                        "growth_protocol_uuid": "a2ce3950-3b28-40b3-a6a5-23c4f7864912",
+                        "growth_protocol": {
+                            "title_id": "Test specimen 1",
+                            "uuid": "a2ce3950-3b28-40b3-a6a5-23c4f7864912",
+                            "version": 2,
+                            "model": {
+                                "type_name": "Protocol",
+                                "version": 1
+                            },
+                            "attribute": [],
+                            "protocol_description": "Test sample growth protocol 1"
+                        }
+                    }
+                ],
+                "annotation_process": [],
+                "other_creation_process": [],
                 "image": [],
                 "file_count": 0,
                 "image_count": 0,


### PR DESCRIPTION
We now store the all the relevant uuids in the dataset in order to create images, so using that instead of trying to re-use the associations that are also stored as-is in attributes.