### PR TITLE
Small bugs

### DIFF
--- a/bia-ingest/bia_ingest/biostudies/generic_conversion_utils.py
+++ b/bia-ingest/bia_ingest/biostudies/generic_conversion_utils.py
@@ -64,9 +64,9 @@ def get_generic_section_as_dict(
     key_mapping: List[Tuple[str, str, Union[str, None, List]]],
     mapped_object: Optional[BaseModel] = None,
     valdiation_error_tracking: Optional[IngestionResult] = None,
-) -> Dict[str, Any | Dict[str, Dict[str, str | List[str]]]]:
+) -> Dict[str, Dict[str, str|List[str]] | BaseModel]:
     """
-    Map biostudies.Submission objects to dict containing either semantic_models or bia_data_model equivalent
+    Map biostudies.Submission objects to dict or an object 
     """
     if type(root) is Submission:
         sections = find_sections_recursive(root.section, section_name, [])

--- a/bia-ingest/bia_ingest/biostudies/v4/study.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/study.py
@@ -21,6 +21,7 @@ from bia_ingest.biostudies.submission_parsing_utils import (
 from bia_ingest.biostudies.api import Attribute, Submission
 from bia_ingest.biostudies.generic_conversion_utils import (
     get_generic_section_as_dict,
+    get_generic_section_as_list,
 )
 
 from bia_shared_datamodels import bia_data_model, semantic_models
@@ -176,25 +177,31 @@ def get_external_reference(
 def get_grant(
     submission: Submission, result_summary: dict
 ) -> List[semantic_models.Grant]:
-    funding_body_dict = get_funding_body(submission, result_summary)
-    key_mapping = [
-        ("id", "grant_id", None),
-    ]
-    grant_dict = get_generic_section_as_dict(
-        submission,
-        [
-            "Funding",
-        ],
-        key_mapping,
-        semantic_models.Grant,
-        result_summary[submission.accno],
-    )
+    funding_sections = find_sections_recursive(submission.section, ["Funding"])
 
     grant_list = []
-    for k, v in grant_dict.items():
-        if k in funding_body_dict:
-            v.funder.append(funding_body_dict[k])
-        grant_list.append(v)
+    for section in funding_sections:
+        attr = attributes_to_dict(section.attributes)
+
+        funding_body = None
+        if "Agency" in attr:
+            funding_body_dict = {"display_name": attr["Agency"]}
+            funding_body = dict_to_api_model(
+                funding_body_dict,
+                semantic_models.FundingBody,
+                result_summary[submission.accno],
+            )
+
+        if "grant_id" in attr:
+            grant_dict = {"id": attr["grant_id"]}
+            if funding_body:
+                grant_dict["funder"] = [funding_body]
+            grant = dict_to_api_model(
+                grant_dict, semantic_models.Grant, result_summary[submission.accno]
+            )
+            grant_list.append(grant)
+        elif funding_body:
+            logger.warning("Found funding body information but no grant")
     return grant_list
 
 

--- a/bia-ingest/bia_ingest/biostudies/v4/study.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/study.py
@@ -42,7 +42,7 @@ def get_study(
 
     submission_attributes = attributes_to_dict(submission.attributes)
     contributors = get_contributor(submission, result_summary)
-    grants = get_grant(submission, result_summary)
+    grants = get_grant_and_funding_body(submission, result_summary)
 
     study_attributes = attributes_to_dict(submission.section.attributes)
 
@@ -174,7 +174,7 @@ def get_external_reference(
 
 
 # TODO: Put comments and docstring
-def get_grant(
+def get_grant_and_funding_body(
     submission: Submission, result_summary: dict
 ) -> List[semantic_models.Grant]:
     funding_sections = find_sections_recursive(submission.section, ["Funding"])
@@ -203,29 +203,6 @@ def get_grant(
         elif funding_body:
             logger.warning("Found funding body information but no grant")
     return grant_list
-
-
-# TODO: Put comments and docstring
-def get_funding_body(
-    submission: Submission, result_summary: dict
-) -> semantic_models.FundingBody:
-    key_mapping = [
-        (
-            "display_name",
-            "Agency",
-            None,
-        ),
-    ]
-    funding_body = get_generic_section_as_dict(
-        submission,
-        [
-            "Funding",
-        ],
-        key_mapping,
-        semantic_models.FundingBody,
-        result_summary[submission.accno],
-    )
-    return funding_body
 
 
 def get_affiliation(

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -86,11 +86,11 @@ def ingest(
             submission_table = load_submission_table_info(accession_id)
         except Exception as error:
             logger.error("Failed to parse information from BioStudies")
-            logging.exception("message")
             result_summary[accession_id].__setattr__(
                 "Uncaught_Exception",
-                str(result_summary[accession_id].Uncaught_Exception) + str(error),
+                "Failed to parse information from BioStudies",
             )
+            logging.exception("message")
             continue
 
         processing_version = determine_biostudies_processing_version(submission)

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -84,11 +84,19 @@ def ingest(
             # Get information from biostudies
             submission = load_submission(accession_id)
             submission_table = load_submission_table_info(accession_id)
+        except AssertionError as error:
+            logger.error("Failed to retrieve information from BioStudies")
+            result_summary[accession_id].__setattr__(
+                "Uncaught_Exception",
+                "Non-200 repsonse from BioStudies",
+            )
+            logging.exception("message")
+            continue
         except Exception as error:
             logger.error("Failed to parse information from BioStudies")
             result_summary[accession_id].__setattr__(
                 "Uncaught_Exception",
-                "Failed to parse information from BioStudies",
+                str(result_summary[accession_id].Uncaught_Exception) + str(error),
             )
             logging.exception("message")
             continue

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -158,10 +158,10 @@ def determine_biostudies_processing_version(submission: Submission):
     override_map = {
         "S-BIAD43": BioStudiesProcessingVersion.V4,
         "S-BIAD44": BioStudiesProcessingVersion.V4,
-        "S-BIAD590": BioStudiesProcessingVersion.V4,
-        "S-BIAD599": BioStudiesProcessingVersion.V4,
-        "S-BIAD628": BioStudiesProcessingVersion.V4,
-        "S-BIAD677": BioStudiesProcessingVersion.V4,
+        #"S-BIAD590": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
+        #"S-BIAD599": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
+        #"S-BIAD628": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
+        #"S-BIAD677": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
         "S-BIAD686": BioStudiesProcessingVersion.V4,
         "S-BIAD822": BioStudiesProcessingVersion.V4,
         "S-BIAD843": BioStudiesProcessingVersion.V4,

--- a/bia-ingest/bia_ingest/cli_logging.py
+++ b/bia-ingest/bia_ingest/cli_logging.py
@@ -21,12 +21,17 @@ class IngestionResult(CLIResult):
     ProcessingVersion: BioStudiesProcessingVersion = (
         BioStudiesProcessingVersion.FALLBACK
     )
+    
     Study_CreationCount: int = Field(default=0)
     Study_ValidationErrorCount: int = Field(default=0)
     Contributor_CreationCount: int = Field(default=0)
     Contributor_ValidationErrorCount: int = Field(default=0)
     Affiliation_CreationCount: int = Field(default=0)
     Affiliation_ValidationErrorCount: int = Field(default=0)
+    FundingBody_CreationCount: int = Field(default=0)
+    FundingBody_ValidationErrorCount: int = Field(default=0)
+    Grant_CreationCount: int = Field(default=0)
+    Grant_ValidationErrorCount: int = Field(default=0)
     # TODO: start ingesting these from biostudies
     # ExternalLink_CreationCount: int = Field(default=0)
     # ExternalLink_ValidationErrorCount: int = Field(default=0)


### PR DESCRIPTION
The AssertionError seemed to have no message, which led to studies that did not return a 200 from the biostudies api to be labelled as successes. My change makes it less clear why it failed (could be due to validation failing or not getting a 200, but in either case we're likely to run it in debug mode to check why it failed.
https://app.clickup.com/t/8696yzdfw

Also noticed a bug with S-BIAD1315 (can test with 'poetry run biaingest ingest --dryrun S-BIAD1315 -v -c --process-filelist skip') where the funding / grant objects were failing. I updated the code for these objects. Note that without 
--process-filelist skip it still fails for some reason (there's an empty filelist?) but that seems like a separate bug to investigate.