### PR TITLE
Email validator

### DIFF
--- a/bia-ingest/bia_ingest/biostudies/v4/study.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/study.py
@@ -408,6 +408,6 @@ def get_unique_email_warnings(
         for warning in unique_warnings:
             result_summary[accno].__setattr__(
                 "Warning",
-                "Email warning: " + str(warning) + "\n"
+                "Skipped invalid author email: " + str(warning) + "\n"
             )
-            logger.warning(f"Email warning: {warning}")
+            logger.warning(f"Skipped invalid author email: {warning}")

--- a/bia-ingest/bia_ingest/cli_logging.py
+++ b/bia-ingest/bia_ingest/cli_logging.py
@@ -124,14 +124,14 @@ def tabulate_ingestion_errors(
             status.stylize("green")
         elif (error_message == "") & (warning_message != ""):
             status = Text("Success with warnings")
-            status.stylize("orange")
+            status.stylize("yellow")
             warning_message = Text(warning_message)
-            warning_message.stylize("orange")
+            warning_message.stylize("yellow")
         elif (error_message != "") & (warning_message != ""):
             status = Text("Failures with warnings")
             status.stylize("red")
             warning_message = Text(warning_message)
-            warning_message.stylize("orange")
+            warning_message.stylize("yellow")
             error_message = Text(error_message)
             error_message.stylize("red")
         elif (error_message != "") & (warning_message == ""):


### PR DESCRIPTION
Added code to catch invalid email addresses, and to record what's wrong with them in the output table. 

If an email address is found to be invalid, then it is made equal to None, and the contributor will still be recorded.

Where there are multiple errors of the same type, for any given study, then only one instance of this is recorded in the output table. 