### PR TITLE
4submissions override

### DIFF
--- a/bia-ingest/bia_ingest/biostudies/api.py
+++ b/bia-ingest/bia_ingest/biostudies/api.py
@@ -201,6 +201,10 @@ def load_submission(accession_id: str) -> Submission:
         "S-BIAD1344": "invalid email: raffaeledefilippis92@gmail.comraffaeledefilippis92@gmail.com changed to: raffaeledefilippis92@gmail.com",
         "S-BSST651": "invalid email: huw.williams@williams@nottingham.ac.uk changed to: huw.williams@nottingham.ac.uk",
         "S-BSST744": "invalid email: ‫britta.engelhardt@tki.unibe.ch (right-to-left embedding) changed to: britta.engelhardt@tki.unibe.ch",
+        "S-BIAD590": "missing study component assosiations subsection",
+        "S-BIAD599": "missing study component assosiations subsection",
+        "S-BIAD628": "missing study component assosiations subsection",
+        #"S-BIAD677": "missing study component assosiations subsection"
     }
     if accession_id in overrides:
         return read_override(accession_id)

--- a/bia-ingest/bia_ingest/biostudies/api.py
+++ b/bia-ingest/bia_ingest/biostudies/api.py
@@ -204,7 +204,7 @@ def load_submission(accession_id: str) -> Submission:
         "S-BIAD590": "missing study component assosiations subsection",
         "S-BIAD599": "missing study component assosiations subsection",
         "S-BIAD628": "missing study component assosiations subsection",
-        #"S-BIAD677": "missing study component assosiations subsection"
+        "S-BIAD677": "missing study component assosiations subsection"
     }
     if accession_id in overrides:
         return read_override(accession_id)

--- a/bia-ingest/bia_ingest/biostudies/v4/image_acquisition_protocol.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/image_acquisition_protocol.py
@@ -107,7 +107,7 @@ def get_imaging_method_fbbi_from_subsection(
     fbbi_id = []
     for section in sections:
         attr_dict = attributes_to_dict(section.attributes)
-        if attr_dict["Ontology Term ID"] and attr_dict["Ontology Value"]:
+        if attr_dict.get("Ontology Term ID") and attr_dict.get("Ontology Value"):
             imaging_method_name.append(f"{attr_dict['Ontology Value']}")
             fbbi_id.append(f"{attr_dict['Ontology Term ID']}")
         elif attr_dict["Ontology Value"]:

--- a/bia-ingest/bia_ingest/biostudies/v4/image_acquisition_protocol.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/image_acquisition_protocol.py
@@ -74,18 +74,20 @@ def extract_image_acquisition_protocol_dicts(
             k: case_insensitive_get(attr_dict, v, default)
             for k, v, default in key_mapping
         }
+        
+        # TODO: change template / create logic to lookup the fbbi ID
+        model_dict["fbbi_id"] = []
 
         if not model_dict["imaging_method_name"]:
-            model_dict["imaging_method_name"] = (
-                get_imaging_method_names_from_subsection(section)
+            # get imaging method name and fbbi_id from subsection if they exist
+            # NOTE: this doesn't check the format of fbbi_id; it can be uri or id 
+            model_dict["imaging_method_name"], model_dict["fbbi_id"] = (
+                get_imaging_method_fbbi_from_subsection(section)
             )
         elif isinstance(model_dict["imaging_method_name"], str):
             model_dict["imaging_method_name"] = [
                 model_dict["imaging_method_name"],
             ]
-
-        # TODO: change template / create logic to lookup the fbbi ID
-        model_dict["fbbi_id"] = []
 
         model_dict["version"] = 0
         model_dict["uuid"] = create_image_acquisition_protocol_uuid(
@@ -97,17 +99,17 @@ def extract_image_acquisition_protocol_dicts(
     return model_dict_map
 
 
-def get_imaging_method_names_from_subsection(
+def get_imaging_method_fbbi_from_subsection(
     image_acquisition_section: Section,
-) -> list[str]:
+) -> list:
     sections = find_sections_recursive(image_acquisition_section, ["Imaging Method"])
     imaging_method_name = []
+    fbbi_id = []
     for section in sections:
         attr_dict = attributes_to_dict(section.attributes)
-        if attr_dict["Ontology Name"] and attr_dict["Ontology Value"]:
-            imaging_method_name.append(
-                f"{attr_dict['Ontology Name']}:{attr_dict['Ontology Value']}"
-            )
+        if attr_dict["Ontology Term ID"] and attr_dict["Ontology Value"]:
+            imaging_method_name.append(f"{attr_dict['Ontology Value']}")
+            fbbi_id.append(f"{attr_dict['Ontology Term ID']}")
         elif attr_dict["Ontology Value"]:
             imaging_method_name.append(f"{attr_dict['Ontology Value']}")
-    return imaging_method_name
+    return [imaging_method_name, fbbi_id]

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -172,7 +172,7 @@ def determine_biostudies_processing_version(submission: Submission):
         "S-BIAD590": BioStudiesProcessingVersion.V4, 
         "S-BIAD599": BioStudiesProcessingVersion.V4, 
         "S-BIAD628": BioStudiesProcessingVersion.V4, 
-        #"S-BIAD677": BioStudiesProcessingVersion.V4, 
+        "S-BIAD677": BioStudiesProcessingVersion.V4, 
         "S-BIAD686": BioStudiesProcessingVersion.V4,
         "S-BIAD822": BioStudiesProcessingVersion.V4,
         "S-BIAD843": BioStudiesProcessingVersion.V4,

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -169,10 +169,10 @@ def determine_biostudies_processing_version(submission: Submission):
     override_map = {
         "S-BIAD43": BioStudiesProcessingVersion.V4,
         "S-BIAD44": BioStudiesProcessingVersion.V4,
-        # "S-BIAD590": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
-        # "S-BIAD599": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
-        # "S-BIAD628": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
-        # "S-BIAD677": BioStudiesProcessingVersion.V4, TODO: deal with nested associations
+        "S-BIAD590": BioStudiesProcessingVersion.V4, 
+        "S-BIAD599": BioStudiesProcessingVersion.V4, 
+        "S-BIAD628": BioStudiesProcessingVersion.V4, 
+        #"S-BIAD677": BioStudiesProcessingVersion.V4, 
         "S-BIAD686": BioStudiesProcessingVersion.V4,
         "S-BIAD822": BioStudiesProcessingVersion.V4,
         "S-BIAD843": BioStudiesProcessingVersion.V4,

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD590/S-BIAD590_original.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD590/S-BIAD590_original.json
@@ -1,0 +1,304 @@
+{
+  "accno" : "S-BIAD590",
+  "attributes" : [ {
+    "name" : "Title",
+    "value" : "A deep-learning classifier identifies patients with clinical heart failure using whole-slide images of H&E tissue."
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2022-11-23"
+  }, {
+    "name" : "RootPath",
+    "value" : "idr0042"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "Over 26 million people worldwide suffer from heart failure annually. When the cause of heart failure cannot be identified, endomyocardial biopsy (EMB) represents the gold-standard for the evaluation of disease. However, manual EMB interpretation has high inter-rater variability. Deep convolutional neural networks (CNNs) have been successfully applied to detect cancer, diabetic retinopathy, and dermatologic lesions from images. In this study, we develop a CNN classifier to detect clinical heart failure from H&E stained whole-slide images from a total of 209 patients, 104 patients were used for training and the remaining 105 patients for independent testing. The CNN was able to identify patients with heart failure or severe pathology with a 99% sensitivity and 94% specificity on the test set, outperforming conventional feature-engineering approaches. Importantly, the CNN outperformed two expert pathologists by nearly 20%. Our results suggest that deep learning analytics of EMB can be used to predict cardiac outcome."
+    }, {
+      "name" : "Keyword",
+      "value" : "heart failure "
+    }, {
+      "name" : "Keyword",
+      "value" : "histopathology"
+    }, {
+      "name" : "Keyword",
+      "value" : "classifier"
+    }, {
+      "name" : "Keyword",
+      "value" : "deep learning"
+    }, {
+      "name" : "Keyword",
+      "value" : "AI"
+    }, {
+      "name" : "License",
+      "value" : "CC BY 4.0",
+      "valqual" : [ {
+        "name" : "URL",
+        "value" : "https://creativecommons.org/licenses/by/4.0/legalcode"
+      } ]
+    }, {
+      "name" : "IDR accession number",
+      "value" : "idr0042"
+    }, {
+      "name" : "Funding statement",
+      "value" : "Research reported in this publication was supported by the National Cancer Institute of the National Institutes of Health under award numbers (R01CA202752-01A1, R01CA208236-01A1, R01 CA216579-01A1, R21CA179327-01, R21CA195152-01 and U24CA199374-01) the National Institute of Diabetes and Digestive and Kidney Diseases under award number R01DK098503-02, The National Center for Advancing Translational Sciences under award number TL1TR001880, the National Heart Lung and Blood Institute under award number R01-HL105993, the DOD Prostate Cancer Synergistic Idea Development Award (PC120857); the National Institute of Diabetes and Digestive and Kidney Diseases (US) under award number 5T32DK007470, the National Center for Research Resources under award number under the award number 1 C06 RR12463-01, the DOD Lung Cancer Idea Development New Investigator Award (LC130463), the DOD Prostate Cancer Synergistic Idea Development Award (PC120857); the DOD Peer Reviewed Cancer Research Program (W81XWH-16-1-0329), the Case Comprehensive Cancer Center Pilot Grant, The Ohio Third Frontier Technology Validation Fund, the VelaSano Grant from the Cleveland Clinic the Wallace H. Coulter Foundation Program in the Department of Biomedical Engineering at Case Western Reserve University, the Wallace H. Coulter Foundation Program in the Department of Biomedical Engineering, the The Clinical and Translational Science Award Program (CTSA) at Case Western Reserve University, and the I-Corps@Ohio Program. JJN was supported by NINDS F30NS092227. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health. The funders had no role in study design, data collection and analysis, decision to publish, or preparation of the manuscript."
+    } ],
+    "links" : [ {
+      "url" : "https://idr.openmicroscopy.org/webclient/?show=project-402",
+      "attributes" : [ {
+        "name" : "Type",
+        "value" : "Image Data Resource (IDR)"
+      } ]
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "JJ Nirschl"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Data curation, Formal analysis, Investigation, Methodology, Software, Writing – original draft, Writing – review & editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "http://orcid.org/0000-0001-6857-341X"
+      }, {
+        "name" : "affiliation",
+        "value" : "o4",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "A Janowczyk"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Formal analysis, Investigation, Methodology, Software, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "EG Peyster"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Data curation, Resources, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "R Frank"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Data curation, Resources"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "KB Margulies"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Conceptualization, Data curation, Resources, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "MD Feldman"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Conceptualization, Data curation, Resources, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "A Madabhushi"
+      }, {
+        "name" : "Email",
+        "value" : "axm788@case.edu"
+      }, {
+        "name" : "role",
+        "value" : "Conceptualization, Funding acquisition, Methodology, Project administration, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "http://orcid.org/0000-0002-5741-0399"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Department of Pathology and Laboratory Medicine, University of Pennsylvania, Philadelphia, PA, United States of America"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Department of Biomedical Engineering, Case Western Reserve University, Cleveland, OH, United States of America"
+      } ]
+    }, {
+      "accno" : "o3",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Cardiovascular Research Institute, University of Pennsylvania, Philadelphia, PA, United States of America"
+      } ]
+    }, {
+      "accno" : "o4",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Department of Physiology, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA, United States of America"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "A deep-learning classifier identifies patients with clinical heart failure using whole-slide images of H&E tissue."
+      }, {
+        "name" : "Year",
+        "value" : "2018"
+      }, {
+        "name" : "DOI",
+        "value" : "https://doi.org/10.1371/journal.pone.0192726"
+      }, {
+        "name" : "PMC ID",
+        "value" : "PMC5882098"
+      } ]
+    }, {
+      "accno" : "Study Component-1",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Histopathology images"
+      }, {
+        "name" : "Description",
+        "value" : "Histopathology sub-image from patient whole-slide images from patients with end-stage clinical heart failure or cadaveric donor hearts from patients without heart failure."
+      }, {
+        "name" : "File List",
+        "value" : "bia_file_list_idr0042.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Image Acquisition-1-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "Aperio ScanScope slide scanner with 20x magnification"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "Pixel Size (XY) (µm) = 2 x 2"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "bright-field microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "bright-field microscopy"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000243"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-1-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "transmural tissue from the left ventricular free wall were fixed in 4% paraformaldehyde and later processed, embedded in paraffin, sectioned and stained with hematoxylin and eosin (H&E) for morphologic analysis."
+        } ]
+      }, {
+        "accno" : "Biosample-1-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "ventricular tissue from human patients"
+        }, {
+          "name" : "Description",
+          "value" : "human heart"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "There were two cohorts of patients: those with end-stage heart failure and a comparison group without heart failure."
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-1-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Homo Sapiens"
+          }, {
+            "name" : "Common name",
+            "value" : "Human"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBITaxon_9606"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-1-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "The primary neural network used in this study was adapted from Janowczyk and Madabhushi. This fully-convolutional architecture is composed of alternating convolutional, batch normalization, and Rectified Linear Unit (ReLU) activation layers. This network has approximately 13,500 learnable parameters. The network accepts 64x 64 pixel RGB image patches (128x128μm) with a label corresponding to the cohort to which the patient belongs (failing or non-failing). The CNN classifier was trained using 100 patches per ROI, per patient, and the training set was augmented rotating each patch by 90 degrees. The output of the CNN is a pixel-level probability of whether ROIs belong to the failing class. The pixels in a single image were averaged to obtain the image-level probability. Each fold of the three-fold cross validation was trained using NVIDIA DIGITS for 30 epochs on a Titan X GPU with CUDA7.5 and cuDNN optimized by Stochastic Gradient Descent built into Caffe and a fixed batch size of 64. Additional networks used in this study: AlexNet, GoogLeNet, and a 50-layer ResNet with dropout with the full or half the number of kernels at each layer. These networks were trained on 5X magnification (250 x 250) RGB images upsampled 2X to 500 x 500 pixels, which allowed data augmentation by random cropping of regions 227x 227 (AlexNet) or 224 x 224 (GoogLeNet or ResNet-50). Given the limited number of images in the training dataset, all networks used aggressive data augmentation including: random cropping, random rotation (90, 180, 270), image mirroring, and stain color augmentation. Each fold of the three-fold cross-validation was trained using NVIDIA DIGITS for 1000 epochs on a NVIDIA GTX 1080-Ti with CUDA 8.0 and cuDNN optimized by AdaGrad built into Caffe, with a fixed batch size of 512 where gradients were accumulated over multiple minibatches."
+        } ]
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD590/S-BIAD590_override.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD590/S-BIAD590_override.json
@@ -1,0 +1,331 @@
+{
+  "accno" : "S-BIAD590",
+  "attributes" : [ {
+    "name" : "Title",
+    "value" : "A deep-learning classifier identifies patients with clinical heart failure using whole-slide images of H&E tissue."
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2022-11-23"
+  }, {
+    "name" : "RootPath",
+    "value" : "idr0042"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "Over 26 million people worldwide suffer from heart failure annually. When the cause of heart failure cannot be identified, endomyocardial biopsy (EMB) represents the gold-standard for the evaluation of disease. However, manual EMB interpretation has high inter-rater variability. Deep convolutional neural networks (CNNs) have been successfully applied to detect cancer, diabetic retinopathy, and dermatologic lesions from images. In this study, we develop a CNN classifier to detect clinical heart failure from H&E stained whole-slide images from a total of 209 patients, 104 patients were used for training and the remaining 105 patients for independent testing. The CNN was able to identify patients with heart failure or severe pathology with a 99% sensitivity and 94% specificity on the test set, outperforming conventional feature-engineering approaches. Importantly, the CNN outperformed two expert pathologists by nearly 20%. Our results suggest that deep learning analytics of EMB can be used to predict cardiac outcome."
+    }, {
+      "name" : "Keyword",
+      "value" : "heart failure "
+    }, {
+      "name" : "Keyword",
+      "value" : "histopathology"
+    }, {
+      "name" : "Keyword",
+      "value" : "classifier"
+    }, {
+      "name" : "Keyword",
+      "value" : "deep learning"
+    }, {
+      "name" : "Keyword",
+      "value" : "AI"
+    }, {
+      "name" : "License",
+      "value" : "CC BY 4.0",
+      "valqual" : [ {
+        "name" : "URL",
+        "value" : "https://creativecommons.org/licenses/by/4.0/legalcode"
+      } ]
+    }, {
+      "name" : "IDR accession number",
+      "value" : "idr0042"
+    }, {
+      "name" : "Funding statement",
+      "value" : "Research reported in this publication was supported by the National Cancer Institute of the National Institutes of Health under award numbers (R01CA202752-01A1, R01CA208236-01A1, R01 CA216579-01A1, R21CA179327-01, R21CA195152-01 and U24CA199374-01) the National Institute of Diabetes and Digestive and Kidney Diseases under award number R01DK098503-02, The National Center for Advancing Translational Sciences under award number TL1TR001880, the National Heart Lung and Blood Institute under award number R01-HL105993, the DOD Prostate Cancer Synergistic Idea Development Award (PC120857); the National Institute of Diabetes and Digestive and Kidney Diseases (US) under award number 5T32DK007470, the National Center for Research Resources under award number under the award number 1 C06 RR12463-01, the DOD Lung Cancer Idea Development New Investigator Award (LC130463), the DOD Prostate Cancer Synergistic Idea Development Award (PC120857); the DOD Peer Reviewed Cancer Research Program (W81XWH-16-1-0329), the Case Comprehensive Cancer Center Pilot Grant, The Ohio Third Frontier Technology Validation Fund, the VelaSano Grant from the Cleveland Clinic the Wallace H. Coulter Foundation Program in the Department of Biomedical Engineering at Case Western Reserve University, the Wallace H. Coulter Foundation Program in the Department of Biomedical Engineering, the The Clinical and Translational Science Award Program (CTSA) at Case Western Reserve University, and the I-Corps@Ohio Program. JJN was supported by NINDS F30NS092227. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health. The funders had no role in study design, data collection and analysis, decision to publish, or preparation of the manuscript."
+    } ],
+    "links" : [ {
+      "url" : "https://idr.openmicroscopy.org/webclient/?show=project-402",
+      "attributes" : [ {
+        "name" : "Type",
+        "value" : "Image Data Resource (IDR)"
+      } ]
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "JJ Nirschl"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Data curation, Formal analysis, Investigation, Methodology, Software, Writing – original draft, Writing – review & editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "http://orcid.org/0000-0001-6857-341X"
+      }, {
+        "name" : "affiliation",
+        "value" : "o4",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "A Janowczyk"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Formal analysis, Investigation, Methodology, Software, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "EG Peyster"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Data curation, Resources, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "R Frank"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Data curation, Resources"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "KB Margulies"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Conceptualization, Data curation, Resources, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "MD Feldman"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "role",
+        "value" : "Conceptualization, Data curation, Resources, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "A Madabhushi"
+      }, {
+        "name" : "Email",
+        "value" : "axm788@case.edu"
+      }, {
+        "name" : "role",
+        "value" : "Conceptualization, Funding acquisition, Methodology, Project administration, Supervision, Writing – review & editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "http://orcid.org/0000-0002-5741-0399"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Department of Pathology and Laboratory Medicine, University of Pennsylvania, Philadelphia, PA, United States of America"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Department of Biomedical Engineering, Case Western Reserve University, Cleveland, OH, United States of America"
+      } ]
+    }, {
+      "accno" : "o3",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Cardiovascular Research Institute, University of Pennsylvania, Philadelphia, PA, United States of America"
+      } ]
+    }, {
+      "accno" : "o4",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Department of Physiology, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA, United States of America"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "A deep-learning classifier identifies patients with clinical heart failure using whole-slide images of H&E tissue."
+      }, {
+        "name" : "Year",
+        "value" : "2018"
+      }, {
+        "name" : "DOI",
+        "value" : "https://doi.org/10.1371/journal.pone.0192726"
+      }, {
+        "name" : "PMC ID",
+        "value" : "PMC5882098"
+      } ]
+    }, {
+      "accno" : "Image Acquisition-1",
+      "type" : "Image Acquisition",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Acquisition"
+      }, {
+        "name" : "Imaging Instrument",
+        "value" : "Aperio ScanScope slide scanner with 20x magnification"
+      }, {
+        "name" : "Image Acquisition Parameters",
+        "value" : "Pixel Size (XY) (µm) = 2 x 2"
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-1-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "bright-field microscopy"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "bright-field microscopy"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000243"
+        } ]
+    } ] 
+    }, {
+      "accno" : "Specimen-2",
+      "type" : "Specimen",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Specimen"
+      }, {
+        "name" : "Sample Preparation Protocol",
+        "value" : "transmural tissue from the left ventricular free wall were fixed in 4% paraformaldehyde and later processed, embedded in paraffin, sectioned and stained with hematoxylin and eosin (H&E) for morphologic analysis."
+      } ]
+    }, {
+      "accno" : "Biosample-3",
+      "type" : "Biosample",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Biosample"
+      }, {
+        "name" : "Biological entity",
+        "value" : "ventricular tissue from human patients"
+      }, {
+        "name" : "Description",
+        "value" : "human heart"
+      }, {
+        "name" : "Experimental variable",
+        "value" : "There were two cohorts of patients: those with end-stage heart failure and a comparison group without heart failure."
+      } ],
+      "subsections" : [ {
+        "accno" : "Organism-3-1",
+        "type" : "Organism",
+        "attributes" : [ {
+          "name" : "Scientific name",
+          "value" : "Homo Sapiens"
+        }, {
+          "name" : "Common name",
+          "value" : "Human"
+        }, {
+          "name" : "NCBI taxon ID",
+          "value" : "NCBITaxon_9606"
+        } ]
+      } ]
+    }, {
+      "accno" : "Image-Analysis-4",
+      "type" : "Image Analysis",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Analysis"
+      }, {
+        "name" : "Image Analysis Overview",
+        "value" : "The primary neural network used in this study was adapted from Janowczyk and Madabhushi. This fully-convolutional architecture is composed of alternating convolutional, batch normalization, and Rectified Linear Unit (ReLU) activation layers. This network has approximately 13,500 learnable parameters. The network accepts 64x 64 pixel RGB image patches (128x128μm) with a label corresponding to the cohort to which the patient belongs (failing or non-failing). The CNN classifier was trained using 100 patches per ROI, per patient, and the training set was augmented rotating each patch by 90 degrees. The output of the CNN is a pixel-level probability of whether ROIs belong to the failing class. The pixels in a single image were averaged to obtain the image-level probability. Each fold of the three-fold cross validation was trained using NVIDIA DIGITS for 30 epochs on a Titan X GPU with CUDA7.5 and cuDNN optimized by Stochastic Gradient Descent built into Caffe and a fixed batch size of 64. Additional networks used in this study: AlexNet, GoogLeNet, and a 50-layer ResNet with dropout with the full or half the number of kernels at each layer. These networks were trained on 5X magnification (250 x 250) RGB images upsampled 2X to 500 x 500 pixels, which allowed data augmentation by random cropping of regions 227x 227 (AlexNet) or 224 x 224 (GoogLeNet or ResNet-50). Given the limited number of images in the training dataset, all networks used aggressive data augmentation including: random cropping, random rotation (90, 180, 270), image mirroring, and stain color augmentation. Each fold of the three-fold cross-validation was trained using NVIDIA DIGITS for 1000 epochs on a NVIDIA GTX 1080-Ti with CUDA 8.0 and cuDNN optimized by AdaGrad built into Caffe, with a fixed batch size of 512 where gradients were accumulated over multiple minibatches."
+      } ]
+    }, {
+      "accno" : "Study Component-5",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Histopathology images"
+      }, {
+        "name" : "Description",
+        "value" : "Histopathology sub-image from patient whole-slide images from patients with end-stage clinical heart failure or cadaveric donor hearts from patients without heart failure."
+      }, {
+        "name" : "File List",
+        "value" : "bia_file_list_idr0042.json"
+      } ],
+      "subsections" : [ {
+        "type" : "Associations",
+        "attributes" : [ {
+          "name" : "Biosample",
+          "value" : "Biosample"
+        }, {
+          "name" : "Specimen",
+          "value" : "Specimen"
+        }, {
+          "name" : "Image acquisition",
+          "value" : "Image Acquisition"
+        }, {
+          "name" : "Image analysis",
+          "value" : "Image Analysis"
+        } ]
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD599/S-BIAD599_original.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD599/S-BIAD599_original.json
@@ -1,0 +1,343 @@
+{
+  "accno" : "S-BIAD599",
+  "attributes" : [ {
+    "name" : "Title",
+    "value" : "An image-based data-driven analysis of cellular architecture in a developing tissue"
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2022-12-13"
+  }, {
+    "name" : "RootPath",
+    "value" : "idr0079"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "A data-driven analysis of cell morphology and intracellular organization in the developing zebrafish posterior lateral line primordium, a model tissue for the study of self-organized morphogenesis. 3D image stacks were acquired using AiryScan FAST-mode confocal fluorescence microscopy. Automated single-cell segmentation and point cloud-based morphometry were developed to extract numerical features representing cell morphology and intracellular protein distributions. Machine learning was used with the extracted numerical features to perform data integration across experiments and context-guided data visualization. The resulting data was analyzed to discover biologically meaningful patterns at the cell and tissue scale."
+    }, {
+      "name" : "License",
+      "value" : "CC BY 4.0"
+    }, {
+      "name" : "Keyword",
+      "value" : "zebrafish"
+    }, {
+      "name" : "Keyword",
+      "value" : "machine learning"
+    }, {
+      "name" : "Keyword",
+      "value" : "segmentation"
+    }, {
+      "name" : "Keyword",
+      "value" : "organogenesis"
+    }, {
+      "name" : "Acknowledgements",
+      "value" : "We thank Sabine Görgens and Andreas Kunze for their support with fish and lab maintenance, respectively. We thank the EMBL Advanced Light Microscopy Facility (ALMF) and the UZH Center for Microscopy and Image Analysis (ZMB) for maintenance of and assistance with microscopes. We thank Alejandra Guzman Herrera for generating the Act2b:mKate2-Rab11a line. We thank Francesca Peri and Stefano De Renzis for kindly providing temporary lab space. We thank Christian Tischer and Marvin Albert for helpful discussion on image analysis and numerical computation. We thank Stefano De Renzis, Daniel Krueger, Marvin Albert and Andrew Kennard for critical reading of the manuscript. JH and EG were supported by the EMBL International PhD Programme (EIPP), M.W. was supported by an EMBO Long-Term Fellowship and the EMBL Interdisciplinary Postdoc (EIPOD) Program under Marie Curie COFUNDII Actions. The Gilmour lab was supported by the European Molecular Biology Laboratory (EMBL), the University of Zurich (UZH) and Swiss National Science Funds Grant 31003A_176235."
+    }, {
+      "name" : "Funding statement",
+      "value" : "Jonas Hartmann: European Molecular Biology Laboratory (International PhD Programme). Elisa Gallo: European Molecular Biology Laboratory (International PhD Programme). Mie Wong: European Molecular Biology Organization (ALTF 205-2015) and H2020 Marie Skłodowska-Curie Actions (COFUNDII - EMBL Interdisciplinary Post-doc (EIPOD) Program). Darren Gilmour: European Molecular Biology Laboratory, Schweizerischer Nationalfonds zur Förderung der Wissenschaftlichen Forschung (31003A_176235) and University of Zurich. The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication."
+    } ],
+    "links" : [ {
+      "url" : "https://idr.openmicroscopy.org/webclient/?show=project-1105",
+      "attributes" : [ {
+        "name" : "Type",
+        "value" : "Image Data Resource"
+      } ]
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Jonas Hartmann"
+      }, {
+        "name" : "Email",
+        "value" : "jonas.m.hartmann@protonmail.com"
+      }, {
+        "name" : "Role",
+        "value" : "Conceptualization, Data curation, Software, Formal analysis, Validation, Investigation, Visualization, Methodology, Writing - original draft, Writing - review and editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "https://orcid.org/0000-0002-5600-8285"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Mie Wong"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "Role",
+        "value" : "Investigation, Writing - review and editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Elisa Gallo"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "Role",
+        "value" : "Investigation, Writing - review and editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "https://orcid.org/0000-0003-2203-6787"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Darren Gilmour"
+      }, {
+        "name" : "Email",
+        "value" : "darren.gilmour@imls.uzh.ch"
+      }, {
+        "name" : "Role",
+        "value" : "Conceptualization, Resources, Supervision, Funding acquisition, Project administration, Writing - review and editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "https://orcid.org/0000-0001-7613-090X"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Teresa Zulueta-Coarasa"
+      }, {
+        "name" : "Email",
+        "value" : "teresaz@ebi.ac.uk"
+      }, {
+        "name" : "Role",
+        "value" : "data curation, submitter"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-0456-6912"
+      }, {
+        "name" : "affiliation",
+        "value" : "o4",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Cell Biology and Biophysics Unit, European Molecular Biology Laboratory (EMBL), Heidelberg, Germany"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Cell Biology and Biophysics Unit, European Molecular Biology Laboratory (EMBL), Heidelberg, GermanyInstitute of Molecular Life Sciences, University of Zurich (UZH)  Zurich, Switzerland - Collaboration for joint PhD degree between EMBL and Heidelberg University, Faculty of Biosciences, Heidelberg, Germany"
+      } ]
+    }, {
+      "accno" : "o3",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Institute of Molecular Life Sciences, University of Zurich (UZH), Zurich, Switzerland"
+      } ]
+    }, {
+      "accno" : "o4",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "European Bioinformatics Institute"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "An image-based data-driven analysis of cellular architecture in a developing tissue"
+      }, {
+        "name" : "Year",
+        "value" : "2020"
+      }, {
+        "name" : "DOI",
+        "value" : "https://doi.org/10.7554/eLife.55913"
+      }, {
+        "name" : "PMC ID",
+        "value" : "PMC7274788"
+      } ]
+    }, {
+      "accno" : "Study Component-1",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "3D confocal images of live embryos and corresponding cell segmentations"
+      }, {
+        "name" : "Description",
+        "value" : "3D confocal live imaging of the zebrafish posterior lateral line primordium labeled with the membrane marker cldnB:lyn-EGFP for segmentation and optionally with one of several additional labels."
+      }, {
+        "name" : "File List",
+        "value" : "bia_file_list_idr0079_1.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Image Acquisition-1-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "Zeiss LSM880 with AiryScan technology (Carl Zeiss AG, Oberkochen, Germany)"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "High-resolution 3D stacks (voxel size: 0.099 μm in xy, 0.225 μm in z) were acquired with a 40 × 1.2 NA water objective with Immersol W immersion fluid (Carl Zeiss, Oberkochen, Germany). Imaging in AiryScan FAST mode (Huff, 2016) with a piezo stage for z-motion and bi-directional scanning allowed acquisition times for an entire volume to be lowered to approximately 20 s (40 s for dual-color stacks using line switching). Deconvolution was performed using the LSM880's built-in 3D AiryScan deconvolution with 'auto' settings. Note that optimal image quality could only be achieved by adjustment of the stage to ensure that the cover glass is exactly normal to the excitation beam. For each dish we imaged, we used 633 nm reflected light and line scanning to get a live view of the cover glass interface, which allowed us to manually adjust the pitch of the stage to be completely horizontal. This process was repeated for both zx and zy line scans."
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "array-scan confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000393"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-1-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "Embryos were manually dechorionated with forceps at 30-34hpf and anaesthetized with 0.01% Tricaine (Sigma-Aldrich, St. Louis, US-MO), then transferred into 1% peqGOLD Low Melt Agarose (Peqlab, Erlangen, Germany) in E3 containing 0.01% Tricaine and immediately deposited onto a MatTek Glass Bottom Microwell Dish (35 mm Petri dish, 10 mm microwell, 0.16–0.19 mm coverglass) (MatTek Corporation, Ashland, US-MA). No more than 10 embryos were mounted in a single dish. A weighted needle tool was used to gently arrange the embryos such that they rest flatly with their lateral side directly on the glass slide. After solidification of the agarose, E3 containing 0.01% Tricaine was added to the dish. Embryos were imaged at 32-36hpf, when the pLLP was located above the posterior half of the embryo's yolk extension."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "Zebrafish (Danio rerio, RRID:ZFIN_ZDB-GENO-060919-1) were grown, maintained and bred according to standard procedures described previously (Westerfield, 2000). All experiments were performed on embryos younger than 3dpf, as is stipulated by the EMBL internal policy 65 (IP65) and European Union Directive 2010/63/EU. Live embryos were kept in E3 buffer at 27–30°C. For experiments, pigmentation of embryos was prevented by treating them with 0.002% N-phenylthiourea (PTU) (Sigma-Aldrich, St. Louis, US-MO) starting at 25hpf. For mounting and during live imaging, embryos were anaesthetized using 0.01% Tricaine (Sigma-Aldrich, St. Louis, US-MO)."
+        } ]
+      }, {
+        "accno" : "Biosample-1-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "Posterior lateral line primordium"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "Fluorescent Labels"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-1-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Danio rerio"
+          }, {
+            "name" : "Common name",
+            "value" : "Zebrafish"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid7955"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-1-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "Image preprocessing: Following AiryScan 3D deconvolution with 'auto' settings on the LSM880, images were converted to 8bit TIFF files using a custom macro for the Fiji distribution (Schindelin et al., 2012) of ImageJ 1.52 g (Schneider et al., 2012). The minimum and maximum values determining the intensity range prior to 8bit conversion were selected manually such that intensity clipping is avoided. Care was taken to apply the same values to all samples of a given marker to ensure consistency. Samples with the cxcr4b:NLS-tdTomato nuclear label exhibited a degree of bleed-through into the lyn-EGFP membrane label channel. To prevent this from interfering with single-cell segmentation, we employed a linear unmixing scheme in which the contribution of NLS-tdTomato (C, the contaminant image) is removed from the green channel (M, mixed image), resulting in the cleaned membrane channel (U, unmixed image). Our approach assumes that the signal in M is composed according to Equation 1, implying that U can be retrieved by subtraction of an appropriate contamination term (Equation 2). (1) M=U+a∙C. (2) U=M−a∙C. To compute the optimal bleed-through factor a we minimized a custom loss function (Equation 3), which is essentially simply the Pearson Correlation Coefficient (PCC) of the contaminant image C and the cleaned image U given a particular candidate factor ai. To ensure that unreasonably high values of a are punished, we centered the values of the cleaned image onto their mean and converted the result to absolute values, causing overly unmixed regions to start correlating with C again.(3) loss=PCC(C,∣∣M−ai∙C−mean(M−ai∙C)∣∣) We found that this approach robustly removes NLS-tdTomato bleed-through, producing unmixed images that could be segmented successfully. Single-Cell segmentation: 3D single-cell segmentation was performed on membrane-labeled stacks acquired, deconvolved and preprocessed as detailed in the sections above. The pipeline for segmentation consists of the following steps, applied sequentially: 1 - 3D median smoothing with a cuboid 3 × 3×3 vxl structural element to reduce shot noise. 2 - 3D Gaussian smoothing with σ = 3 pxl to further reduce noise and smoothen structures. 3 - Thresholding to retrieve a binary mask of foreground objects (i.e. the membranes). To automatically determine the appropriate threshold, we use a custom function inspired by a semi-manual approach for spot detection (Raj et al., 2008). Starting from the most frequent value in the image histogram as a base threshold, we iteratively scan a limited range of positive offsets (usually 0 to 10 in steps of 1, for slightly lower-quality images 0 to 40 in steps of 2) and count the number of connected components in the inverse of the binary mask resultant from applying each threshold. This roughly represents the number of cell bodies in the stack that are fully enclosed in cell membranes at a given threshold. We consider the threshold producing the largest number the best option and use it to generate the final membrane mask. 4 - Removal of disconnected components by morphological hole filling. 5 - Labeling of connected components on the inverted membrane mask. This ideally yields one connected component per cell, i.e. the cytoplasm. 6 - Removal of connected components smaller than 1'000 voxels (artifacts) and re-labeling of connected components larger than 1'000'000 voxels as background objects. 7 - Watershed expansion using the labeled connected components as seeds and the smoothed input image as topography (with additional 3D Gaussian smoothing on top of steps 1 and 2, with σ = 3 pxl). The background objects surrounding the primordium are also expanded. 8 - Assignment of the zero label to background objects and removal of any objects disconnected from the primordium by retaining only the single largest foreground object. We manually optimized the parameters of this pipeline for our data by inspecting the output during an extensive set of test runs. Finally, we also manually double-checked all segmentations and discarded rare cases where more than approx. 10% of cells in a stack had been missed or exhibited under- or oversegmentation."
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-2",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "3D confocal images of fixed embryos and corresponding cell segmentations"
+      }, {
+        "name" : "Description",
+        "value" : "3D confocal imaging of fixed samples of the zebrafish posterior lateral line primordium labeled with the membrane marker cldnB:lyn-EGFP and stained for pea3 mRNA using single molecule Fluorescence In-Situ Hybridization (smFISH)."
+      }, {
+        "name" : "File List",
+        "value" : "bia_file_list_idr0079_2.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Image Acquisition-2-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "Zeiss LSM880 with AiryScan technology (Carl Zeiss AG, Oberkochen, Germany)"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "Imaging was performed with a 63 × 1.4 NA oil immersion objective on the LSM880 in FAST mode with 488 nm and 639 nm excitation lasers. Stacks were acquired using 8x averaging with 0.187 μm z-spacing and a pixel size of 0.085 μm, then deconvolved with the built-in 3D AiryScan deconvolution on 'auto' settings."
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-2-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "array-scan confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000393"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-2-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "Single molecule Fluorescence In-Situ Hybridization (smFISH) was performed according to standard protocols (Durdu et al., 2014; Raj et al., 2008) using previously published Quasar 670-conjugated Stellaris smFISH probes (LGC, Biosearch Technologies, Hoddesdon, UK) designed to target pea3 mRNA, listed below. Briefly, embryos were fixed overnight in 4% PFA in PBS-T (PBS with 0.1% Neonate-20) at 4°C, then rinsed three times in PBS-T and subsequently permeabilized with 100% methanol overnight at −20°C. Embryos were rehydrated with a methanol series (75%, 50%, 25% Methanol in PBS-T, 5 min per step) and rinsed three times with PBS-T. The yolk was manually removed using forceps. Next, samples were pre-incubated with hybridization buffer (0.1 g/ml deyxtrane sulfate, 0.02 g/ml RNase-free BSA, 1 mg/ml E. coli tRNA, 10% formamide, 5x SSC, 0.1% Neonate-20 in ddH2O) at 30°C for 30 min and subsequently hybridized with pea3 probe solution (0.1 μM in hybridization buffer) at 30°C overnight in the dark. After probe removal, embryos were stained with DAPI (1:1000) in washing buffer (10% formamide, 5x SSC, 0.1% Neonate-20 in ddH2O) for 15 min at 30°C and finally kept in washing buffer for 45 min at 30°C. Stained embryos were mounted on glass slides using VECTASHIELD HardSet Antifade Mounting Medium (Vector Laboratories, Burlingame, US-CA) and imaged immediately to prevent loss of signal due to photobleaching."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "Zebrafish (Danio rerio, RRID:ZFIN_ZDB-GENO-060919-1) were grown, maintained and bred according to standard procedures described previously (Westerfield, 2000). All experiments were performed on embryos younger than 3dpf, as is stipulated by the EMBL internal policy 65 (IP65) and European Union Directive 2010/63/EU. Live embryos were kept in E3 buffer at 27–30°C. For experiments, pigmentation of embryos was prevented by treating them with 0.002% N-phenylthiourea (PTU) (Sigma-Aldrich, St. Louis, US-MO) starting at 25hpf."
+        } ]
+      }, {
+        "accno" : "Biosample-2-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "Posterior lateral line primordium"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-2-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Danio rerio"
+          }, {
+            "name" : "Common name",
+            "value" : "Zebrafish"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid7955"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-2-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "Image preprocessing: Following AiryScan 3D deconvolution with 'auto' settings on the LSM880, images were converted to 8bit TIFF files using a custom macro for the Fiji distribution (Schindelin et al., 2012) of ImageJ 1.52 g (Schneider et al., 2012). The minimum and maximum values determining the intensity range prior to 8bit conversion were selected manually such that intensity clipping is avoided. Care was taken to apply the same values to all samples of a given marker to ensure consistency. Single-Cell segmentation: 3D single-cell segmentation was performed on membrane-labeled stacks acquired, deconvolved and preprocessed as detailed in the sections above. The pipeline for segmentation consists of the following steps, applied sequentially: 1 - 3D median smoothing with a cuboid 3 × 3×3 vxl structural element to reduce shot noise. 2 - 3D Gaussian smoothing with σ = 3 pxl to further reduce noise and smoothen structures. 3 - Thresholding to retrieve a binary mask of foreground objects (i.e. the membranes). To automatically determine the appropriate threshold, we use a custom function inspired by a semi-manual approach for spot detection (Raj et al., 2008). Starting from the most frequent value in the image histogram as a base threshold, we iteratively scan a limited range of positive offsets (usually 0 to 10 in steps of 1, for slightly lower-quality images 0 to 40 in steps of 2) and count the number of connected components in the inverse of the binary mask resultant from applying each threshold. This roughly represents the number of cell bodies in the stack that are fully enclosed in cell membranes at a given threshold. We consider the threshold producing the largest number the best option and use it to generate the final membrane mask. 4 - Removal of disconnected components by morphological hole filling. 5 - Labeling of connected components on the inverted membrane mask. This ideally yields one connected component per cell, i.e. the cytoplasm. 6 - Removal of connected components smaller than 1'000 voxels (artifacts) and re-labeling of connected components larger than 1'000'000 voxels as background objects. 7 - Watershed expansion using the labeled connected components as seeds and the smoothed input image as topography (with additional 3D Gaussian smoothing on top of steps 1 and 2, with σ = 3 pxl). The background objects surrounding the primordium are also expanded. 8 - Assignment of the zero label to background objects and removal of any objects disconnected from the primordium by retaining only the single largest foreground object. We manually optimized the parameters of this pipeline for our data by inspecting the output during an extensive set of test runs. Finally, we also manually double-checked all segmentations and discarded rare cases where more than approx. 10% of cells in a stack had been missed or exhibited under- or oversegmentation."
+        } ]
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD599/S-BIAD599_override.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD599/S-BIAD599_override.json
@@ -1,0 +1,397 @@
+{
+  "accno" : "S-BIAD599",
+  "attributes" : [ {
+    "name" : "Title",
+    "value" : "An image-based data-driven analysis of cellular architecture in a developing tissue"
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2022-12-13"
+  }, {
+    "name" : "RootPath",
+    "value" : "idr0079"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "A data-driven analysis of cell morphology and intracellular organization in the developing zebrafish posterior lateral line primordium, a model tissue for the study of self-organized morphogenesis. 3D image stacks were acquired using AiryScan FAST-mode confocal fluorescence microscopy. Automated single-cell segmentation and point cloud-based morphometry were developed to extract numerical features representing cell morphology and intracellular protein distributions. Machine learning was used with the extracted numerical features to perform data integration across experiments and context-guided data visualization. The resulting data was analyzed to discover biologically meaningful patterns at the cell and tissue scale."
+    }, {
+      "name" : "License",
+      "value" : "CC BY 4.0"
+    }, {
+      "name" : "Keyword",
+      "value" : "zebrafish"
+    }, {
+      "name" : "Keyword",
+      "value" : "machine learning"
+    }, {
+      "name" : "Keyword",
+      "value" : "segmentation"
+    }, {
+      "name" : "Keyword",
+      "value" : "organogenesis"
+    }, {
+      "name" : "Acknowledgements",
+      "value" : "We thank Sabine Görgens and Andreas Kunze for their support with fish and lab maintenance, respectively. We thank the EMBL Advanced Light Microscopy Facility (ALMF) and the UZH Center for Microscopy and Image Analysis (ZMB) for maintenance of and assistance with microscopes. We thank Alejandra Guzman Herrera for generating the Act2b:mKate2-Rab11a line. We thank Francesca Peri and Stefano De Renzis for kindly providing temporary lab space. We thank Christian Tischer and Marvin Albert for helpful discussion on image analysis and numerical computation. We thank Stefano De Renzis, Daniel Krueger, Marvin Albert and Andrew Kennard for critical reading of the manuscript. JH and EG were supported by the EMBL International PhD Programme (EIPP), M.W. was supported by an EMBO Long-Term Fellowship and the EMBL Interdisciplinary Postdoc (EIPOD) Program under Marie Curie COFUNDII Actions. The Gilmour lab was supported by the European Molecular Biology Laboratory (EMBL), the University of Zurich (UZH) and Swiss National Science Funds Grant 31003A_176235."
+    }, {
+      "name" : "Funding statement",
+      "value" : "Jonas Hartmann: European Molecular Biology Laboratory (International PhD Programme). Elisa Gallo: European Molecular Biology Laboratory (International PhD Programme). Mie Wong: European Molecular Biology Organization (ALTF 205-2015) and H2020 Marie Skłodowska-Curie Actions (COFUNDII - EMBL Interdisciplinary Post-doc (EIPOD) Program). Darren Gilmour: European Molecular Biology Laboratory, Schweizerischer Nationalfonds zur Förderung der Wissenschaftlichen Forschung (31003A_176235) and University of Zurich. The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication."
+    } ],
+    "links" : [ {
+      "url" : "https://idr.openmicroscopy.org/webclient/?show=project-1105",
+      "attributes" : [ {
+        "name" : "Type",
+        "value" : "Image Data Resource"
+      } ]
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Jonas Hartmann"
+      }, {
+        "name" : "Email",
+        "value" : "jonas.m.hartmann@protonmail.com"
+      }, {
+        "name" : "Role",
+        "value" : "Conceptualization, Data curation, Software, Formal analysis, Validation, Investigation, Visualization, Methodology, Writing - original draft, Writing - review and editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "https://orcid.org/0000-0002-5600-8285"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Mie Wong"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "Role",
+        "value" : "Investigation, Writing - review and editing"
+      }, {
+        "name" : "ORCID"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Elisa Gallo"
+      }, {
+        "name" : "Email"
+      }, {
+        "name" : "Role",
+        "value" : "Investigation, Writing - review and editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "https://orcid.org/0000-0003-2203-6787"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Darren Gilmour"
+      }, {
+        "name" : "Email",
+        "value" : "darren.gilmour@imls.uzh.ch"
+      }, {
+        "name" : "Role",
+        "value" : "Conceptualization, Resources, Supervision, Funding acquisition, Project administration, Writing - review and editing"
+      }, {
+        "name" : "ORCID",
+        "value" : "https://orcid.org/0000-0001-7613-090X"
+      }, {
+        "name" : "affiliation",
+        "value" : "o3",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Teresa Zulueta-Coarasa"
+      }, {
+        "name" : "Email",
+        "value" : "teresaz@ebi.ac.uk"
+      }, {
+        "name" : "Role",
+        "value" : "data curation, submitter"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-0456-6912"
+      }, {
+        "name" : "affiliation",
+        "value" : "o4",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Cell Biology and Biophysics Unit, European Molecular Biology Laboratory (EMBL), Heidelberg, Germany"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Cell Biology and Biophysics Unit, European Molecular Biology Laboratory (EMBL), Heidelberg, GermanyInstitute of Molecular Life Sciences, University of Zurich (UZH)  Zurich, Switzerland - Collaboration for joint PhD degree between EMBL and Heidelberg University, Faculty of Biosciences, Heidelberg, Germany"
+      } ]
+    }, {
+      "accno" : "o3",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Institute of Molecular Life Sciences, University of Zurich (UZH), Zurich, Switzerland"
+      } ]
+    }, {
+      "accno" : "o4",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "European Bioinformatics Institute"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "An image-based data-driven analysis of cellular architecture in a developing tissue"
+      }, {
+        "name" : "Year",
+        "value" : "2020"
+      }, {
+        "name" : "DOI",
+        "value" : "https://doi.org/10.7554/eLife.55913"
+      }, {
+        "name" : "PMC ID",
+        "value" : "PMC7274788"
+      } ]
+    }, {
+        "accno" : "Image Acquisition-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Image Acquisition"
+        }, {
+          "name" : "Imaging Instrument",
+          "value" : "Zeiss LSM880 with AiryScan technology (Carl Zeiss AG, Oberkochen, Germany)"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "High-resolution 3D stacks (voxel size: 0.099 μm in xy, 0.225 μm in z) were acquired with a 40 × 1.2 NA water objective with Immersol W immersion fluid (Carl Zeiss, Oberkochen, Germany). Imaging in AiryScan FAST mode (Huff, 2016) with a piezo stage for z-motion and bi-directional scanning allowed acquisition times for an entire volume to be lowered to approximately 20 s (40 s for dual-color stacks using line switching). Deconvolution was performed using the LSM880's built-in 3D AiryScan deconvolution with 'auto' settings. Note that optimal image quality could only be achieved by adjustment of the stage to ensure that the cover glass is exactly normal to the excitation beam. For each dish we imaged, we used 633 nm reflected light and line scanning to get a live view of the cover glass interface, which allowed us to manually adjust the pitch of the stage to be completely horizontal. This process was repeated for both zx and zy line scans."
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "array-scan confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000393"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-2",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Specimen"
+        }, {
+          "name" : "Sample Preparation Protocol",
+          "value" : "Embryos were manually dechorionated with forceps at 30-34hpf and anaesthetized with 0.01% Tricaine (Sigma-Aldrich, St. Louis, US-MO), then transferred into 1% peqGOLD Low Melt Agarose (Peqlab, Erlangen, Germany) in E3 containing 0.01% Tricaine and immediately deposited onto a MatTek Glass Bottom Microwell Dish (35 mm Petri dish, 10 mm microwell, 0.16–0.19 mm coverglass) (MatTek Corporation, Ashland, US-MA). No more than 10 embryos were mounted in a single dish. A weighted needle tool was used to gently arrange the embryos such that they rest flatly with their lateral side directly on the glass slide. After solidification of the agarose, E3 containing 0.01% Tricaine was added to the dish. Embryos were imaged at 32-36hpf, when the pLLP was located above the posterior half of the embryo's yolk extension."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "Zebrafish (Danio rerio, RRID:ZFIN_ZDB-GENO-060919-1) were grown, maintained and bred according to standard procedures described previously (Westerfield, 2000). All experiments were performed on embryos younger than 3dpf, as is stipulated by the EMBL internal policy 65 (IP65) and European Union Directive 2010/63/EU. Live embryos were kept in E3 buffer at 27–30°C. For experiments, pigmentation of embryos was prevented by treating them with 0.002% N-phenylthiourea (PTU) (Sigma-Aldrich, St. Louis, US-MO) starting at 25hpf. For mounting and during live imaging, embryos were anaesthetized using 0.01% Tricaine (Sigma-Aldrich, St. Louis, US-MO)."
+        } ]
+      }, {
+        "accno" : "Biosample-3",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Biosample"
+        }, {
+          "name" : "Biological entity",
+          "value" : "Posterior lateral line primordium"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "Fluorescent Labels"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-3-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Danio rerio"
+          }, {
+            "name" : "Common name",
+            "value" : "Zebrafish"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid7955"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-4",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Image Analysis"
+        }, {
+          "name" : "Image Analysis Overview",
+          "value" : "Image preprocessing: Following AiryScan 3D deconvolution with 'auto' settings on the LSM880, images were converted to 8bit TIFF files using a custom macro for the Fiji distribution (Schindelin et al., 2012) of ImageJ 1.52 g (Schneider et al., 2012). The minimum and maximum values determining the intensity range prior to 8bit conversion were selected manually such that intensity clipping is avoided. Care was taken to apply the same values to all samples of a given marker to ensure consistency. Samples with the cxcr4b:NLS-tdTomato nuclear label exhibited a degree of bleed-through into the lyn-EGFP membrane label channel. To prevent this from interfering with single-cell segmentation, we employed a linear unmixing scheme in which the contribution of NLS-tdTomato (C, the contaminant image) is removed from the green channel (M, mixed image), resulting in the cleaned membrane channel (U, unmixed image). Our approach assumes that the signal in M is composed according to Equation 1, implying that U can be retrieved by subtraction of an appropriate contamination term (Equation 2). (1) M=U+a∙C. (2) U=M−a∙C. To compute the optimal bleed-through factor a we minimized a custom loss function (Equation 3), which is essentially simply the Pearson Correlation Coefficient (PCC) of the contaminant image C and the cleaned image U given a particular candidate factor ai. To ensure that unreasonably high values of a are punished, we centered the values of the cleaned image onto their mean and converted the result to absolute values, causing overly unmixed regions to start correlating with C again.(3) loss=PCC(C,∣∣M−ai∙C−mean(M−ai∙C)∣∣) We found that this approach robustly removes NLS-tdTomato bleed-through, producing unmixed images that could be segmented successfully. Single-Cell segmentation: 3D single-cell segmentation was performed on membrane-labeled stacks acquired, deconvolved and preprocessed as detailed in the sections above. The pipeline for segmentation consists of the following steps, applied sequentially: 1 - 3D median smoothing with a cuboid 3 × 3×3 vxl structural element to reduce shot noise. 2 - 3D Gaussian smoothing with σ = 3 pxl to further reduce noise and smoothen structures. 3 - Thresholding to retrieve a binary mask of foreground objects (i.e. the membranes). To automatically determine the appropriate threshold, we use a custom function inspired by a semi-manual approach for spot detection (Raj et al., 2008). Starting from the most frequent value in the image histogram as a base threshold, we iteratively scan a limited range of positive offsets (usually 0 to 10 in steps of 1, for slightly lower-quality images 0 to 40 in steps of 2) and count the number of connected components in the inverse of the binary mask resultant from applying each threshold. This roughly represents the number of cell bodies in the stack that are fully enclosed in cell membranes at a given threshold. We consider the threshold producing the largest number the best option and use it to generate the final membrane mask. 4 - Removal of disconnected components by morphological hole filling. 5 - Labeling of connected components on the inverted membrane mask. This ideally yields one connected component per cell, i.e. the cytoplasm. 6 - Removal of connected components smaller than 1'000 voxels (artifacts) and re-labeling of connected components larger than 1'000'000 voxels as background objects. 7 - Watershed expansion using the labeled connected components as seeds and the smoothed input image as topography (with additional 3D Gaussian smoothing on top of steps 1 and 2, with σ = 3 pxl). The background objects surrounding the primordium are also expanded. 8 - Assignment of the zero label to background objects and removal of any objects disconnected from the primordium by retaining only the single largest foreground object. We manually optimized the parameters of this pipeline for our data by inspecting the output during an extensive set of test runs. Finally, we also manually double-checked all segmentations and discarded rare cases where more than approx. 10% of cells in a stack had been missed or exhibited under- or oversegmentation."
+        } ]
+      }, {
+        "accno" : "Image Acquisition-6",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Image Acquisition 2"
+        }, {
+          "name" : "Imaging Instrument",
+          "value" : "Zeiss LSM880 with AiryScan technology (Carl Zeiss AG, Oberkochen, Germany)"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "Imaging was performed with a 63 × 1.4 NA oil immersion objective on the LSM880 in FAST mode with 488 nm and 639 nm excitation lasers. Stacks were acquired using 8x averaging with 0.187 μm z-spacing and a pixel size of 0.085 μm, then deconvolved with the built-in 3D AiryScan deconvolution on 'auto' settings."
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-6-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "array-scan confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000393"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-7",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Specimen 2"
+        }, {
+          "name" : "Sample Preparation Protocol",
+          "value" : "Single molecule Fluorescence In-Situ Hybridization (smFISH) was performed according to standard protocols (Durdu et al., 2014; Raj et al., 2008) using previously published Quasar 670-conjugated Stellaris smFISH probes (LGC, Biosearch Technologies, Hoddesdon, UK) designed to target pea3 mRNA, listed below. Briefly, embryos were fixed overnight in 4% PFA in PBS-T (PBS with 0.1% Neonate-20) at 4°C, then rinsed three times in PBS-T and subsequently permeabilized with 100% methanol overnight at −20°C. Embryos were rehydrated with a methanol series (75%, 50%, 25% Methanol in PBS-T, 5 min per step) and rinsed three times with PBS-T. The yolk was manually removed using forceps. Next, samples were pre-incubated with hybridization buffer (0.1 g/ml deyxtrane sulfate, 0.02 g/ml RNase-free BSA, 1 mg/ml E. coli tRNA, 10% formamide, 5x SSC, 0.1% Neonate-20 in ddH2O) at 30°C for 30 min and subsequently hybridized with pea3 probe solution (0.1 μM in hybridization buffer) at 30°C overnight in the dark. After probe removal, embryos were stained with DAPI (1:1000) in washing buffer (10% formamide, 5x SSC, 0.1% Neonate-20 in ddH2O) for 15 min at 30°C and finally kept in washing buffer for 45 min at 30°C. Stained embryos were mounted on glass slides using VECTASHIELD HardSet Antifade Mounting Medium (Vector Laboratories, Burlingame, US-CA) and imaged immediately to prevent loss of signal due to photobleaching."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "Zebrafish (Danio rerio, RRID:ZFIN_ZDB-GENO-060919-1) were grown, maintained and bred according to standard procedures described previously (Westerfield, 2000). All experiments were performed on embryos younger than 3dpf, as is stipulated by the EMBL internal policy 65 (IP65) and European Union Directive 2010/63/EU. Live embryos were kept in E3 buffer at 27–30°C. For experiments, pigmentation of embryos was prevented by treating them with 0.002% N-phenylthiourea (PTU) (Sigma-Aldrich, St. Louis, US-MO) starting at 25hpf."
+        } ]
+      }, {
+        "accno" : "Biosample-8",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Biosample 2"
+        }, {
+          "name" : "Biological entity",
+          "value" : "Posterior lateral line primordium"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-8-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Danio rerio"
+          }, {
+            "name" : "Common name",
+            "value" : "Zebrafish"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid7955"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-9",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Image Analysis 2"
+        }, {
+          "name" : "Image Analysis Overview",
+          "value" : "Image preprocessing: Following AiryScan 3D deconvolution with 'auto' settings on the LSM880, images were converted to 8bit TIFF files using a custom macro for the Fiji distribution (Schindelin et al., 2012) of ImageJ 1.52 g (Schneider et al., 2012). The minimum and maximum values determining the intensity range prior to 8bit conversion were selected manually such that intensity clipping is avoided. Care was taken to apply the same values to all samples of a given marker to ensure consistency. Single-Cell segmentation: 3D single-cell segmentation was performed on membrane-labeled stacks acquired, deconvolved and preprocessed as detailed in the sections above. The pipeline for segmentation consists of the following steps, applied sequentially: 1 - 3D median smoothing with a cuboid 3 × 3×3 vxl structural element to reduce shot noise. 2 - 3D Gaussian smoothing with σ = 3 pxl to further reduce noise and smoothen structures. 3 - Thresholding to retrieve a binary mask of foreground objects (i.e. the membranes). To automatically determine the appropriate threshold, we use a custom function inspired by a semi-manual approach for spot detection (Raj et al., 2008). Starting from the most frequent value in the image histogram as a base threshold, we iteratively scan a limited range of positive offsets (usually 0 to 10 in steps of 1, for slightly lower-quality images 0 to 40 in steps of 2) and count the number of connected components in the inverse of the binary mask resultant from applying each threshold. This roughly represents the number of cell bodies in the stack that are fully enclosed in cell membranes at a given threshold. We consider the threshold producing the largest number the best option and use it to generate the final membrane mask. 4 - Removal of disconnected components by morphological hole filling. 5 - Labeling of connected components on the inverted membrane mask. This ideally yields one connected component per cell, i.e. the cytoplasm. 6 - Removal of connected components smaller than 1'000 voxels (artifacts) and re-labeling of connected components larger than 1'000'000 voxels as background objects. 7 - Watershed expansion using the labeled connected components as seeds and the smoothed input image as topography (with additional 3D Gaussian smoothing on top of steps 1 and 2, with σ = 3 pxl). The background objects surrounding the primordium are also expanded. 8 - Assignment of the zero label to background objects and removal of any objects disconnected from the primordium by retaining only the single largest foreground object. We manually optimized the parameters of this pipeline for our data by inspecting the output during an extensive set of test runs. Finally, we also manually double-checked all segmentations and discarded rare cases where more than approx. 10% of cells in a stack had been missed or exhibited under- or oversegmentation."
+        } ]
+      }, {
+      "accno" : "Study Component-5",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "3D confocal images of live embryos and corresponding cell segmentations"
+      }, {
+        "name" : "Description",
+        "value" : "3D confocal live imaging of the zebrafish posterior lateral line primordium labeled with the membrane marker cldnB:lyn-EGFP for segmentation and optionally with one of several additional labels."
+      }, {
+        "name" : "File List",
+        "value" : "bia_file_list_idr0079_1.json"
+      } ],
+      "subsections" : [ {
+       "type" : "Associations",
+        "attributes" : [ {
+          "name" : "Biosample",
+          "value" : "Biosample"
+        }, {
+          "name" : "Specimen",
+          "value" : "Specimen"
+        }, {
+          "name" : "Image acquisition",
+          "value" : "Image Acquisition"
+        }, {
+          "name" : "Image analysis",
+          "value" : "Image Analysis"
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-10",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "3D confocal images of fixed embryos and corresponding cell segmentations"
+      }, {
+        "name" : "Description",
+        "value" : "3D confocal imaging of fixed samples of the zebrafish posterior lateral line primordium labeled with the membrane marker cldnB:lyn-EGFP and stained for pea3 mRNA using single molecule Fluorescence In-Situ Hybridization (smFISH)."
+      }, {
+        "name" : "File List",
+        "value" : "bia_file_list_idr0079_2.json"
+      } ],
+      "subsections" : [ {
+        "type" : "Associations",
+        "attributes" : [ {
+          "name" : "Biosample",
+          "value" : "Biosample 2"
+        }, {
+          "name" : "Specimen",
+          "value" : "Specimen 2"
+        }, {
+          "name" : "Image acquisition",
+          "value" : "Image Acquisition 2"
+        }, {
+          "name" : "Image analysis",
+          "value" : "Image Analysis 2"
+        } ]
+    } ]
+  } ]
+  },
+  "type" : "submission"
+}

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD628/S-BIAD628_original.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD628/S-BIAD628_original.json
@@ -1,0 +1,471 @@
+{
+  "accno" : "S-BIAD628",
+  "attributes" : [ {
+    "name" : "REMBI_PageTab Conversion Script Version",
+    "value" : "1.0.0"
+  }, {
+    "name" : "Title",
+    "value" : "Volumetric light-sheet data of freely moving sea anemone"
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2023-03-02"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "Several important questions in biology require non-invasive and three-dimensional imaging techniques with appropriate spatiotemporal resolution that permit live organisms to move in an unconstrained fashion over an extended field-of-view. While selective-plane illumination microscopy (SPIM) has emerged as a powerful method to observe live biological specimens at high spatio-temporal resolution, typical implementations often necessitate constraining sample mounting or lack the required volumetric speed. Here, we report on an open-top, dual-objective oblique plane microscope (OPM) capable of observing millimeter sized, freely moving animals at cellular resolution. We demonstrate the capabilities of our mesoscopic OPM (MesOPM) by imaging the behavioural dynamics of the sea anemone Nematostella vectensis over 1.56 × 1.56 × 0.25 mm at 1.5 × 2.8 × 5.3µm resolution and 0.5Hz volume rate."
+    }, {
+      "name" : "Keyword",
+      "value" : "oblique plane microscope (OPM)"
+    }, {
+      "name" : "Keyword",
+      "value" : "Nematostella vectensis"
+    }, {
+      "name" : "Acknowledgements",
+      "value" : "We would like to acknowledge support by the EMBL Heidelberg mechanical and electronic workshops, especially Alejandro Gil Ortiz, as well as Lars Hufnagel, Anniek Stokkermans and Sebastian Hambura for help and support. We are further grateful for useful advice from Adam Glaser during the initial phase of our project. We thank EMBL Heidelberg and Euro-BioImaging for the help with dataset conversion and deposition."
+    }, {
+      "name" : "Funding statement",
+      "value" : "This work was supported by funds from the European Molecular Biology Laboratory. I.K. receives funding from EU Horizon 2020 under grant agreement no. 101046203 (BY-COVID). B.Ö. was supported by the EOSC Future project, grant agreement number: 101017536. I.O was supported by UiT The Arctic University of Norway \"Tematiske satsinger\" (VirtualStain) no. 2061348 and Research Council of Norway, INTPART-International Partnerships for Excellent Education and Research no. 309802. K.S was supported by Marie Skłodowska Curie Cofund Actions MSCA-COFUND-FP no. 664726."
+    } ],
+    "links" : [ {
+      "url" : "https://zenodo.org/record/7147818"
+    }, {
+      "url" : "https://opticapublishing.figshare.com/articles/journal_contribution/Supplementary_document_for_An_oblique_plane_microscope_for_mesoscopic_imaging_of_freely_moving_organisms_with_cellular_resolution_-_6162562_pdf/21627050"
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Kaushikaram Subramanian"
+      }, {
+        "name" : "Email",
+        "value" : "kaushikaram.subramanian@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "first author"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Ida Opstad"
+      }, {
+        "name" : "Email",
+        "value" : "ida.opstad@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "submitter"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0003-4462-4600"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Rajwinder Singh"
+      }, {
+        "name" : "Role",
+        "value" : "Microscope development"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Aissam Ikmi"
+      }, {
+        "name" : "Email",
+        "value" : "aissam.ikmi@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "principal investigator"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Robert Prevedel"
+      }, {
+        "name" : "Email",
+        "value" : "prevedel@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "principal investigator"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Isabel Kemmer"
+      }, {
+        "name" : "Email",
+        "value" : "isabel.kemmer@eurobioimaging.eu"
+      }, {
+        "name" : "Role",
+        "value" : "data steward"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-8799-4671"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Bugra Özdemir"
+      }, {
+        "name" : "Email",
+        "value" : "bugra.oezdemir@eurobioimaging.eu"
+      }, {
+        "name" : "Role",
+        "value" : "data conversion"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0001-9823-0581"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "EMBL Heidelberg"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Euro-BioImaging ERIC"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "An oblique plane microscope for mesoscopic imaging of freely moving organisms with cellular resolution"
+      }, {
+        "name" : "Year",
+        "value" : "2022"
+      }, {
+        "name" : "Authors",
+        "value" : "Singh R, Subramanian K, Power RM, Paix A, Gil A, Ikmi A, Prevedel R"
+      }, {
+        "name" : "DOI",
+        "value" : "https://doi.org/10.1364/OE.471845"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Marie Skłodowska Curie Cofund Actions MSCA-COFUND-FP"
+      }, {
+        "name" : "grant_id",
+        "value" : "664726"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "UiT The Arctic University of Norway \"Tematiske satsinger\" (VirtualStain)"
+      }, {
+        "name" : "grant_id",
+        "value" : "2061348"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Research Council of Norway, INTPART-International Partnerships for Excellent Education and Research"
+      }, {
+        "name" : "grant_id",
+        "value" : "309802"
+      } ]
+    }, {
+      "accno" : "Study Component-1",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Live imaging of muscular organisation (circular & longitudinal muscle population)"
+      }, {
+        "name" : "Description",
+        "value" : "imaging of muscular structure of one-week old anesthetized Nematostella polyps expressing a fluorescently tagged Myosin Heavy Chain protein"
+      }, {
+        "name" : "File List",
+        "value" : "File_list_MHC.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Image Acquisition-1-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "custom-built Oblique plane microscope (OPM; a variation of light-sheet microscopy); for details see https://doi.org/10.1364/OE.471845"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "\"The entire volume stack comprises 429 frames, 1.3 µm apart, 40 ms exposure time, 0.5 mW excitation power. Total acquisition time for volume: 21 sec\""
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "SPIM"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBBI"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000369"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-1-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "imaging performed in large water droplets mounted in custom sample holder"
+        } ]
+      }, {
+        "accno" : "Biosample-1-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "primary polyps; Myosin Heavy Chain protein"
+        }, {
+          "name" : "Description",
+          "value" : "one week old, anasthetized"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "Mhc-mNG"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "anasthetized"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "3D volumetric imaging"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-1-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Nematostella vectensis"
+          }, {
+            "name" : "Common name",
+            "value" : "starlet sea anemone"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid45351"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-1-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "The raw OPM images have been deskewed and the field-of-view cropped. The image dimensions on the deskewed image stacks are: X,Y = 0.488 µm, Z=1.306 µm. The image stacks were then converted to OME-ZARR for convenient visualization in 3D."
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-2",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Live imaging of cell junctions"
+      }, {
+        "name" : "Description",
+        "value" : "Imaging of cadherin to localize apical adherens junctions which visualizes cell-cell contacts in the body wall"
+      }, {
+        "name" : "File List",
+        "value" : "File_list_Cadherin.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Image Acquisition-2-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "custom-built Oblique plane microscope (OPM; a variation of light-sheet microscopy); for details see https://doi.org/10.1364/OE.471845"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "laser power: 2 mW; 50 ms or 100 ms camera exposure time as indicated in the filenames; the entire imaging stack comprises 500 frames, 1.3 µm apart."
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-2-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "SPIM"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBBI"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000369"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-2-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "To ensure the animals could move freely a custom-manufactured mount with a tapering wedge geometry was used (2 mm width, 12 mm length and a depth of 4mm), onto which a thin FEP foil was attached. The animals were placed into the resulting FEP groove which was filled with artificial sea water to provide a physiological environment."
+        } ]
+      }, {
+        "accno" : "Biosample-2-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "primary polyps; cadherin; cell junction molecule;"
+        }, {
+          "name" : "Description",
+          "value" : "one week old, freely moving"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "Cdh1-eGFP"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "artificial seawater"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "3D volumetric imaging"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-2-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Nematostella vectensis"
+          }, {
+            "name" : "Common name",
+            "value" : "starlet sea anemone"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid45351"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-2-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "The raw OPM images have been deskewed and the field-of-view cropped. The image dimensions on the deskewed image stacks are: X,Y = 0.488 µm, Z=1.306 µm. The image stacks were then converted to OME-ZARR for convenient visualization in 3D."
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-3",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Time-lapse imaging of neurons"
+      }, {
+        "name" : "Description",
+        "value" : "Time series of Nematostella polyp undergoing body contraction along oral-aboral axis to capture the nerve net of the polyp during a peristalic wave"
+      }, {
+        "name" : "File List",
+        "value" : "File_list_Elavmb.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Image Acquisition-3-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "custom-built Oblique plane microscope (OPM; a variation of light-sheet microscopy) including high-speed, large-sensor sCMOS camera (3200x3200 pixel, Kinetix sCMOS, Teledyne Photometrics), for details see https://doi.org/10.1364/OE.471845"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "Each volume is composed of 600 frames acquired at 300fps, yielding a volume every 2 seconds (0.5 Hz) ; total laser power: 2 mW; acquisition time 1 ms per plane."
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-3-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "SPIM"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBBI"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000369"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-3-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "To ensure the animals could move freely a custom-manufactured mount with a tapering wedge geometry was used (2 mm width, 12 mm length and a depth of 4mm), onto which a thin FEP foil was attached. The animals were placed into the resulting FEP groove which was filled with artificial sea water to provide a physiological environment."
+        } ]
+      }, {
+        "accno" : "Biosample-3-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "primary polyps; Neuronal population;"
+        }, {
+          "name" : "Description",
+          "value" : "one week old, freely moving"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "Elav>mb-eGFP"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "artificial seawater"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "timelapse"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-3-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Nematostella vectensis"
+          }, {
+            "name" : "Common name",
+            "value" : "starlet sea anemone"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid45351"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-3-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "The raw OPM images have been deskewed and the field-of-view cropped.The image dimensions on the deskewed image stacks are: X,Y = 0.488 µm, Z=1.306 µm. The image stacks were then converted to OME-ZARR for convenient visualization in 3D."
+        } ]
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD628/S-BIAD628_override.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD628/S-BIAD628_override.json
@@ -1,0 +1,552 @@
+{
+  "accno" : "S-BIAD628",
+  "attributes" : [ {
+    "name" : "REMBI_PageTab Conversion Script Version",
+    "value" : "1.0.0"
+  }, {
+    "name" : "Title",
+    "value" : "Volumetric light-sheet data of freely moving sea anemone"
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2023-03-02"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "Several important questions in biology require non-invasive and three-dimensional imaging techniques with appropriate spatiotemporal resolution that permit live organisms to move in an unconstrained fashion over an extended field-of-view. While selective-plane illumination microscopy (SPIM) has emerged as a powerful method to observe live biological specimens at high spatio-temporal resolution, typical implementations often necessitate constraining sample mounting or lack the required volumetric speed. Here, we report on an open-top, dual-objective oblique plane microscope (OPM) capable of observing millimeter sized, freely moving animals at cellular resolution. We demonstrate the capabilities of our mesoscopic OPM (MesOPM) by imaging the behavioural dynamics of the sea anemone Nematostella vectensis over 1.56 × 1.56 × 0.25 mm at 1.5 × 2.8 × 5.3µm resolution and 0.5Hz volume rate."
+    }, {
+      "name" : "Keyword",
+      "value" : "oblique plane microscope (OPM)"
+    }, {
+      "name" : "Keyword",
+      "value" : "Nematostella vectensis"
+    }, {
+      "name" : "Acknowledgements",
+      "value" : "We would like to acknowledge support by the EMBL Heidelberg mechanical and electronic workshops, especially Alejandro Gil Ortiz, as well as Lars Hufnagel, Anniek Stokkermans and Sebastian Hambura for help and support. We are further grateful for useful advice from Adam Glaser during the initial phase of our project. We thank EMBL Heidelberg and Euro-BioImaging for the help with dataset conversion and deposition."
+    }, {
+      "name" : "Funding statement",
+      "value" : "This work was supported by funds from the European Molecular Biology Laboratory. I.K. receives funding from EU Horizon 2020 under grant agreement no. 101046203 (BY-COVID). B.Ö. was supported by the EOSC Future project, grant agreement number: 101017536. I.O was supported by UiT The Arctic University of Norway \"Tematiske satsinger\" (VirtualStain) no. 2061348 and Research Council of Norway, INTPART-International Partnerships for Excellent Education and Research no. 309802. K.S was supported by Marie Skłodowska Curie Cofund Actions MSCA-COFUND-FP no. 664726."
+    } ],
+    "links" : [ {
+      "url" : "https://zenodo.org/record/7147818"
+    }, {
+      "url" : "https://opticapublishing.figshare.com/articles/journal_contribution/Supplementary_document_for_An_oblique_plane_microscope_for_mesoscopic_imaging_of_freely_moving_organisms_with_cellular_resolution_-_6162562_pdf/21627050"
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Kaushikaram Subramanian"
+      }, {
+        "name" : "Email",
+        "value" : "kaushikaram.subramanian@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "first author"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Ida Opstad"
+      }, {
+        "name" : "Email",
+        "value" : "ida.opstad@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "submitter"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0003-4462-4600"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Rajwinder Singh"
+      }, {
+        "name" : "Role",
+        "value" : "Microscope development"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Aissam Ikmi"
+      }, {
+        "name" : "Email",
+        "value" : "aissam.ikmi@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "principal investigator"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Robert Prevedel"
+      }, {
+        "name" : "Email",
+        "value" : "prevedel@embl.de"
+      }, {
+        "name" : "Role",
+        "value" : "principal investigator"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Isabel Kemmer"
+      }, {
+        "name" : "Email",
+        "value" : "isabel.kemmer@eurobioimaging.eu"
+      }, {
+        "name" : "Role",
+        "value" : "data steward"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-8799-4671"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Bugra Özdemir"
+      }, {
+        "name" : "Email",
+        "value" : "bugra.oezdemir@eurobioimaging.eu"
+      }, {
+        "name" : "Role",
+        "value" : "data conversion"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0001-9823-0581"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "EMBL Heidelberg"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Euro-BioImaging ERIC"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "An oblique plane microscope for mesoscopic imaging of freely moving organisms with cellular resolution"
+      }, {
+        "name" : "Year",
+        "value" : "2022"
+      }, {
+        "name" : "Authors",
+        "value" : "Singh R, Subramanian K, Power RM, Paix A, Gil A, Ikmi A, Prevedel R"
+      }, {
+        "name" : "DOI",
+        "value" : "https://doi.org/10.1364/OE.471845"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Marie Skłodowska Curie Cofund Actions MSCA-COFUND-FP"
+      }, {
+        "name" : "grant_id",
+        "value" : "664726"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "UiT The Arctic University of Norway \"Tematiske satsinger\" (VirtualStain)"
+      }, {
+        "name" : "grant_id",
+        "value" : "2061348"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Research Council of Norway, INTPART-International Partnerships for Excellent Education and Research"
+      }, {
+        "name" : "grant_id",
+        "value" : "309802"
+      } ]
+      }, {
+        "accno" : "Image Acquisition-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Image Acquisition"
+        }, {
+          "name" : "Imaging Instrument",
+          "value" : "custom-built Oblique plane microscope (OPM; a variation of light-sheet microscopy); for details see https://doi.org/10.1364/OE.471845"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "\"The entire volume stack comprises 429 frames, 1.3 µm apart, 40 ms exposure time, 0.5 mW excitation power. Total acquisition time for volume: 21 sec\""
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "SPIM"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBBI"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000369"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-2",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Specimen"
+        }, {
+          "name" : "Sample Preparation Protocol",
+          "value" : "imaging performed in large water droplets mounted in custom sample holder"
+        } ]
+      }, {
+        "accno" : "Biosample-3",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Biosample"
+        }, {
+          "name" : "Biological entity",
+          "value" : "primary polyps; Myosin Heavy Chain protein"
+        }, {
+          "name" : "Description",
+          "value" : "one week old, anasthetized"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "Mhc-mNG"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "anasthetized"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "3D volumetric imaging"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-3-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "Nematostella vectensis"
+          }, {
+            "name" : "Common name",
+            "value" : "starlet sea anemone"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid45351"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-4",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Title",
+          "value" : "Image Analysis"
+        }, {
+          "name" : "Image Analysis Overview",
+          "value" : "The raw OPM images have been deskewed and the field-of-view cropped. The image dimensions on the deskewed image stacks are: X,Y = 0.488 µm, Z=1.306 µm. The image stacks were then converted to OME-ZARR for convenient visualization in 3D."
+        } ]
+      }, {
+      "accno" : "Study Component-5",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Live imaging of muscular organisation (circular & longitudinal muscle population)"
+      }, {
+        "name" : "Description",
+        "value" : "imaging of muscular structure of one-week old anesthetized Nematostella polyps expressing a fluorescently tagged Myosin Heavy Chain protein"
+      }, {
+        "name" : "File List",
+        "value" : "File_list_MHC.json"
+      } ],
+      "subsections" : [  {
+        "type" : "Associations",
+         "attributes" : [ {
+           "name" : "Biosample",
+           "value" : "Biosample"
+         }, {
+           "name" : "Specimen",
+           "value" : "Specimen"
+         }, {
+           "name" : "Image acquisition",
+           "value" : "Image Acquisition"
+         }, {
+           "name" : "Image analysis",
+           "value" : "Image Analysis"
+         } ]
+       } ]
+      }, {
+          "accno" : "Image Acquisition-6",
+          "type" : "Image Acquisition",
+          "attributes" : [ {
+            "name" : "Title",
+            "value" : "Image Acquisition 2"
+          }, {
+            "name" : "Imaging Instrument",
+            "value" : "custom-built Oblique plane microscope (OPM; a variation of light-sheet microscopy); for details see https://doi.org/10.1364/OE.471845"
+          }, {
+            "name" : "Image Acquisition Parameters",
+            "value" : "laser power: 2 mW; 50 ms or 100 ms camera exposure time as indicated in the filenames; the entire imaging stack comprises 500 frames, 1.3 µm apart."
+          } ],
+          "subsections" : [ {
+            "accno" : "Imaging Method-6-1",
+            "type" : "Imaging Method",
+            "attributes" : [ {
+              "name" : "Ontology Value",
+              "value" : "SPIM"
+            }, {
+              "name" : "Ontology Name",
+              "value" : "FBBI"
+            }, {
+              "name" : "Ontology Term ID",
+              "value" : "FBbi:00000369"
+            } ]
+          } ]
+        }, {
+          "accno" : "Specimen-7",
+          "type" : "Specimen",
+          "attributes" : [ {
+            "name" : "Title",
+            "value" : "Specimen 2"
+          }, {
+            "name" : "Sample Preparation Protocol",
+            "value" : "To ensure the animals could move freely a custom-manufactured mount with a tapering wedge geometry was used (2 mm width, 12 mm length and a depth of 4mm), onto which a thin FEP foil was attached. The animals were placed into the resulting FEP groove which was filled with artificial sea water to provide a physiological environment."
+          } ]
+        }, {
+          "accno" : "Biosample-8",
+          "type" : "Biosample",
+          "attributes" : [ {
+            "name" : "Title",
+            "value" : "Biosample 2"
+          }, {
+            "name" : "Biological entity",
+            "value" : "primary polyps; cadherin; cell junction molecule;"
+          }, {
+            "name" : "Description",
+            "value" : "one week old, freely moving"
+          }, {
+            "name" : "Intrinsic variable",
+            "value" : "Cdh1-eGFP"
+          }, {
+            "name" : "Extrinsic variable",
+            "value" : "artificial seawater"
+          }, {
+            "name" : "Experimental variable",
+            "value" : "3D volumetric imaging"
+          } ],
+          "subsections" : [ {
+            "accno" : "Organism-8-1",
+            "type" : "Organism",
+            "attributes" : [ {
+              "name" : "Scientific name",
+              "value" : "Nematostella vectensis"
+            }, {
+              "name" : "Common name",
+              "value" : "starlet sea anemone"
+            }, {
+              "name" : "NCBI taxon ID",
+              "value" : "NCBI:txid45351"
+            } ]
+          } ]
+        }, {
+          "accno" : "Image-Analysis-9",
+          "type" : "Image Analysis",
+          "attributes" : [ {
+            "name" : "Title",
+            "value" : "Image Analysis 2"
+          }, {
+            "name" : "Image Analysis Overview",
+            "value" : "The raw OPM images have been deskewed and the field-of-view cropped. The image dimensions on the deskewed image stacks are: X,Y = 0.488 µm, Z=1.306 µm. The image stacks were then converted to OME-ZARR for convenient visualization in 3D."
+          } ]
+    }, {
+      "accno" : "Study Component-10",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Live imaging of cell junctions"
+      }, {
+        "name" : "Description",
+        "value" : "Imaging of cadherin to localize apical adherens junctions which visualizes cell-cell contacts in the body wall"
+      }, {
+        "name" : "File List",
+        "value" : "File_list_Cadherin.json"
+      } ],
+      "subsections" : [  {
+        "type" : "Associations",
+        "attributes" : [ { 
+          "name" : "Biosample",
+          "value" : "Biosample 2"
+        }, {
+          "name" : "Specimen",
+          "value" : "Specimen 2"
+        }, {
+          "name" : "Image acquisition",
+          "value" : "Image Acquisition 2"
+        }, {
+          "name" : "Image analysis",
+          "value" : "Image Analysis 2"
+        } ]
+      } ]
+    }, {
+      "accno" : "Image Acquisition-11",
+      "type" : "Image Acquisition",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Acquisition 3"
+      }, {
+        "name" : "Imaging Instrument",
+        "value" : "custom-built Oblique plane microscope (OPM; a variation of light-sheet microscopy) including high-speed, large-sensor sCMOS camera (3200x3200 pixel, Kinetix sCMOS, Teledyne Photometrics), for details see https://doi.org/10.1364/OE.471845"
+      }, {
+        "name" : "Image Acquisition Parameters",
+        "value" : "Each volume is composed of 600 frames acquired at 300fps, yielding a volume every 2 seconds (0.5 Hz) ; total laser power: 2 mW; acquisition time 1 ms per plane."
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-11-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "SPIM"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "FBBI"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000369"
+        } ]
+      } ]
+    }, {
+      "accno" : "Specimen-12",
+      "type" : "Specimen",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Specimen 3"
+        }, {
+        "name" : "Sample Preparation Protocol",
+        "value" : "To ensure the animals could move freely a custom-manufactured mount with a tapering wedge geometry was used (2 mm width, 12 mm length and a depth of 4mm), onto which a thin FEP foil was attached. The animals were placed into the resulting FEP groove which was filled with artificial sea water to provide a physiological environment."
+      } ]
+    }, {
+      "accno" : "Biosample-13",
+      "type" : "Biosample",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Biosample 3"
+      }, {
+        "name" : "Biological entity",
+        "value" : "primary polyps; Neuronal population;"
+      }, {
+        "name" : "Description",
+        "value" : "one week old, freely moving"
+      }, {
+        "name" : "Intrinsic variable",
+        "value" : "Elav>mb-eGFP"
+      }, {
+        "name" : "Extrinsic variable",
+        "value" : "artificial seawater"
+      }, {
+        "name" : "Experimental variable",
+        "value" : "timelapse"
+      } ],
+      "subsections" : [ {
+        "accno" : "Organism-13-1",
+        "type" : "Organism",
+        "attributes" : [ {
+          "name" : "Scientific name",
+          "value" : "Nematostella vectensis"
+        }, {
+          "name" : "Common name",
+          "value" : "starlet sea anemone"
+        }, {
+          "name" : "NCBI taxon ID",
+          "value" : "NCBI:txid45351"
+        } ]
+      } ]
+    }, {
+      "accno" : "Image-Analysis-14",
+      "type" : "Image Analysis",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Analysis 3"
+      }, {
+        "name" : "Image Analysis Overview",
+        "value" : "The raw OPM images have been deskewed and the field-of-view cropped.The image dimensions on the deskewed image stacks are: X,Y = 0.488 µm, Z=1.306 µm. The image stacks were then converted to OME-ZARR for convenient visualization in 3D."
+      } ]
+    }, {
+      "accno" : "Study Component-15",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Time-lapse imaging of neurons"
+      }, {
+        "name" : "Description",
+        "value" : "Time series of Nematostella polyp undergoing body contraction along oral-aboral axis to capture the nerve net of the polyp during a peristalic wave"
+      }, {
+        "name" : "File List",
+        "value" : "File_list_Elavmb.json"
+      } ],
+      "subsections" : [ {
+        "type" : "Associations",
+        "attributes" : [ {
+          "name" : "Biosample",
+          "value" : "Biosample 3"
+        }, {
+          "name" : "Specimen",
+          "value" : "Specimen 3"
+        }, {
+          "name" : "Image acquisition",
+          "value" : "Image Acquisition 3"
+        }, {
+          "name" : "Image analysis",
+          "value" : "Image Analysis 3"
+        } ]
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD677/S-BIAD677_original.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD677/S-BIAD677_original.json
@@ -1,0 +1,551 @@
+{
+  "accno" : "S-BIAD677",
+  "attributes" : [ {
+    "name" : "REMBI_PageTab Conversion Script Version",
+    "value" : "1.0.0"
+  }, {
+    "name" : "Title",
+    "value" : "Bronchial epithelia from adults and children: SARS-CoV-2 spread via syncytia formation and type III interferon infectivity restriction"
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2023-05-02"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "Here, we reconstituted bronchial epithelia from adult and child donors and show that SARS-CoV-2 infections spread fast, resulting in the formation and synchronized release of large clusters of infected cells and syncytia into the apical lumen, contributing to virus dissemination. Some epithelia, for the most part from children, revealed an intrinsic resistance to infection and virus spread. This infection control correlates with faster type III interferon secretion and can be transferred to permissive epithelia through exogenous interferon application. Child epithelia also showed a muted inflammatory response compared with adult, suggesting a specific and age-adapted epithelial response to SARS-CoV-2 infection that may explain why children are less susceptible to severe COVID-19."
+    }, {
+      "name" : "License",
+      "value" : "CC0"
+    }, {
+      "name" : "Keyword",
+      "value" : "SARS-CoV-2"
+    }, {
+      "name" : "Keyword",
+      "value" : "bronchial epithelia"
+    }, {
+      "name" : "Keyword",
+      "value" : "infection"
+    }, {
+      "name" : "Keyword",
+      "value" : "syncytia"
+    }, {
+      "name" : "Keyword",
+      "value" : "children"
+    }, {
+      "name" : "Keyword",
+      "value" : "interferon"
+    }, {
+      "name" : "Acknowledgements",
+      "value" : "Light and electron imaging was performed at the Bordeaux Imaging Center (BIC), member of the FranceBioImaging national infrastructure (grant ANR-10-INBS-04) and of the French BioImaging Node of Euro-BioImaging ERIC (https://ror.org/05d78xc36). We thank the BIC for relentless support during the lockdown"
+    }, {
+      "name" : "Funding statement",
+      "value" : "M.-L.B. was supported by the Région Nouvelle Aquitaine and UBReact, Bordeaux University. I.K. receives funding from EU Horizon 2020 under grant agreement no. 101046203 (BY-COVID)."
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Nicolas Landrein"
+      }, {
+        "name" : "Email",
+        "value" : "nicolas.landrein@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "submitter"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0001-8875-4242"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Harald Wodrich"
+      }, {
+        "name" : "Email",
+        "value" : "harald.wodrich@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "principal investigator"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-4764-1708"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Guillaume Beucher"
+      }, {
+        "name" : "Email",
+        "value" : "guillaume.beucher@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "first author"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Thomas Trian"
+      }, {
+        "name" : "Email",
+        "value" : "thomas.trian@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "contributor"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-2567-4867"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Marie-Line Andreola"
+      }, {
+        "name" : "Email",
+        "value" : "marie-aline.andreola@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "contributor"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0001-9808-7391"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Isabel Kemmer"
+      }, {
+        "name" : "Email",
+        "value" : "isabel.kemmer@eurobioimaging.eu"
+      }, {
+        "name" : "Role",
+        "value" : "data steward"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-8799-4671"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "University of Bordeaux"
+      }, {
+        "name" : "RORID",
+        "value" : "https://ror.org/057qpr032"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Euro-BioImaging ERIC"
+      }, {
+        "name" : "RORID",
+        "value" : "https://ror.org/05d78xc36"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Bronchial epithelia from adults and children: SARS-CoV-2 spread via syncytia formation and type III interferon infectivity restriction"
+      }, {
+        "name" : "Year",
+        "value" : "2022"
+      }, {
+        "name" : "Authors",
+        "value" : "Guillaume Beucher, Marie-Lise Blondot, Alexis Celle, Noémie Pied, Patricia Recordon-Pinson, Pauline Esteves, Muriel Faure, Mathieu Métifiot, Sabrina Lacomme, Denis Dacheux, Derrick R. Robinson, Gernot Längst, Fabien Beaufils, Marie-Edith Lafon, Patrick Berger, Marc Landry, Denis Malvy, Thomas Trian, Marie-Line Andreola, Harald Wodrich"
+      }, {
+        "name" : "DOI",
+        "value" : "10.1073/pnas.2202370119"
+      }, {
+        "name" : "PMC ID",
+        "value" : "PMC9651868"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "laboratoire d'excellence ParaFrap"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant ANR-11-LABX-0024"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Fondation Recherche Medicale (FRM)"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant DEQ20180339229"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Agence Nationale de la Recherche"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant ANR-CE14-0015-01, project ROSAE"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Fondation de France"
+      }, {
+        "name" : "grant_id",
+        "value" : "project ANACONDA"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "France BioImaging"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant ANR-10-INBS-04"
+      } ]
+    }, {
+      "accno" : "Study Component-1",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Infected Multiciliated Cells Form Syncytia with Basal Cells at the Apical Side of the BE"
+      }, {
+        "name" : "Description",
+        "value" : "we used human reconstituted bronchial epithelia (BE) to investigate the onset of infection and replication of SARS-CoV-2 with widefield and confocal microscopy. BE are an important tissue because subsequent infection of the bronchial tissue determines whether a SARS-CoV-2 infection results in severe or mild respiratory illness, by controlling the spread into the lower respiratory tract. These features differentiate our approach from similar studies using primary respiratory cells from either upper airway (nasal, tracheal)"
+      }, {
+        "name" : "File List",
+        "value" : "file_list_sc1.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Biosample-1-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "bronchial epithelia (BE)"
+        }, {
+          "name" : "Description",
+          "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "patient ID and patient age"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "infection with SARS-CoV-2"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "days after infection"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-1-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "homo sapiens"
+          }, {
+            "name" : "Common name",
+            "value" : "human"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid9606"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-1-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+        } ]
+      }, {
+        "accno" : "Image Acquisition-1-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "Leica inverted DMi6000 widefield microscope + Lumencor ligth source + Hamamatsu ORCA-Flash4.0 LT"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "fluorescence microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000246"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image Acquisition-1-2",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center) 405nm diode laser + white laser 470-670nm"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "diverse parameters; to be found inside the metadata of the .lif images"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-2",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000251"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-1-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "To quantify colocalisation between N positive cells (infected cells) and either cytokeratin 5 (Cytk5, basal cells), mucin 5A (goblet cells) or acetylated tubulin (multi ciliated cells) 10x magnification images or a 63x magnification images were acquired and processed for image analysis. Z-projections of different focal planes were generated and regions of interest (ROI) were designed to delimit the area of analysis. A threshold was then applied to the projection of both N positive cells and Cytk5 (or tubulin) positive cells in order to obtain respective masks. Masks were analyzed using the “colocalization” function in ImageJ to calculate the number of double positive cells (N and Cytk5). Obtained values were normalized by either total number of N or total number of Cytk5 (or tubulin or mucin) positive cells to calculate the percentage of basal cells (or ciliated/goblet cells) that are infected."
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-2",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Electron microscopy of BE after SARS-CoV-2 infection"
+      }, {
+        "name" : "Description",
+        "value" : "Study of the ultra structure of the BE during an SARS-CoV-2 infection."
+      }, {
+        "name" : "File List",
+        "value" : "file_list_sc2.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Biosample-2-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "bronchial epithelia (BE)"
+        }, {
+          "name" : "Description",
+          "value" : "BE culture from patient-derived material"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "patient ID and patient age"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "infection with SARS-CoV-2"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "days after infection"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-2-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "homo sapiens"
+          }, {
+            "name" : "Common name",
+            "value" : "human"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid9606"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-2-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "BE were first washed in physiological serum and then fixed with 2.5% (v/v) glutaraldehyde and 2% (v/v) paraformaldehyde in 0.1M phosphate buffer (pH 7.4) during 2h minimum at room temperature (RT). Then samples were washed in 0.1M phosphate buffer and post-fixed in 1% (v/v) osmium tetroxide in phosphate buffer 0.1 M during 2h, in the dark, at RT, then washing in water and dehydrated through a series of graded ethanol and embedded in a mixture of pure ethanol and epoxy resin (Epon 812; Delta Microscopy, Toulouse, France) 50/50 (v/v) during 2 hours and then in 100% resin overnight at RT. The polymerization of the resin was carried out over a period between 24-48 hours at 60°C. Samples were then sectioned using a diamond knife (Diatome, Biel-Bienne,Switzerland) on an ultramicrotome (EM UCT, Leica Microsystems, Vienna, Austria). Ultrathin sections (70 nm) were picked up on copper grids and then stained with uranyless and lead citrate."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery. BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+        } ]
+      }, {
+        "accno" : "Image Acquisition-2-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "H7650, Hitachi Transmission Electron Microscope"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "80 kV"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-2-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "transmission electron microscopy (TEM)"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000258"
+          } ]
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-3",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "An Accelerated Type III IFN Response Protects BE from SARSCoV-2 Infection"
+      }, {
+        "name" : "Description",
+        "value" : "We study the effect of Type III IFN by knocking out the IFN (CRISPR/Cas9) and by treating the BE with Type III IFN"
+      }, {
+        "name" : "File List",
+        "value" : "file_list_sc3.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Biosample-3-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "bronchial epithelia (BE)"
+        }, {
+          "name" : "Description",
+          "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "patient ID; CRISPR-knockout of interferon-genes"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "infection with SARS-CoV-2"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "treatment with interferon (5 ng or 50 ng of IFN-λ)"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-3-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "homo sapiens"
+          }, {
+            "name" : "Common name",
+            "value" : "human"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid9606"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-3-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+        } ]
+      }, {
+        "accno" : "Image Acquisition-3-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "Leica inverted DMi6000 widefield microscope"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-3-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "fluorescence microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000246"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image Acquisition-3-2",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center)"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "diverse parameters; to be found inside the metadata of the .lif images"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-3-2",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000251"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-3-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "To determine the infected surface in presence or absence of IFN treatment the entire epithelial surface was recorded at 10x magnification for each condition, for each donor and processed for image analysis. Z-projections of the entire epithelium were generated and determined as ROI. The infected area or as normalized value to the non-treated controlinfected area was determined by the N-signal and calculated as percentage of infected area or as normalized value to the non-treated control"
+        } ]
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD677/S-BIAD677_override.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD677/S-BIAD677_override.json
@@ -241,7 +241,120 @@
         "value" : "grant ANR-10-INBS-04"
       } ]
     }, {
-      "accno" : "Study Component-1",
+      "accno" : "Biosample-1",
+      "type" : "Biosample",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Biosample"
+        }, {
+        "name" : "Biological entity",
+        "value" : "bronchial epithelia (BE)"
+      }, {
+        "name" : "Description",
+        "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
+      }, {
+        "name" : "Intrinsic variable",
+        "value" : "patient ID and patient age"
+      }, {
+        "name" : "Extrinsic variable",
+        "value" : "infection with SARS-CoV-2"
+      }, {
+        "name" : "Experimental variable",
+        "value" : "days after infection"
+      } ],
+      "subsections" : [ {
+        "accno" : "Organism-1-1",
+        "type" : "Organism",
+        "attributes" : [ {
+          "name" : "Scientific name",
+          "value" : "homo sapiens"
+        }, {
+          "name" : "Common name",
+          "value" : "human"
+        }, {
+          "name" : "NCBI taxon ID",
+          "value" : "NCBI:txid9606"
+        } ]
+      } ]
+    }, {
+      "accno" : "Specimen-2",
+      "type" : "Specimen",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Specimen"
+        }, {
+        "name" : "Sample Preparation Protocol",
+        "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
+      }, {
+        "name" : "Growth Protocol",
+        "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+      } ]
+    }, {
+      "accno" : "Image Acquisition-3",
+      "type" : "Image Acquisition",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Acquisition"
+      }, {
+        "name" : "Imaging Instrument",
+        "value" : "Leica inverted DMi6000 widefield microscope + Lumencor ligth source + Hamamatsu ORCA-Flash4.0 LT"
+      }, {
+        "name" : "Image Acquisition Parameters",
+        "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-3-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "fluorescence microscopy"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "FBbi"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000246"
+        } ]
+      } ]
+    }, {
+      "accno" : "Image Acquisition-4",
+      "type" : "Image Acquisition",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Acquisition 2"
+      }, {
+        "name" : "Imaging Instrument",
+        "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center) 405nm diode laser + white laser 470-670nm"
+      }, {
+        "name" : "Image Acquisition Parameters",
+        "value" : "diverse parameters; to be found inside the metadata of the .lif images"
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-4-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "confocal microscopy"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "FBbi"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000251"
+        } ]
+      } ]
+    }, {
+      "accno" : "Image-Analysis-5",
+      "type" : "Image Analysis",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Analysis"
+      }, {
+        "name" : "Image Analysis Overview",
+        "value" : "To quantify colocalisation between N positive cells (infected cells) and either cytokeratin 5 (Cytk5, basal cells), mucin 5A (goblet cells) or acetylated tubulin (multi ciliated cells) 10x magnification images or a 63x magnification images were acquired and processed for image analysis. Z-projections of different focal planes were generated and regions of interest (ROI) were designed to delimit the area of analysis. A threshold was then applied to the projection of both N positive cells and Cytk5 (or tubulin) positive cells in order to obtain respective masks. Masks were analyzed using the “colocalization” function in ImageJ to calculate the number of double positive cells (N and Cytk5). Obtained values were normalized by either total number of N or total number of Cytk5 (or tubulin or mucin) positive cells to calculate the percentage of basal cells (or ciliated/goblet cells) that are infected."
+      } ]
+    }, {
+      "accno" : "Study Component-6",
       "type" : "Study Component",
       "attributes" : [ {
         "name" : "Name",
@@ -254,106 +367,114 @@
         "value" : "file_list_sc1.json"
       } ],
       "subsections" : [ {
-        "accno" : "Biosample-1-1",
-        "type" : "Biosample",
-        "attributes" : [ {
-          "name" : "Biological entity",
-          "value" : "bronchial epithelia (BE)"
+        "type" : "Associations",
+         "attributes" : [ {
+           "name" : "Biosample",
+           "value" : "Biosample"
+         }, {
+           "name" : "Specimen",
+           "value" : "Specimen"
+         }, {
+           "name" : "Image acquisition",
+           "value" : "Image Acquisition"
+         }, {
+           "name" : "Image analysis",
+           "value" : "Image Analysis"
+         } ]
+       }, {
+        "type" : "Associations",
+         "attributes" : [ {
+           "name" : "Biosample",
+           "value" : "Biosample"
+         }, {
+           "name" : "Specimen",
+           "value" : "Specimen"
+         }, {
+           "name" : "Image acquisition",
+           "value" : "Image Acquisition 2"
+         }, {
+           "name" : "Image analysis",
+           "value" : "Image Analysis"
+         } ]
+       } ]
+    }, {
+      "accno" : "Biosample-7",
+      "type" : "Biosample",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Biosample 2"
         }, {
-          "name" : "Description",
-          "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
-        }, {
-          "name" : "Intrinsic variable",
-          "value" : "patient ID and patient age"
-        }, {
-          "name" : "Extrinsic variable",
-          "value" : "infection with SARS-CoV-2"
-        }, {
-          "name" : "Experimental variable",
-          "value" : "days after infection"
-        } ],
-        "subsections" : [ {
-          "accno" : "Organism-1-1",
-          "type" : "Organism",
-          "attributes" : [ {
-            "name" : "Scientific name",
-            "value" : "homo sapiens"
-          }, {
-            "name" : "Common name",
-            "value" : "human"
-          }, {
-            "name" : "NCBI taxon ID",
-            "value" : "NCBI:txid9606"
-          } ]
-        } ]
+        "name" : "Biological entity",
+        "value" : "bronchial epithelia (BE)"
       }, {
-        "accno" : "Specimen-1-1",
-        "type" : "Specimen",
-        "attributes" : [ {
-          "name" : "Sample Preparation Protocol",
-          "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
-        }, {
-          "name" : "Growth Protocol",
-          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
-        } ]
+        "name" : "Description",
+        "value" : "BE culture from patient-derived material"
       }, {
-        "accno" : "Image Acquisition-1-1",
-        "type" : "Image Acquisition",
-        "attributes" : [ {
-          "name" : "Imaging Instrument",
-          "value" : "Leica inverted DMi6000 widefield microscope + Lumencor ligth source + Hamamatsu ORCA-Flash4.0 LT"
-        }, {
-          "name" : "Image Acquisition Parameters",
-          "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
-        } ],
-        "subsections" : [ {
-          "accno" : "Imaging Method-1-1",
-          "type" : "Imaging Method",
-          "attributes" : [ {
-            "name" : "Ontology Value",
-            "value" : "fluorescence microscopy"
-          }, {
-            "name" : "Ontology Name",
-            "value" : "FBbi"
-          }, {
-            "name" : "Ontology Term ID",
-            "value" : "FBbi:00000246"
-          } ]
-        } ]
+        "name" : "Intrinsic variable",
+        "value" : "patient ID and patient age"
       }, {
-        "accno" : "Image Acquisition-1-2",
-        "type" : "Image Acquisition",
-        "attributes" : [ {
-          "name" : "Imaging Instrument",
-          "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center) 405nm diode laser + white laser 470-670nm"
-        }, {
-          "name" : "Image Acquisition Parameters",
-          "value" : "diverse parameters; to be found inside the metadata of the .lif images"
-        } ],
-        "subsections" : [ {
-          "accno" : "Imaging Method-1-2",
-          "type" : "Imaging Method",
-          "attributes" : [ {
-            "name" : "Ontology Value",
-            "value" : "confocal microscopy"
-          }, {
-            "name" : "Ontology Name",
-            "value" : "FBbi"
-          }, {
-            "name" : "Ontology Term ID",
-            "value" : "FBbi:00000251"
-          } ]
-        } ]
+        "name" : "Extrinsic variable",
+        "value" : "infection with SARS-CoV-2"
       }, {
-        "accno" : "Image-Analysis-1-1",
-        "type" : "Image Analysis",
+        "name" : "Experimental variable",
+        "value" : "days after infection"
+      } ],
+      "subsections" : [ {
+        "accno" : "Organism-7-1",
+        "type" : "Organism",
         "attributes" : [ {
-          "name" : "Image Analysis Overview",
-          "value" : "To quantify colocalisation between N positive cells (infected cells) and either cytokeratin 5 (Cytk5, basal cells), mucin 5A (goblet cells) or acetylated tubulin (multi ciliated cells) 10x magnification images or a 63x magnification images were acquired and processed for image analysis. Z-projections of different focal planes were generated and regions of interest (ROI) were designed to delimit the area of analysis. A threshold was then applied to the projection of both N positive cells and Cytk5 (or tubulin) positive cells in order to obtain respective masks. Masks were analyzed using the “colocalization” function in ImageJ to calculate the number of double positive cells (N and Cytk5). Obtained values were normalized by either total number of N or total number of Cytk5 (or tubulin or mucin) positive cells to calculate the percentage of basal cells (or ciliated/goblet cells) that are infected."
+          "name" : "Scientific name",
+          "value" : "homo sapiens"
+        }, {
+          "name" : "Common name",
+          "value" : "human"
+        }, {
+          "name" : "NCBI taxon ID",
+          "value" : "NCBI:txid9606"
         } ]
       } ]
     }, {
-      "accno" : "Study Component-2",
+      "accno" : "Specimen-8",
+      "type" : "Specimen",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Specimen 2"
+      }, {
+        "name" : "Sample Preparation Protocol",
+        "value" : "BE were first washed in physiological serum and then fixed with 2.5% (v/v) glutaraldehyde and 2% (v/v) paraformaldehyde in 0.1M phosphate buffer (pH 7.4) during 2h minimum at room temperature (RT). Then samples were washed in 0.1M phosphate buffer and post-fixed in 1% (v/v) osmium tetroxide in phosphate buffer 0.1 M during 2h, in the dark, at RT, then washing in water and dehydrated through a series of graded ethanol and embedded in a mixture of pure ethanol and epoxy resin (Epon 812; Delta Microscopy, Toulouse, France) 50/50 (v/v) during 2 hours and then in 100% resin overnight at RT. The polymerization of the resin was carried out over a period between 24-48 hours at 60°C. Samples were then sectioned using a diamond knife (Diatome, Biel-Bienne,Switzerland) on an ultramicrotome (EM UCT, Leica Microsystems, Vienna, Austria). Ultrathin sections (70 nm) were picked up on copper grids and then stained with uranyless and lead citrate."
+      }, {
+        "name" : "Growth Protocol",
+        "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery. BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+      } ]
+    }, {
+      "accno" : "Image Acquisition-9",
+      "type" : "Image Acquisition",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Acquisition 3"
+      }, {
+        "name" : "Imaging Instrument",
+        "value" : "H7650, Hitachi Transmission Electron Microscope"
+      }, {
+        "name" : "Image Acquisition Parameters",
+        "value" : "80 kV"
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-9-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "transmission electron microscopy (TEM)"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "FBbi"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000258"
+        } ]
+      } ] 
+    }, {
+      "accno" : "Study Component-10",
       "type" : "Study Component",
       "attributes" : [ {
         "name" : "Name",
@@ -366,75 +487,133 @@
         "value" : "file_list_sc2.json"
       } ],
       "subsections" : [ {
-        "accno" : "Biosample-2-1",
-        "type" : "Biosample",
-        "attributes" : [ {
-          "name" : "Biological entity",
-          "value" : "bronchial epithelia (BE)"
-        }, {
-          "name" : "Description",
-          "value" : "BE culture from patient-derived material"
-        }, {
-          "name" : "Intrinsic variable",
-          "value" : "patient ID and patient age"
-        }, {
-          "name" : "Extrinsic variable",
-          "value" : "infection with SARS-CoV-2"
-        }, {
-          "name" : "Experimental variable",
-          "value" : "days after infection"
-        } ],
-        "subsections" : [ {
-          "accno" : "Organism-2-1",
-          "type" : "Organism",
-          "attributes" : [ {
-            "name" : "Scientific name",
-            "value" : "homo sapiens"
-          }, {
-            "name" : "Common name",
-            "value" : "human"
-          }, {
-            "name" : "NCBI taxon ID",
-            "value" : "NCBI:txid9606"
-          } ]
-        } ]
+        "type" : "Associations",
+         "attributes" : [ {
+           "name" : "Biosample",
+           "value" : "Biosample 2"
+         }, {
+           "name" : "Specimen",
+           "value" : "Specimen 2"
+         }, {
+           "name" : "Image acquisition",
+           "value" : "Image Acquisition 3"
+         } ]
+       } ]
+    }, {
+      "accno" : "Biosample-11",
+      "type" : "Biosample",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Biosample 3"
       }, {
-        "accno" : "Specimen-2-1",
-        "type" : "Specimen",
-        "attributes" : [ {
-          "name" : "Sample Preparation Protocol",
-          "value" : "BE were first washed in physiological serum and then fixed with 2.5% (v/v) glutaraldehyde and 2% (v/v) paraformaldehyde in 0.1M phosphate buffer (pH 7.4) during 2h minimum at room temperature (RT). Then samples were washed in 0.1M phosphate buffer and post-fixed in 1% (v/v) osmium tetroxide in phosphate buffer 0.1 M during 2h, in the dark, at RT, then washing in water and dehydrated through a series of graded ethanol and embedded in a mixture of pure ethanol and epoxy resin (Epon 812; Delta Microscopy, Toulouse, France) 50/50 (v/v) during 2 hours and then in 100% resin overnight at RT. The polymerization of the resin was carried out over a period between 24-48 hours at 60°C. Samples were then sectioned using a diamond knife (Diatome, Biel-Bienne,Switzerland) on an ultramicrotome (EM UCT, Leica Microsystems, Vienna, Austria). Ultrathin sections (70 nm) were picked up on copper grids and then stained with uranyless and lead citrate."
-        }, {
-          "name" : "Growth Protocol",
-          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery. BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
-        } ]
+        "name" : "Biological entity",
+        "value" : "bronchial epithelia (BE)"
       }, {
-        "accno" : "Image Acquisition-2-1",
-        "type" : "Image Acquisition",
+        "name" : "Description",
+        "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
+      }, {
+        "name" : "Intrinsic variable",
+        "value" : "patient ID; CRISPR-knockout of interferon-genes"
+      }, {
+        "name" : "Extrinsic variable",
+        "value" : "infection with SARS-CoV-2"
+      }, {
+        "name" : "Experimental variable",
+        "value" : "treatment with interferon (5 ng or 50 ng of IFN-λ)"
+      } ],
+      "subsections" : [ {
+        "accno" : "Organism-11-1",
+        "type" : "Organism",
         "attributes" : [ {
-          "name" : "Imaging Instrument",
-          "value" : "H7650, Hitachi Transmission Electron Microscope"
+          "name" : "Scientific name",
+          "value" : "homo sapiens"
         }, {
-          "name" : "Image Acquisition Parameters",
-          "value" : "80 kV"
-        } ],
-        "subsections" : [ {
-          "accno" : "Imaging Method-2-1",
-          "type" : "Imaging Method",
-          "attributes" : [ {
-            "name" : "Ontology Value",
-            "value" : "transmission electron microscopy (TEM)"
-          }, {
-            "name" : "Ontology Name",
-            "value" : "FBbi"
-          }, {
-            "name" : "Ontology Term ID",
-            "value" : "FBbi:00000258"
-          } ]
+          "name" : "Common name",
+          "value" : "human"
+        }, {
+          "name" : "NCBI taxon ID",
+          "value" : "NCBI:txid9606"
         } ]
       } ]
     }, {
-      "accno" : "Study Component-3",
+      "accno" : "Specimen-12",
+      "type" : "Specimen",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Specimen 3"
+      }, {
+        "name" : "Sample Preparation Protocol",
+        "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
+      }, {
+        "name" : "Growth Protocol",
+        "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+      } ]
+    }, {
+      "accno" : "Image Acquisition-13",
+      "type" : "Image Acquisition",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Acquisition 4"
+      }, {
+        "name" : "Imaging Instrument",
+        "value" : "Leica inverted DMi6000 widefield microscope"
+      }, {
+        "name" : "Image Acquisition Parameters",
+        "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-13-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "fluorescence microscopy"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "FBbi"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000246"
+        } ]
+      } ]
+    }, {
+      "accno" : "Image Acquisition-14",
+      "type" : "Image Acquisition",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Acquisition 5"
+      }, {
+        "name" : "Imaging Instrument",
+        "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center)"
+      }, {
+        "name" : "Image Acquisition Parameters",
+        "value" : "diverse parameters; to be found inside the metadata of the .lif images"
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-14-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "confocal microscopy"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "FBbi"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000251"
+        } ]
+      } ]
+    }, {
+      "accno" : "Image-Analysis-15",
+      "type" : "Image Analysis",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Image Analysis 2"
+      }, {
+        "name" : "Image Analysis Overview",
+        "value" : "To determine the infected surface in presence or absence of IFN treatment the entire epithelial surface was recorded at 10x magnification for each condition, for each donor and processed for image analysis. Z-projections of the entire epithelium were generated and determined as ROI. The infected area or as normalized value to the non-treated controlinfected area was determined by the N-signal and calculated as percentage of infected area or as normalized value to the non-treated control"
+      } ] 
+    }, {
+      "accno" : "Study Component-16",
       "type" : "Study Component",
       "attributes" : [ {
         "name" : "Name",
@@ -447,104 +626,36 @@
         "value" : "file_list_sc3.json"
       } ],
       "subsections" : [ {
-        "accno" : "Biosample-3-1",
-        "type" : "Biosample",
-        "attributes" : [ {
-          "name" : "Biological entity",
-          "value" : "bronchial epithelia (BE)"
-        }, {
-          "name" : "Description",
-          "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
-        }, {
-          "name" : "Intrinsic variable",
-          "value" : "patient ID; CRISPR-knockout of interferon-genes"
-        }, {
-          "name" : "Extrinsic variable",
-          "value" : "infection with SARS-CoV-2"
-        }, {
-          "name" : "Experimental variable",
-          "value" : "treatment with interferon (5 ng or 50 ng of IFN-λ)"
-        } ],
-        "subsections" : [ {
-          "accno" : "Organism-3-1",
-          "type" : "Organism",
-          "attributes" : [ {
-            "name" : "Scientific name",
-            "value" : "homo sapiens"
-          }, {
-            "name" : "Common name",
-            "value" : "human"
-          }, {
-            "name" : "NCBI taxon ID",
-            "value" : "NCBI:txid9606"
-          } ]
-        } ]
-      }, {
-        "accno" : "Specimen-3-1",
-        "type" : "Specimen",
-        "attributes" : [ {
-          "name" : "Sample Preparation Protocol",
-          "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
-        }, {
-          "name" : "Growth Protocol",
-          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
-        } ]
-      }, {
-        "accno" : "Image Acquisition-3-1",
-        "type" : "Image Acquisition",
-        "attributes" : [ {
-          "name" : "Imaging Instrument",
-          "value" : "Leica inverted DMi6000 widefield microscope"
-        }, {
-          "name" : "Image Acquisition Parameters",
-          "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
-        } ],
-        "subsections" : [ {
-          "accno" : "Imaging Method-3-1",
-          "type" : "Imaging Method",
-          "attributes" : [ {
-            "name" : "Ontology Value",
-            "value" : "fluorescence microscopy"
-          }, {
-            "name" : "Ontology Name",
-            "value" : "FBbi"
-          }, {
-            "name" : "Ontology Term ID",
-            "value" : "FBbi:00000246"
-          } ]
-        } ]
-      }, {
-        "accno" : "Image Acquisition-3-2",
-        "type" : "Image Acquisition",
-        "attributes" : [ {
-          "name" : "Imaging Instrument",
-          "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center)"
-        }, {
-          "name" : "Image Acquisition Parameters",
-          "value" : "diverse parameters; to be found inside the metadata of the .lif images"
-        } ],
-        "subsections" : [ {
-          "accno" : "Imaging Method-3-2",
-          "type" : "Imaging Method",
-          "attributes" : [ {
-            "name" : "Ontology Value",
-            "value" : "confocal microscopy"
-          }, {
-            "name" : "Ontology Name",
-            "value" : "FBbi"
-          }, {
-            "name" : "Ontology Term ID",
-            "value" : "FBbi:00000251"
-          } ]
-        } ]
-      }, {
-        "accno" : "Image-Analysis-3-1",
-        "type" : "Image Analysis",
-        "attributes" : [ {
-          "name" : "Image Analysis Overview",
-          "value" : "To determine the infected surface in presence or absence of IFN treatment the entire epithelial surface was recorded at 10x magnification for each condition, for each donor and processed for image analysis. Z-projections of the entire epithelium were generated and determined as ROI. The infected area or as normalized value to the non-treated controlinfected area was determined by the N-signal and calculated as percentage of infected area or as normalized value to the non-treated control"
-        } ]
-      } ]
+        "type" : "Associations",
+         "attributes" : [ {
+           "name" : "Biosample",
+           "value" : "Biosample 3"
+         }, {
+           "name" : "Specimen",
+           "value" : "Specimen 3"
+         }, {
+           "name" : "Image acquisition",
+           "value" : "Image Acquisition 4"
+         }, {
+           "name" : "Image analysis",
+           "value" : "Image Analysis 2"
+         } ]
+       }, {
+        "type" : "Associations",
+         "attributes" : [ {
+           "name" : "Biosample",
+           "value" : "Biosample 3"
+         }, {
+           "name" : "Specimen",
+           "value" : "Specimen 3"
+         }, {
+           "name" : "Image acquisition",
+           "value" : "Image Acquisition 5"
+         }, {
+           "name" : "Image analysis",
+           "value" : "Image Analysis 2"
+         } ]
+       } ]
     } ]
   },
   "type" : "submission"

--- a/bia-ingest/submission_overrides/biostudies/S-BIAD677/S-BIAD677_override.json
+++ b/bia-ingest/submission_overrides/biostudies/S-BIAD677/S-BIAD677_override.json
@@ -1,0 +1,551 @@
+{
+  "accno" : "S-BIAD677",
+  "attributes" : [ {
+    "name" : "REMBI_PageTab Conversion Script Version",
+    "value" : "1.0.0"
+  }, {
+    "name" : "Title",
+    "value" : "Bronchial epithelia from adults and children: SARS-CoV-2 spread via syncytia formation and type III interferon infectivity restriction"
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2023-05-02"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Description",
+      "value" : "Here, we reconstituted bronchial epithelia from adult and child donors and show that SARS-CoV-2 infections spread fast, resulting in the formation and synchronized release of large clusters of infected cells and syncytia into the apical lumen, contributing to virus dissemination. Some epithelia, for the most part from children, revealed an intrinsic resistance to infection and virus spread. This infection control correlates with faster type III interferon secretion and can be transferred to permissive epithelia through exogenous interferon application. Child epithelia also showed a muted inflammatory response compared with adult, suggesting a specific and age-adapted epithelial response to SARS-CoV-2 infection that may explain why children are less susceptible to severe COVID-19."
+    }, {
+      "name" : "License",
+      "value" : "CC0"
+    }, {
+      "name" : "Keyword",
+      "value" : "SARS-CoV-2"
+    }, {
+      "name" : "Keyword",
+      "value" : "bronchial epithelia"
+    }, {
+      "name" : "Keyword",
+      "value" : "infection"
+    }, {
+      "name" : "Keyword",
+      "value" : "syncytia"
+    }, {
+      "name" : "Keyword",
+      "value" : "children"
+    }, {
+      "name" : "Keyword",
+      "value" : "interferon"
+    }, {
+      "name" : "Acknowledgements",
+      "value" : "Light and electron imaging was performed at the Bordeaux Imaging Center (BIC), member of the FranceBioImaging national infrastructure (grant ANR-10-INBS-04) and of the French BioImaging Node of Euro-BioImaging ERIC (https://ror.org/05d78xc36). We thank the BIC for relentless support during the lockdown"
+    }, {
+      "name" : "Funding statement",
+      "value" : "M.-L.B. was supported by the Région Nouvelle Aquitaine and UBReact, Bordeaux University. I.K. receives funding from EU Horizon 2020 under grant agreement no. 101046203 (BY-COVID)."
+    } ],
+    "subsections" : [ {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Nicolas Landrein"
+      }, {
+        "name" : "Email",
+        "value" : "nicolas.landrein@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "submitter"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0001-8875-4242"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Harald Wodrich"
+      }, {
+        "name" : "Email",
+        "value" : "harald.wodrich@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "principal investigator"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-4764-1708"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Guillaume Beucher"
+      }, {
+        "name" : "Email",
+        "value" : "guillaume.beucher@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "first author"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Thomas Trian"
+      }, {
+        "name" : "Email",
+        "value" : "thomas.trian@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "contributor"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-2567-4867"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Marie-Line Andreola"
+      }, {
+        "name" : "Email",
+        "value" : "marie-aline.andreola@u-bordeaux.fr"
+      }, {
+        "name" : "Role",
+        "value" : "contributor"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0001-9808-7391"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Isabel Kemmer"
+      }, {
+        "name" : "Email",
+        "value" : "isabel.kemmer@eurobioimaging.eu"
+      }, {
+        "name" : "Role",
+        "value" : "data steward"
+      }, {
+        "name" : "ORCID",
+        "value" : "0000-0002-8799-4671"
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "University of Bordeaux"
+      }, {
+        "name" : "RORID",
+        "value" : "https://ror.org/057qpr032"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Euro-BioImaging ERIC"
+      }, {
+        "name" : "RORID",
+        "value" : "https://ror.org/05d78xc36"
+      } ]
+    }, {
+      "type" : "Publication",
+      "attributes" : [ {
+        "name" : "Title",
+        "value" : "Bronchial epithelia from adults and children: SARS-CoV-2 spread via syncytia formation and type III interferon infectivity restriction"
+      }, {
+        "name" : "Year",
+        "value" : "2022"
+      }, {
+        "name" : "Authors",
+        "value" : "Guillaume Beucher, Marie-Lise Blondot, Alexis Celle, Noémie Pied, Patricia Recordon-Pinson, Pauline Esteves, Muriel Faure, Mathieu Métifiot, Sabrina Lacomme, Denis Dacheux, Derrick R. Robinson, Gernot Längst, Fabien Beaufils, Marie-Edith Lafon, Patrick Berger, Marc Landry, Denis Malvy, Thomas Trian, Marie-Line Andreola, Harald Wodrich"
+      }, {
+        "name" : "DOI",
+        "value" : "10.1073/pnas.2202370119"
+      }, {
+        "name" : "PMC ID",
+        "value" : "PMC9651868"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "laboratoire d'excellence ParaFrap"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant ANR-11-LABX-0024"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Fondation Recherche Medicale (FRM)"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant DEQ20180339229"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Agence Nationale de la Recherche"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant ANR-CE14-0015-01, project ROSAE"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "Fondation de France"
+      }, {
+        "name" : "grant_id",
+        "value" : "project ANACONDA"
+      } ]
+    }, {
+      "type" : "Funding",
+      "attributes" : [ {
+        "name" : "Agency",
+        "value" : "France BioImaging"
+      }, {
+        "name" : "grant_id",
+        "value" : "grant ANR-10-INBS-04"
+      } ]
+    }, {
+      "accno" : "Study Component-1",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Infected Multiciliated Cells Form Syncytia with Basal Cells at the Apical Side of the BE"
+      }, {
+        "name" : "Description",
+        "value" : "we used human reconstituted bronchial epithelia (BE) to investigate the onset of infection and replication of SARS-CoV-2 with widefield and confocal microscopy. BE are an important tissue because subsequent infection of the bronchial tissue determines whether a SARS-CoV-2 infection results in severe or mild respiratory illness, by controlling the spread into the lower respiratory tract. These features differentiate our approach from similar studies using primary respiratory cells from either upper airway (nasal, tracheal)"
+      }, {
+        "name" : "File List",
+        "value" : "file_list_sc1.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Biosample-1-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "bronchial epithelia (BE)"
+        }, {
+          "name" : "Description",
+          "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "patient ID and patient age"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "infection with SARS-CoV-2"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "days after infection"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-1-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "homo sapiens"
+          }, {
+            "name" : "Common name",
+            "value" : "human"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid9606"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-1-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+        } ]
+      }, {
+        "accno" : "Image Acquisition-1-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "Leica inverted DMi6000 widefield microscope + Lumencor ligth source + Hamamatsu ORCA-Flash4.0 LT"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "fluorescence microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000246"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image Acquisition-1-2",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center) 405nm diode laser + white laser 470-670nm"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "diverse parameters; to be found inside the metadata of the .lif images"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-1-2",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000251"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-1-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "To quantify colocalisation between N positive cells (infected cells) and either cytokeratin 5 (Cytk5, basal cells), mucin 5A (goblet cells) or acetylated tubulin (multi ciliated cells) 10x magnification images or a 63x magnification images were acquired and processed for image analysis. Z-projections of different focal planes were generated and regions of interest (ROI) were designed to delimit the area of analysis. A threshold was then applied to the projection of both N positive cells and Cytk5 (or tubulin) positive cells in order to obtain respective masks. Masks were analyzed using the “colocalization” function in ImageJ to calculate the number of double positive cells (N and Cytk5). Obtained values were normalized by either total number of N or total number of Cytk5 (or tubulin or mucin) positive cells to calculate the percentage of basal cells (or ciliated/goblet cells) that are infected."
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-2",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Electron microscopy of BE after SARS-CoV-2 infection"
+      }, {
+        "name" : "Description",
+        "value" : "Study of the ultra structure of the BE during an SARS-CoV-2 infection."
+      }, {
+        "name" : "File List",
+        "value" : "file_list_sc2.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Biosample-2-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "bronchial epithelia (BE)"
+        }, {
+          "name" : "Description",
+          "value" : "BE culture from patient-derived material"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "patient ID and patient age"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "infection with SARS-CoV-2"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "days after infection"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-2-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "homo sapiens"
+          }, {
+            "name" : "Common name",
+            "value" : "human"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid9606"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-2-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "BE were first washed in physiological serum and then fixed with 2.5% (v/v) glutaraldehyde and 2% (v/v) paraformaldehyde in 0.1M phosphate buffer (pH 7.4) during 2h minimum at room temperature (RT). Then samples were washed in 0.1M phosphate buffer and post-fixed in 1% (v/v) osmium tetroxide in phosphate buffer 0.1 M during 2h, in the dark, at RT, then washing in water and dehydrated through a series of graded ethanol and embedded in a mixture of pure ethanol and epoxy resin (Epon 812; Delta Microscopy, Toulouse, France) 50/50 (v/v) during 2 hours and then in 100% resin overnight at RT. The polymerization of the resin was carried out over a period between 24-48 hours at 60°C. Samples were then sectioned using a diamond knife (Diatome, Biel-Bienne,Switzerland) on an ultramicrotome (EM UCT, Leica Microsystems, Vienna, Austria). Ultrathin sections (70 nm) were picked up on copper grids and then stained with uranyless and lead citrate."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery. BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+        } ]
+      }, {
+        "accno" : "Image Acquisition-2-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "H7650, Hitachi Transmission Electron Microscope"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "80 kV"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-2-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "transmission electron microscopy (TEM)"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000258"
+          } ]
+        } ]
+      } ]
+    }, {
+      "accno" : "Study Component-3",
+      "type" : "Study Component",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "An Accelerated Type III IFN Response Protects BE from SARSCoV-2 Infection"
+      }, {
+        "name" : "Description",
+        "value" : "We study the effect of Type III IFN by knocking out the IFN (CRISPR/Cas9) and by treating the BE with Type III IFN"
+      }, {
+        "name" : "File List",
+        "value" : "file_list_sc3.json"
+      } ],
+      "subsections" : [ {
+        "accno" : "Biosample-3-1",
+        "type" : "Biosample",
+        "attributes" : [ {
+          "name" : "Biological entity",
+          "value" : "bronchial epithelia (BE)"
+        }, {
+          "name" : "Description",
+          "value" : "BE culture from patient-derived material, stained with antibodies to discriminate different cell-types and cellular features"
+        }, {
+          "name" : "Intrinsic variable",
+          "value" : "patient ID; CRISPR-knockout of interferon-genes"
+        }, {
+          "name" : "Extrinsic variable",
+          "value" : "infection with SARS-CoV-2"
+        }, {
+          "name" : "Experimental variable",
+          "value" : "treatment with interferon (5 ng or 50 ng of IFN-λ)"
+        } ],
+        "subsections" : [ {
+          "accno" : "Organism-3-1",
+          "type" : "Organism",
+          "attributes" : [ {
+            "name" : "Scientific name",
+            "value" : "homo sapiens"
+          }, {
+            "name" : "Common name",
+            "value" : "human"
+          }, {
+            "name" : "NCBI taxon ID",
+            "value" : "NCBI:txid9606"
+          } ]
+        } ]
+      }, {
+        "accno" : "Specimen-3-1",
+        "type" : "Specimen",
+        "attributes" : [ {
+          "name" : "Sample Preparation Protocol",
+          "value" : "For antigen detection, BE were washed repeatedly with PBS to remove mucus then fixed with 4% paraformaldehyde for 30min using complete insert immersion. Epithelia were then washed in PBS and permeabilized with 0.5% TritonX-100 in PBS for 10min at room temperature and washed again before being blocked in IF buffer (PBS containing 10% SVF and 0.05% saponin) for 1h at room temperature. Primary antibody was diluted in IF buffer and applied to inserts for 1h at room temperature. Samples were washed three times under agitation with PBS and incubated with secondary antibody, fluorescently labeled phalloidin to stain the actin cytoskeleton and 2μg/mL of DAPI (4’,6-diamidino-2-phenylindole), diluted in IF buffer and incubated for 2h at room temperature. Insert were then washed extensively in PBS, desalted in H2O miliQ and rinsed in 100% Ethanol and air-dried. Membranes were then removed from inserts and mounted in DAKO Fluorescence Mounting Medium prior to microscopy analysis."
+        }, {
+          "name" : "Growth Protocol",
+          "value" : "The BE cell culture was established from bronchial brushings or lung resection performed between the third and fifth bronchial generation from patients undergoing elective surgery as previously described (38). BE explants were cultured using PneumaCult Ex medium (Stemcell) for expansion of basal epithelial cells at 37 °C in 5% CO2. Then, 105 basal cells were grown on cell culture inserts (Corning) within the air–liquid interface for 21 d using PneumaCult ALI medium (Stemcell). Such a culture allows the differentiation into pseudostratified mucociliary airway epithelia composed of ciliated cells, goblet cells, club cells, and basal cells. The complete differentiation was assessed by the capacity of cilia to beat and mucus production under a light microscope."
+        } ]
+      }, {
+        "accno" : "Image Acquisition-3-1",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "Leica inverted DMi6000 widefield microscope"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "between 10 and 200ms exposure time for each channel (647nm: 200ms;  594 nm: 400 ms; 488nm: 100 ms; 405nm: 10 ms)"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-3-1",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "fluorescence microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000246"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image Acquisition-3-2",
+        "type" : "Image Acquisition",
+        "attributes" : [ {
+          "name" : "Imaging Instrument",
+          "value" : "SP8 confocal microscope (Leica Microsystems at the Bordeaux Imaging Center)"
+        }, {
+          "name" : "Image Acquisition Parameters",
+          "value" : "diverse parameters; to be found inside the metadata of the .lif images"
+        } ],
+        "subsections" : [ {
+          "accno" : "Imaging Method-3-2",
+          "type" : "Imaging Method",
+          "attributes" : [ {
+            "name" : "Ontology Value",
+            "value" : "confocal microscopy"
+          }, {
+            "name" : "Ontology Name",
+            "value" : "FBbi"
+          }, {
+            "name" : "Ontology Term ID",
+            "value" : "FBbi:00000251"
+          } ]
+        } ]
+      }, {
+        "accno" : "Image-Analysis-3-1",
+        "type" : "Image Analysis",
+        "attributes" : [ {
+          "name" : "Image Analysis Overview",
+          "value" : "To determine the infected surface in presence or absence of IFN treatment the entire epithelial surface was recorded at 10x magnification for each condition, for each donor and processed for image analysis. Z-projections of the entire epithelium were generated and determined as ROI. The infected area or as normalized value to the non-treated controlinfected area was determined by the N-signal and calculated as percentage of infected area or as normalized value to the non-treated control"
+        } ]
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-test-data/bia_test_data/mock_objects/mock_image_acquisition_protocol.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_image_acquisition_protocol.py
@@ -32,9 +32,9 @@ def get_image_acquisition_protocol() -> List[bia_data_model.ImageAcquisitionProt
             "protocol_description": "Test image acquisition parameters 2",
             "imaging_instrument_description": "Test imaging instrument 2",
             "imaging_method_name": [
-                "fluorescence microscopy",
+                "fluorescence microscopy"
             ],
-            "fbbi_id": [],
+            "fbbi_id": ["FBbi:00000246"],
             "version": 0,
         },
     ]

--- a/bia-test-data/data/biad_v4/S-BIADTEST.json
+++ b/bia-test-data/data/biad_v4/S-BIADTEST.json
@@ -286,9 +286,20 @@
       }, {
         "name" : "Image acquisition parameters",
         "value" : "Test image acquisition parameters 2"
-      }, {
-        "name" : "Imaging method",
-        "value" : "fluorescence microscopy"
+      } ],
+      "subsections" : [ {
+        "accno" : "Imaging Method-7-1",
+        "type" : "Imaging Method",
+        "attributes" : [ {
+          "name" : "Ontology Value",
+          "value" : "fluorescence microscopy"
+        }, {
+          "name" : "Ontology Name",
+          "value" : "FBbi"
+        }, {
+          "name" : "Ontology Term ID",
+          "value" : "FBbi:00000246"
+        } ]
       } ]
     }, {
       "accno" : "Image analysis-5",


### PR DESCRIPTION
Prepared new jsons for ingest for 4 submissions that didn't have study component associations in the v4 template format, used option 2 in the related clickup ticket: https://app.clickup.com/t/86971jyhf

Las commit is for this ticket: https://app.clickup.com/t/86973tkc2 
