### PR TITLE
Multi platform builds

### DIFF
--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - master
+      - multi-platform-builds
   # pull_request: ~
 env:
   REGISTRY: ghcr.io
@@ -24,6 +25,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build image label
         id: image-label
         run: |

--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - master
-      - multi-platform-builds
   # pull_request: ~
 env:
   REGISTRY: ghcr.io

--- a/api/Readme.md
+++ b/api/Readme.md
@@ -104,6 +104,7 @@ docker buildx build --platform linux/amd64,linux/arm64 ../ -f Dockerfile -t bia-
 docker image tag bia-integrator-api ghcr.io/bioimage-archive/bia-integrator-api:$(make api.version)
 docker image push ghcr.io/bioimage-archive/bia-integrator-api:$(make api.version)
 ```
+Note that, if using docker desktop, you may need set it to use the containerd image store in order to perform multi-platform builds (https://docs.docker.com/build/building/multi-platform/). This is a setting under General (see: https://docs.docker.com/desktop/features/containerd/)
 
 ### Testing CI changes
 


### PR DESCRIPTION
Forgot to setup buildx propperly in  https://github.com/BioImage-Archive/bia-integrator/pull/277, so fixing that here.

Tested in branch push first: https://github.com/BioImage-Archive/bia-integrator/actions/runs/12672067042

Issue: https://app.clickup.com/t/8697cy0x7


On macs, using the docker image published to github is stopping immediately with error:

exec /root/.local/bin/poetry: exec format error\n 

this is because the build is being created for amd architecture and not arm (apple MX chips). Using multi-platform builds creates images with an index pointing to different manifests for each platform.  (local) docker can pick whichever works on that architecture.
