### PR TITLE
Make cli default to API and update README

### DIFF
--- a/bia-assign-image/README.md
+++ b/bia-assign-image/README.md
@@ -13,7 +13,7 @@ This package has 2 cli applications:
 The artefacts created are saved to the API by default. The current version of the cli allows saving
 to disk using the option `--persistence-mode disk` on either command. However, this will be deprecated in
 a future revision.
-## Assigning file refernce(s) to BIA Image objects
+## Assigning file reference(s) to BIA Image objects (in other words, create a BIA Image object for those file reference(s))
 To create a BIA Image of a set of file references run:
 ``` sh
 poetry run bia-assign-image assign <STUDY ACCESSION ID> <LIST OF FILE REFERENCE UUIDS>
@@ -28,13 +28,13 @@ To create an image representation from an image (without image conversion also o
 ``` sh
 $ poetry run bia-assign-image representations create <STUDY ACCESSION ID> <IMAGE UUID>
 ```
-E.g. Assuming the command above to create the BIA Image object has been run:
+E.g. Assuming the `assign` command above to create the BIA Image object has been run:
 ```sh
 $ poetry run bia-assign-image representations create S-BIAD1285 92fd093d-c8d2-4d89-ba28-9a9891cec73f
 ```
 
 By default this creates only the UPLOADED_BY_SUBMITTER image representation. Other image representations are
-created when during conversion of images. However, they could also be created by explicitly specifying a
+created during conversion of images. However, they could also be created by explicitly specifying a
 value for the `--reps-to-create` option. E.g. to create THUMBNAIL and STATIC_DISPLAY:
 ```sh
 $ poetry run bia-assign-image representations create --reps-to-create THUMBNAIL --reps-to-create STATIC_DISPLAY S-BIAD1285 92fd093d-c8d2-4d89-ba28-9a9891cec73f

--- a/bia-assign-image/README.md
+++ b/bia-assign-image/README.md
@@ -1,17 +1,18 @@
 ## Description
-This sub-package assigns file reference(s) to BIA Image objects and creates image representations but *not* actual images associated with the representations. It is in alpha mode!
+This sub-package assigns file reference(s) to BIA Image objects and creates image representations but *not* actual images associated with the representations.
 
 ## Setup
 
-1. Install the project using poetry.
-2. All artefacts are currently written to a hard coded dir ~/.cache/bia-integrator-data-sm
-3. Only `--persistence-mode disk`) works at the moment
+Install the project using poetry.
 
 ## Usage
 This package has 2 cli applications:
  * **assign**: used to assign file reference(s) to BIA Image objects
  * **representations**: used to create image representation objects (without conversion of images) from BIA Image objects.
 
+The artefacts created are saved to the API by default. The current version of the cli allows saving
+to disk using the option `--persistence-mode disk` on either command. However, this will be deprecated in
+a future revision.
 ## Assigning file refernce(s) to BIA Image objects
 To create a BIA Image of a set of file references run:
 ``` sh
@@ -21,39 +22,20 @@ E.g. Assuming the study S-BIAD1285 has been ingested:
 ```
 poetry run bia-assign-image assign S-BIAD1285 b768fb72-7ea2-4b80-b54d-bdf5ca280bfd
 ```
-By default this creates BIA Image objects under:
-~/.cache/bia-integrator-data-sm/
-  image/
-    image_1_uuid.json
-    ...
 
 ## Creating representations (without conversion of images)
-To create Image representations and experimentally captured images from file references (without image conversion also occuring), run:
+To create an image representation from an image (without image conversion also occuring), run:
 ``` sh
 $ poetry run bia-assign-image representations create <STUDY ACCESSION ID> <IMAGE UUID>
 ```
-E.g. Assuming the command above has been run:
+E.g. Assuming the command above to create the BIA Image object has been run:
 ```sh
 $ poetry run bia-assign-image representations create S-BIAD1285 92fd093d-c8d2-4d89-ba28-9a9891cec73f
 ```
 
-By default this create ImageRepresentation objects locally under:
-```sh
-  image_representation/
-    image_representation_1_uuid.json
-    image_representation_2_uuid.json
-    image_representation_3_uuid.json
-    ...
-```
-
-By default this creates 3 image representations (but not the actual images) for each of the file references.
-1. UPLOADED_BY_SUBMITTER
-2. INTERACTIVE_DISPLAY (ome_zarr)
-3. THUMBNAIL
-
-The STATIC_DISPLAY representation is not created by default because the BIA website only needs one static display per experimental imaging dataset. All interactive images need a thumbnail for the website, so they are usually created together.
-
-An option can be passed into the command to specify representations to create. E.g. to create only THUMBNAIL and STATIC_DISPLAY:
+By default this creates only the UPLOADED_BY_SUBMITTER image representation. Other image representations are
+created when during conversion of images. However, they could also be created by explicitly specifying a
+value for the `--reps-to-create` option. E.g. to create THUMBNAIL and STATIC_DISPLAY:
 ```sh
 $ poetry run bia-assign-image representations create --reps-to-create THUMBNAIL --reps-to-create STATIC_DISPLAY S-BIAD1285 92fd093d-c8d2-4d89-ba28-9a9891cec73f
 ```

--- a/bia-assign-image/bia_assign_image/cli.py
+++ b/bia-assign-image/bia_assign_image/cli.py
@@ -60,7 +60,7 @@ def assign(
     file_reference_uuids: Annotated[List[str], typer.Argument()],
     persistence_mode: Annotated[
         PersistenceMode, typer.Option(case_sensitive=False)
-    ] = PersistenceMode.disk,
+    ] = PersistenceMode.api,
     dryrun: Annotated[bool, typer.Option()] = False,
 ) -> None:
     persister = persistence_strategy_factory(
@@ -181,13 +181,11 @@ def create(
     image_uuid_list: Annotated[List[str], typer.Argument()],
     persistence_mode: Annotated[
         PersistenceMode, typer.Option(case_sensitive=False)
-    ] = PersistenceMode.disk,
+    ] = PersistenceMode.api,
     reps_to_create: Annotated[
         List[ImageRepresentationUseType], typer.Option(case_sensitive=False)
     ] = [
         ImageRepresentationUseType.UPLOADED_BY_SUBMITTER,
-        ImageRepresentationUseType.THUMBNAIL,
-        ImageRepresentationUseType.INTERACTIVE_DISPLAY,
     ],
     dryrun: Annotated[bool, typer.Option()] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,

--- a/bia-assign-image/tests/test_bia_assign_image_cli.py
+++ b/bia-assign-image/tests/test_bia_assign_image_cli.py
@@ -40,6 +40,8 @@ def test_bia_assign_cli(monkeypatch, tmpdir):
         cli.app,
         [
             "assign",
+            "--persistence-mode",
+            "disk",
             accession_id,
             file_reference_uuids,
         ],
@@ -65,26 +67,26 @@ def test_bia_create_image_representation_cli(monkeypatch, tmpdir):
             mock_image.get_image_with_one_file_reference(),
         ]
     )
-    persister.persist(
-        [
-            mock_image_representation.get_image_representation_of_interactive_display(),
-        ]
-    )
-    persister.persist(
-        [
-            mock_image_representation.get_image_representation_of_thumbnail(),
-        ]
-    )
-    persister.persist(
-        [
-            mock_image_representation.get_image_representation_of_uploaded_by_submitter(),
-        ]
-    )
-    persister.persist(
-        [
-            mock_image_representation.get_image_representation_of_static_display(),
-        ]
-    )
+    # persister.persist(
+    #    [
+    #        mock_image_representation.get_image_representation_of_interactive_display(),
+    #    ]
+    # )
+    # persister.persist(
+    #    [
+    #        mock_image_representation.get_image_representation_of_thumbnail(),
+    #    ]
+    # )
+    # persister.persist(
+    #    [
+    #        mock_image_representation.get_image_representation_of_uploaded_by_submitter(),
+    #    ]
+    # )
+    # persister.persist(
+    #    [
+    #        mock_image_representation.get_image_representation_of_static_display(),
+    #    ]
+    # )
 
     image_uuid = mock_image.get_image_with_one_file_reference().uuid
     monkeypatch.setattr(cli.settings, "bia_data_dir", str(output_dir_base))
@@ -93,6 +95,8 @@ def test_bia_create_image_representation_cli(monkeypatch, tmpdir):
         [
             "representations",
             "create",
+            "--persistence-mode",
+            "disk",
             accession_id,
             str(image_uuid),
         ],
@@ -101,5 +105,15 @@ def test_bia_create_image_representation_cli(monkeypatch, tmpdir):
     assert result.exit_code == 0
     image_representations_path = Path(output_dir_base) / "image_representation"
     created = [p for p in image_representations_path.rglob("*.json")]
-    assert len(created) == 4
-    # TODO: Check actual results !!!
+    assert len(created) == 1
+
+    expected = (
+        mock_image_representation.get_image_representation_of_uploaded_by_submitter()
+    )
+    created = persister.fetch_by_uuid(
+        [
+            expected.uuid,
+        ],
+        type(expected),
+    )[0]
+    assert created == expected

--- a/bia-assign-image/tests/test_bia_assign_image_cli.py
+++ b/bia-assign-image/tests/test_bia_assign_image_cli.py
@@ -67,26 +67,6 @@ def test_bia_create_image_representation_cli(monkeypatch, tmpdir):
             mock_image.get_image_with_one_file_reference(),
         ]
     )
-    # persister.persist(
-    #    [
-    #        mock_image_representation.get_image_representation_of_interactive_display(),
-    #    ]
-    # )
-    # persister.persist(
-    #    [
-    #        mock_image_representation.get_image_representation_of_thumbnail(),
-    #    ]
-    # )
-    # persister.persist(
-    #    [
-    #        mock_image_representation.get_image_representation_of_uploaded_by_submitter(),
-    #    ]
-    # )
-    # persister.persist(
-    #    [
-    #        mock_image_representation.get_image_representation_of_static_display(),
-    #    ]
-    # )
 
     image_uuid = mock_image.get_image_with_one_file_reference().uuid
     monkeypatch.setattr(cli.settings, "bia_data_dir", str(output_dir_base))


### PR DESCRIPTION
The README was not congruent with the last set of changes, and this PR is related to the [clickup ticket](https://app.clickup.com/t/86973eygc) to update it. The following were also modified in light of team discussions:
* Make CLI commands default to use API
* Make `represenations create` command default to creating just the `UPLOADED_BY_SUBMITTER` representation