### PR TITLE
updated text expectations after pydantic version bump

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -71,7 +71,7 @@ def get_contributor_dict(
             ],
             "rorid": "None",
             "address": "None",
-            "website": AnyUrl("https://www.none.com"),
+            "website": "https://www.none.com/",
             "orcid": "None",
         }
     return contributor_dict
@@ -87,7 +87,7 @@ def get_affiliation_dict(
         affiliation |= {
             "rorid": "None",
             "address": "None",
-            "website": AnyUrl("https://www.none.com"),
+            "website": "https://www.none.com/",
         }
     return affiliation
 


### PR DESCRIPTION
Looking at the change, this shouldn't have any real effect - the objects now get turned to 'strings that are valid urls' when dumped & gain a trailing / if they didn't have one and don't have a fragment identifer. 