### PR TITLE
added cli command that outputs uningested accession ids

### DIFF
--- a/bia-ingest/README.md
+++ b/bia-ingest/README.md
@@ -65,3 +65,13 @@ When ingest finishes a table of results is printed out. To also get this table w
 ```sh
 $ poetry run biaingest ingest S-BIAD1285 S-BIAD1385 -c --write-csv output_table.csv
 ```
+
+
+## Getting new Biostudies Studies
+
+run:
+```
+poetry run biaingest find new-biostudies-studies
+```
+
+which will create a file in the input_files/ directory of studies that are relevant to the current ingest process but are not yet ingested.

--- a/bia-ingest/bia_ingest/biostudies/api.py
+++ b/bia-ingest/bia_ingest/biostudies/api.py
@@ -172,6 +172,32 @@ class SubmissionTable(BaseModel):
     sections: Optional[List[str]] = None
 
 
+# Search data structures
+
+class SearchResult(BaseModel):
+    accession: str
+    type: str
+    title: str
+    author: str
+    links: int
+    files: int
+    release_date: str
+    views: int
+    isPublic: bool
+
+
+class SearchPage(BaseModel):
+    page: int
+    pageSize: int
+    totalHits: int
+    isTotalHitsExact: bool
+    sortBy: str
+    sortOrder: str
+    hits: List[SearchResult]
+    query: Optional[str]
+    facets: Optional[str]
+
+
 # API functions
 
 

--- a/bia-ingest/bia_ingest/biostudies/find_bia_studies.py
+++ b/bia-ingest/bia_ingest/biostudies/find_bia_studies.py
@@ -1,0 +1,100 @@
+import requests
+from bia_ingest.biostudies.api import SearchPage, SearchResult
+import pathlib
+from datetime import date
+import logging
+from typing import Optional
+
+logger = logging.getLogger("__main__." + __name__)
+
+
+def get_all_bia_studies(page_size: int) -> list[SearchResult]:
+    BIOSTUDIES_COLLECTION_SEARCH = "https://www.ebi.ac.uk/biostudies/api/v1/BioImages/search?pageSize={page_size}&page={page_number}"
+    headers = {
+        "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36"
+    }
+    url = BIOSTUDIES_COLLECTION_SEARCH.format(page_size=1, page_number=1)
+    total_hits = SearchPage.model_validate_json(
+        requests.get(url, headers=headers).content
+    ).totalHits
+
+    results = []
+    last_page = total_hits // page_size + 1
+    page_count = 1
+
+    while page_count <= last_page:
+
+        url = BIOSTUDIES_COLLECTION_SEARCH.format(
+            page_size=page_size, page_number=page_count
+        )
+
+        r = requests.get(url, headers=headers)
+        assert r.status_code == 200
+        search_page = SearchPage.model_validate_json(r.content)
+        for hit in search_page.hits:
+            results.append(hit)
+        page_count += 1
+    return results
+
+
+def studies_by_source(
+    list_of_search_results: list[SearchResult],
+) -> dict[str, list[SearchResult]]:
+    EMPIAR_studies = []
+    BIAD_studies = []
+    BSST_studies = []
+    SJCBD_studies = []
+    other_studies = []
+
+    for result in list_of_search_results:
+        accession_id: str = result.accession
+        if accession_id.startswith("EMPIAR"):
+            EMPIAR_studies.append(result)
+        elif accession_id.startswith("S-BIAD"):
+            BIAD_studies.append(result)
+        elif accession_id.startswith("S-BSST"):
+            BSST_studies.append(result)
+        elif accession_id.startswith("S-JCBD"):
+            SJCBD_studies.append(result)
+        else:
+            other_studies.append(result)
+
+    return {
+        "EMPIAR": EMPIAR_studies,
+        "BIAD": BIAD_studies,
+        "BSST": BSST_studies,
+        "SJCBD": SJCBD_studies,
+        "other": other_studies,
+    }
+
+
+def get_processed_studies() -> list[str]:
+    with open(
+        pathlib.Path(__file__).parents[2] / "input_files" / "ingested_submissions", "r"
+    ) as f:
+        acc_ids = f.readlines()
+    return [acc_id.strip("\n") for acc_id in acc_ids]
+
+
+def find_unprocessed_studies(output_file: Optional[pathlib.Path]):
+
+    page_size = 100
+    imaging_studies = get_all_bia_studies(page_size)
+    grouped_studies = studies_by_source(imaging_studies)
+    studies_of_interest = (
+        grouped_studies["BIAD"] + grouped_studies["BSST"] + grouped_studies["other"]
+    )
+    acc_id_of_interest = [result.accession for result in studies_of_interest]
+    processed_acc_ids = get_processed_studies()
+    unprocessed_acc_ids = set(acc_id_of_interest) - set(processed_acc_ids)
+
+    if not output_file:
+        output_file = (
+            pathlib.Path(__file__).parents[2]
+            / "input_files"
+            / f"uningested_studies_of_interest_{str(date.today())}"
+        )
+
+    with open(output_file, "w") as f:
+        for id in unprocessed_acc_ids:
+            f.write(f"{id}\n")

--- a/bia-ingest/bia_ingest/biostudies/find_bia_studies.py
+++ b/bia-ingest/bia_ingest/biostudies/find_bia_studies.py
@@ -69,6 +69,7 @@ def studies_by_source(
 
 
 def get_processed_studies() -> list[str]:
+    # TODO: use BIA API to get all studies & update settings class to use env values for testing
     with open(
         pathlib.Path(__file__).parents[2] / "input_files" / "ingested_submissions", "r"
     ) as f:

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -26,6 +26,7 @@ from bia_ingest.biostudies.process_submission_v4 import (
 from bia_ingest.biostudies.process_submission_default import (
     process_submission_default,
 )
+from bia_ingest.biostudies.find_bia_studies import (find_unprocessed_studies)
 
 import logging
 from rich import print
@@ -33,6 +34,8 @@ from rich.logging import RichHandler
 from .cli_logging import tabulate_ingestion_errors, write_table, IngestionResult
 
 app = typer.Typer()
+find = typer.Typer()
+app.add_typer(find, name="find")
 
 
 logging.basicConfig(
@@ -48,6 +51,13 @@ class ProcessFilelistMode(str, Enum):
     always = "always"
     ask = "ask"
     skip = "skip"
+
+
+@find.command("new-biostudies-studies")
+def find_new_studies(
+    output_file: Annotated[Optional[Path], typer.Option("--output_file", "-o")] = None
+):
+    find_unprocessed_studies(output_file)
 
 
 @app.command(help="Ingest from biostudies and echo json of bia_data_model.Study")

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -7,6 +7,7 @@ from bia_ingest.biostudies.api import Submission, SubmissionTable, requests
 from bia_test_data.mock_objects.mock_object_constants import accession_id
 from bia_ingest.cli_logging import IngestionResult
 from bia_test_data import bia_test_data_dir
+from bia_ingest.biostudies.api import SearchResult, SearchPage
 
 
 @pytest.fixture
@@ -43,3 +44,42 @@ def mock_request_get(monkeypatch):
         return return_value
 
     monkeypatch.setattr(requests, "get", _mock_request_get)
+
+
+@pytest.fixture
+def mock_search_result(monkeypatch):
+    """Requests.get mocked to read file from disk"""
+
+    mock_result = {
+        "page": 1,
+        "pageSize": 1,
+        "totalHits": 1,
+        "isTotalHitsExact": True,
+        "sortBy": "release_date",
+        "sortOrder": "descending",
+        "hits": [
+            {
+                "accession": "S-BIADTEST",
+                "type": "study",
+                "title": "Test Title",
+                "author": "Test Authors",
+                "links": 0,
+                "files": 0,
+                "release_date": "2025-01-01",
+                "views": 0,
+                "isPublic": True,
+            }
+        ],
+        "query": None,
+        "facets": None,
+    }
+    search_result = SearchPage(**mock_result)
+
+    def _mock_search_result(url, headers) -> Dict[str, str]:
+
+        return_value = Mock()
+        return_value.status_code = 200
+        return_value.content = search_result.model_dump_json()
+        return return_value
+
+    monkeypatch.setattr(requests, "get", _mock_search_result)

--- a/bia-ingest/test/test_bia_ingest_cli.py
+++ b/bia-ingest/test/test_bia_ingest_cli.py
@@ -111,7 +111,7 @@ def test_cli_writes_expected_files(
             assert created_object == expected_object
 
 
-def test_cli_writes_expected_files(
+def test_cli_find_test_study(
     monkeypatch,
     tmp_path: Path,
     mock_search_result,

--- a/bia-ingest/test/test_bia_ingest_cli.py
+++ b/bia-ingest/test/test_bia_ingest_cli.py
@@ -109,3 +109,24 @@ def test_cli_writes_expected_files(
                 created_object_path.read_text()
             )
             assert created_object == expected_object
+
+
+def test_cli_writes_expected_files(
+    monkeypatch,
+    tmp_path: Path,
+    mock_search_result,
+    expected_objects,
+):
+
+    outfile = tmp_path.absolute() / "find_output"
+
+    result = runner.invoke(
+        cli.app,
+        ["find", "new-biostudies-studies", "-o", outfile],
+    )
+    assert result.exit_code == 0
+
+    with open(outfile, "r") as f:
+        lines = f.readlines()
+
+    assert lines == ["S-BIADTEST\n"]


### PR DESCRIPTION
ticket: https://app.clickup.com/t/8697na58z

Note this currently just uses the 'ingested_submissions' file as reference for what has been ingested. This should really use the API but i would want to update some code in the config.py & create clients slightly differently in order to make testing against an api easier. This seems like a separate ticket / would make the PR really big like the one for export, so splitting it up here.