### PR TITLE
Fix shared-model-tests back to original states

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -71,7 +71,7 @@ def get_contributor_dict(
             ],
             "rorid": "None",
             "address": "None",
-            "website": "https://www.none.com/",
+            "website": AnyUrl("https://www.none.com/"),
             "orcid": "None",
         }
     return contributor_dict
@@ -87,7 +87,7 @@ def get_affiliation_dict(
         affiliation |= {
             "rorid": "None",
             "address": "None",
-            "website": "https://www.none.com/",
+            "website": AnyUrl("https://www.none.com/"),
         }
     return affiliation
 


### PR DESCRIPTION
pydantic changed url serialization back in https://docs.pydantic.dev/latest/changelog/#v2106-2025-01-23, so returning tests to original state