### PR TITLE
added dependency based ordering to add_objects_to_api for testing

### DIFF
--- a/bia-export/bia-study-metadata.json
+++ b/bia-export/bia-study-metadata.json
@@ -1,0 +1,448 @@
+{
+    "S-BIAD1388": {
+        "uuid": "bc04a972-696b-4829-92e5-be9041ff2e0f",
+        "version": 0,
+        "model": {
+            "type_name": "Study",
+            "version": 2
+        },
+        "attribute": [
+            {
+                "provenance": "bia_ingest",
+                "name": "biostudies json/pagetab entry",
+                "value": {
+                    "json": "https://www.ebi.ac.uk/biostudies/files/S-BIAD1388/S-BIAD1388.json",
+                    "pagetab": "https://www.ebi.ac.uk/biostudies/files/S-BIAD1388/S-BIAD1388.tsv"
+                }
+            }
+        ],
+        "accession_id": "S-BIAD1388",
+        "licence": "CC_BY_4.0",
+        "author": [
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0001-7755-6283",
+                "display_name": "Aziza Elmesmari",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "University of Glasgow"
+                    }
+                ],
+                "contact_email": "aziza.elmesmari@glasgow.ac.uk",
+                "role": null
+            }
+        ],
+        "title": "Distinct tissue-niche localization and function of synovial tissue myeloid DC subsets in health, and in active and remission Rheumatoid Arthritis \n\n",
+        "release_date": "2024-12-02",
+        "description": "immunofluorescent staining in Synovial tissue  of  Healthy, active  Rheumatoid arthritis and and Rheumatoid arthritis in remission. \n",
+        "keyword": [
+            "CD68",
+            "CLEC10A",
+            "AXL",
+            "CD1c",
+            "LAMP3",
+            "Synovial tissue ",
+            "Human"
+        ],
+        "acknowledgement": "",
+        "see_also": [],
+        "related_publication": [],
+        "grant": [],
+        "funding_statement": "",
+        "dataset": [
+            {
+                "title_id": "Synovium Tissues ",
+                "uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                "version": 1,
+                "model": {
+                    "type_name": "Dataset",
+                    "version": 1
+                },
+                "attribute": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "associations",
+                        "value": {
+                            "associations": [
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Healthy synovial tissue",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD68 & CLEC10A"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of Active rheumatoid arthritis",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD68 & CLEC10A"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of rheumatoid arthritis in remission",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD68 & CLEC10A"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Healthy synovial tissue",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD1c & AXL"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of Active rheumatoid arthritis",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD1c & LAMP3"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of Active rheumatoid arthritis",
+                                    "image_acquisition": "CosMx",
+                                    "specimen": "CosMx staining"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "image_acquisition_protocol_uuid",
+                        "value": {
+                            "image_acquisition_protocol_uuid": [
+                                "3adb7c29-4c3f-4475-9731-5a79a993c398",
+                                "3d4b245e-a629-42e0-a101-853663511f82"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "specimen_imaging_preparation_protocol_uuid",
+                        "value": {
+                            "specimen_imaging_preparation_protocol_uuid": [
+                                "ebc9e74f-241d-4e0d-9a1d-43d9b485d3d0",
+                                "e1bd3be7-4bde-464d-abdf-f4081d65e1af",
+                                "be32ebed-8815-4005-9c60-0ae210adfc66",
+                                "493173e7-c584-49ae-a223-a0ff801f2089"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "bio_sample_uuid",
+                        "value": {
+                            "bio_sample_uuid": [
+                                "65c35fed-f997-4e6d-8724-d2d5180a1e96",
+                                "557ef897-1036-4884-8bfb-081be2096a6e",
+                                "190a45ce-3932-4fdf-803d-a8a1e21986aa"
+                            ]
+                        }
+                    }
+                ],
+                "description": "immunofluorescent staining in Synovial tissue  of  Healthy, active  Rheumatoid arthritis and and Rheumatoid arthritis in remission. ",
+                "analysis_method": [],
+                "correlation_method": [],
+                "example_image_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD1388/2563e244-377d-4d80-b833-868a59dfb903/8a3e9dfb-9406-48df-90e9-2d0872050352.png"
+                ],
+                "submitted_in_study_uuid": "bc04a972-696b-4829-92e5-be9041ff2e0f",
+                "acquisition_process": [
+                    {
+                        "default_open": true,
+                        "title_id": "Confocal Microscopy ",
+                        "uuid": "3adb7c29-4c3f-4475-9731-5a79a993c398",
+                        "version": 0,
+                        "model": {
+                            "type_name": "ImageAcquisitionProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "CD68 (red) & CLEC10A ( Green)\nCD1c (Green) & LAMP3 (Red)\nCD1c (Green ) & AXL (Red)\n",
+                        "imaging_instrument_description": "Zeiss LSM 880 confocal microscope, using either a water immersion LD C-Apochromat \u00d740/aperture1aperture1.3, or an oil immersion Plan-Apochromat \u00d763/1.4 objectives, and images acquired using Zen Black software (Zeiss). ",
+                        "fbbi_id": [],
+                        "imaging_method_name": [
+                            "confocal microscopy"
+                        ]
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CosMx",
+                        "uuid": "3d4b245e-a629-42e0-a101-853663511f82",
+                        "version": 0,
+                        "model": {
+                            "type_name": "ImageAcquisitionProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "membrane 488nm\npanCK 532nm\nCD45 594nm \nCD3 647nm \nDAPI UV",
+                        "imaging_instrument_description": "CosMx Spatial Molecular Imager",
+                        "fbbi_id": [],
+                        "imaging_method_name": [
+                            "single cell",
+                            "spatial transcriptomic"
+                        ]
+                    }
+                ],
+                "specimen_imaging_preparation_protocol": [
+                    {
+                        "default_open": true,
+                        "title_id": "CD68 & CLEC10A",
+                        "uuid": "ebc9e74f-241d-4e0d-9a1d-43d9b485d3d0",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "Formalin-fixed paraffin-embedded 5\u03bcm-thick synovial tissue sections were stained with antibodies directed against markers  CD68 (Red) or CLEC10A (Green) or in combination, or with appropriate isotope control antibodies following previously published protocol.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CD1c & AXL",
+                        "uuid": "e1bd3be7-4bde-464d-abdf-f4081d65e1af",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "Formalin-fixed paraffin-embedded 5\u03bcm-thick synovial tissue sections were stained with antibodies directed against markers  AXL (Red) or CD1c (Green) or in combination, or with appropriate isotope control antibodies following previously published protocol.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CD1c & LAMP3",
+                        "uuid": "be32ebed-8815-4005-9c60-0ae210adfc66",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "Formalin-fixed paraffin-embedded 5\u03bcm-thick synovial tissue sections were stained with antibodies directed against markers  LAMP3 (Red) or CD1c (Green) or in combination, or with appropriate isotope control antibodies following previously published protocol.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CosMx staining",
+                        "uuid": "493173e7-c584-49ae-a223-a0ff801f2089",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "We used the Nanostring CosMx Spatial Molecular Imaging platform to measure expression of 960 genes discriminating transcriptional profiles and spatial localization of 127,199 cells (69 fields-of-view (FOV)) in paraffin-embedded synovial biopsies from 3 active naive to treatment and 3 RA patients in sustained clinical and imaging remission (~11 FOV per donor). Slides were stained with DAPI, CD45, CD3, PanCK, CD298/b2m (membrane)",
+                        "signal_channel_information": []
+                    }
+                ],
+                "biological_entity": [
+                    {
+                        "default_open": true,
+                        "title_id": "Healthy synovial tissue",
+                        "uuid": "65c35fed-f997-4e6d-8724-d2d5180a1e96",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 3
+                        },
+                        "attribute": [],
+                        "organism_classification": [
+                            {
+                                "attribute": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Synovial tissue of Healthy donor",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "Synovial tissue of Active rheumatoid arthritis",
+                        "uuid": "557ef897-1036-4884-8bfb-081be2096a6e",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 3
+                        },
+                        "attribute": [],
+                        "organism_classification": [
+                            {
+                                "attribute": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Synovial tissue of Active rheumatoid arthritis",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "Synovial tissue of rheumatoid arthritis in remission",
+                        "uuid": "190a45ce-3932-4fdf-803d-a8a1e21986aa",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 3
+                        },
+                        "attribute": [],
+                        "organism_classification": [
+                            {
+                                "attribute": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Synovial tissue of rheumatoid arthritis in remission",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    }
+                ],
+                "annotation_process": [],
+                "other_creation_process": [],
+                "image": [
+                    {
+                        "uuid": "2563e244-377d-4d80-b833-868a59dfb903",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_0ebb55bf-47d6-40f8-9b63-52cd78efadf5",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "3cd04676-5070-4f2e-a9c1-744ad201eae3",
+                        "original_file_reference_uuid": [
+                            "0ebb55bf-47d6-40f8-9b63-52cd78efadf5"
+                        ]
+                    },
+                    {
+                        "uuid": "4371de21-efa4-4ae8-b050-a41c8d2e4348",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_69fa8889-8e08-429a-bebc-1ddf5ca14145",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "d2b21a24-f1e6-4d47-9f30-0d230bc0e9fe",
+                        "original_file_reference_uuid": [
+                            "69fa8889-8e08-429a-bebc-1ddf5ca14145"
+                        ]
+                    },
+                    {
+                        "uuid": "83fa4235-6e69-45d6-990e-6e640940d577",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_66b555b6-4e90-4b0e-a8c4-099668aead3d",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "0e87e3bd-e674-4792-93c6-baae3d155533",
+                        "original_file_reference_uuid": [
+                            "66b555b6-4e90-4b0e-a8c4-099668aead3d"
+                        ]
+                    },
+                    {
+                        "uuid": "a7fd5a9d-3e7d-4362-95b2-72936756e033",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_2cd0c70d-b8fc-4766-acb5-254e3060456b",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "f29f2e0e-9cc7-45f9-98dd-a80cf733c6b6",
+                        "original_file_reference_uuid": [
+                            "2cd0c70d-b8fc-4766-acb5-254e3060456b"
+                        ]
+                    },
+                    {
+                        "uuid": "b2a60947-9989-409f-80b5-35badbee6900",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_2ef5eab0-b745-47bd-8257-83cf23c54487",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "2c4a3f34-0229-49f4-b707-020550dc86b0",
+                        "original_file_reference_uuid": [
+                            "2ef5eab0-b745-47bd-8257-83cf23c54487"
+                        ]
+                    }
+                ],
+                "file_count": 20,
+                "image_count": 5,
+                "file_type_aggregation": [
+                    ".tif"
+                ]
+            }
+        ]
+    }
+}

--- a/bia-export/bia_export/cli.py
+++ b/bia-export/bia_export/cli.py
@@ -210,7 +210,7 @@ def get_uuid_from_accession_id(accession_id: str) -> str:
     else:
         logger.error(f"Could not find Study: {accession_id} in API")
         raise RuntimeError(
-            "Could not find Study with accession id: {accession_id} in API"
+            f"Could not find Study with accession id: {accession_id} in API"
         )
 
 

--- a/bia-export/test.json
+++ b/bia-export/test.json
@@ -1,0 +1,448 @@
+{
+    "S-BIAD1388": {
+        "uuid": "bc04a972-696b-4829-92e5-be9041ff2e0f",
+        "version": 0,
+        "model": {
+            "type_name": "Study",
+            "version": 2
+        },
+        "attribute": [
+            {
+                "provenance": "bia_ingest",
+                "name": "biostudies json/pagetab entry",
+                "value": {
+                    "json": "https://www.ebi.ac.uk/biostudies/files/S-BIAD1388/S-BIAD1388.json",
+                    "pagetab": "https://www.ebi.ac.uk/biostudies/files/S-BIAD1388/S-BIAD1388.tsv"
+                }
+            }
+        ],
+        "accession_id": "S-BIAD1388",
+        "licence": "CC_BY_4.0",
+        "author": [
+            {
+                "rorid": null,
+                "address": null,
+                "website": null,
+                "orcid": "0000-0001-7755-6283",
+                "display_name": "Aziza Elmesmari",
+                "affiliation": [
+                    {
+                        "rorid": null,
+                        "address": null,
+                        "website": null,
+                        "display_name": "University of Glasgow"
+                    }
+                ],
+                "contact_email": "aziza.elmesmari@glasgow.ac.uk",
+                "role": null
+            }
+        ],
+        "title": "Distinct tissue-niche localization and function of synovial tissue myeloid DC subsets in health, and in active and remission Rheumatoid Arthritis \n\n",
+        "release_date": "2024-12-02",
+        "description": "immunofluorescent staining in Synovial tissue  of  Healthy, active  Rheumatoid arthritis and and Rheumatoid arthritis in remission. \n",
+        "keyword": [
+            "CD68",
+            "CLEC10A",
+            "AXL",
+            "CD1c",
+            "LAMP3",
+            "Synovial tissue ",
+            "Human"
+        ],
+        "acknowledgement": "",
+        "see_also": [],
+        "related_publication": [],
+        "grant": [],
+        "funding_statement": "",
+        "dataset": [
+            {
+                "title_id": "Synovium Tissues ",
+                "uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                "version": 1,
+                "model": {
+                    "type_name": "Dataset",
+                    "version": 1
+                },
+                "attribute": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "associations",
+                        "value": {
+                            "associations": [
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Healthy synovial tissue",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD68 & CLEC10A"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of Active rheumatoid arthritis",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD68 & CLEC10A"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of rheumatoid arthritis in remission",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD68 & CLEC10A"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Healthy synovial tissue",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD1c & AXL"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of Active rheumatoid arthritis",
+                                    "image_acquisition": "Confocal Microscopy ",
+                                    "specimen": "CD1c & LAMP3"
+                                },
+                                {
+                                    "image_analysis": null,
+                                    "image_correlation": null,
+                                    "biosample": "Synovial tissue of Active rheumatoid arthritis",
+                                    "image_acquisition": "CosMx",
+                                    "specimen": "CosMx staining"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "image_acquisition_protocol_uuid",
+                        "value": {
+                            "image_acquisition_protocol_uuid": [
+                                "3adb7c29-4c3f-4475-9731-5a79a993c398",
+                                "3d4b245e-a629-42e0-a101-853663511f82"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "specimen_imaging_preparation_protocol_uuid",
+                        "value": {
+                            "specimen_imaging_preparation_protocol_uuid": [
+                                "ebc9e74f-241d-4e0d-9a1d-43d9b485d3d0",
+                                "e1bd3be7-4bde-464d-abdf-f4081d65e1af",
+                                "be32ebed-8815-4005-9c60-0ae210adfc66",
+                                "493173e7-c584-49ae-a223-a0ff801f2089"
+                            ]
+                        }
+                    },
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "bio_sample_uuid",
+                        "value": {
+                            "bio_sample_uuid": [
+                                "65c35fed-f997-4e6d-8724-d2d5180a1e96",
+                                "557ef897-1036-4884-8bfb-081be2096a6e",
+                                "190a45ce-3932-4fdf-803d-a8a1e21986aa"
+                            ]
+                        }
+                    }
+                ],
+                "description": "immunofluorescent staining in Synovial tissue  of  Healthy, active  Rheumatoid arthritis and and Rheumatoid arthritis in remission. ",
+                "analysis_method": [],
+                "correlation_method": [],
+                "example_image_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD1388/2563e244-377d-4d80-b833-868a59dfb903/8a3e9dfb-9406-48df-90e9-2d0872050352.png"
+                ],
+                "submitted_in_study_uuid": "bc04a972-696b-4829-92e5-be9041ff2e0f",
+                "acquisition_process": [
+                    {
+                        "default_open": true,
+                        "title_id": "Confocal Microscopy ",
+                        "uuid": "3adb7c29-4c3f-4475-9731-5a79a993c398",
+                        "version": 0,
+                        "model": {
+                            "type_name": "ImageAcquisitionProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "CD68 (red) & CLEC10A ( Green)\nCD1c (Green) & LAMP3 (Red)\nCD1c (Green ) & AXL (Red)\n",
+                        "imaging_instrument_description": "Zeiss LSM 880 confocal microscope, using either a water immersion LD C-Apochromat \u00d740/aperture1aperture1.3, or an oil immersion Plan-Apochromat \u00d763/1.4 objectives, and images acquired using Zen Black software (Zeiss). ",
+                        "fbbi_id": [],
+                        "imaging_method_name": [
+                            "confocal microscopy"
+                        ]
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CosMx",
+                        "uuid": "3d4b245e-a629-42e0-a101-853663511f82",
+                        "version": 0,
+                        "model": {
+                            "type_name": "ImageAcquisitionProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "membrane 488nm\npanCK 532nm\nCD45 594nm \nCD3 647nm \nDAPI UV",
+                        "imaging_instrument_description": "CosMx Spatial Molecular Imager",
+                        "fbbi_id": [],
+                        "imaging_method_name": [
+                            "single cell",
+                            "spatial transcriptomic"
+                        ]
+                    }
+                ],
+                "specimen_imaging_preparation_protocol": [
+                    {
+                        "default_open": true,
+                        "title_id": "CD68 & CLEC10A",
+                        "uuid": "ebc9e74f-241d-4e0d-9a1d-43d9b485d3d0",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "Formalin-fixed paraffin-embedded 5\u03bcm-thick synovial tissue sections were stained with antibodies directed against markers  CD68 (Red) or CLEC10A (Green) or in combination, or with appropriate isotope control antibodies following previously published protocol.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CD1c & AXL",
+                        "uuid": "e1bd3be7-4bde-464d-abdf-f4081d65e1af",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "Formalin-fixed paraffin-embedded 5\u03bcm-thick synovial tissue sections were stained with antibodies directed against markers  AXL (Red) or CD1c (Green) or in combination, or with appropriate isotope control antibodies following previously published protocol.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CD1c & LAMP3",
+                        "uuid": "be32ebed-8815-4005-9c60-0ae210adfc66",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "Formalin-fixed paraffin-embedded 5\u03bcm-thick synovial tissue sections were stained with antibodies directed against markers  LAMP3 (Red) or CD1c (Green) or in combination, or with appropriate isotope control antibodies following previously published protocol.",
+                        "signal_channel_information": []
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "CosMx staining",
+                        "uuid": "493173e7-c584-49ae-a223-a0ff801f2089",
+                        "version": 0,
+                        "model": {
+                            "type_name": "SpecimenImagingPreparationProtocol",
+                            "version": 2
+                        },
+                        "attribute": [],
+                        "protocol_description": "We used the Nanostring CosMx Spatial Molecular Imaging platform to measure expression of 960 genes discriminating transcriptional profiles and spatial localization of 127,199 cells (69 fields-of-view (FOV)) in paraffin-embedded synovial biopsies from 3 active naive to treatment and 3 RA patients in sustained clinical and imaging remission (~11 FOV per donor). Slides were stained with DAPI, CD45, CD3, PanCK, CD298/b2m (membrane)",
+                        "signal_channel_information": []
+                    }
+                ],
+                "biological_entity": [
+                    {
+                        "default_open": true,
+                        "title_id": "Healthy synovial tissue",
+                        "uuid": "65c35fed-f997-4e6d-8724-d2d5180a1e96",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 3
+                        },
+                        "attribute": [],
+                        "organism_classification": [
+                            {
+                                "attribute": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Synovial tissue of Healthy donor",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "Synovial tissue of Active rheumatoid arthritis",
+                        "uuid": "557ef897-1036-4884-8bfb-081be2096a6e",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 3
+                        },
+                        "attribute": [],
+                        "organism_classification": [
+                            {
+                                "attribute": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Synovial tissue of Active rheumatoid arthritis",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    },
+                    {
+                        "default_open": true,
+                        "title_id": "Synovial tissue of rheumatoid arthritis in remission",
+                        "uuid": "190a45ce-3932-4fdf-803d-a8a1e21986aa",
+                        "version": 0,
+                        "model": {
+                            "type_name": "BioSample",
+                            "version": 3
+                        },
+                        "attribute": [],
+                        "organism_classification": [
+                            {
+                                "attribute": [],
+                                "common_name": "human",
+                                "scientific_name": "Homo sapiens",
+                                "ncbi_id": null
+                            }
+                        ],
+                        "biological_entity_description": "Synovial tissue of rheumatoid arthritis in remission",
+                        "experimental_variable_description": [],
+                        "extrinsic_variable_description": [],
+                        "intrinsic_variable_description": [],
+                        "growth_protocol_uuid": null,
+                        "growth_protocol": null
+                    }
+                ],
+                "annotation_process": [],
+                "other_creation_process": [],
+                "image": [
+                    {
+                        "uuid": "2563e244-377d-4d80-b833-868a59dfb903",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_0ebb55bf-47d6-40f8-9b63-52cd78efadf5",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "3cd04676-5070-4f2e-a9c1-744ad201eae3",
+                        "original_file_reference_uuid": [
+                            "0ebb55bf-47d6-40f8-9b63-52cd78efadf5"
+                        ]
+                    },
+                    {
+                        "uuid": "4371de21-efa4-4ae8-b050-a41c8d2e4348",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_69fa8889-8e08-429a-bebc-1ddf5ca14145",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "d2b21a24-f1e6-4d47-9f30-0d230bc0e9fe",
+                        "original_file_reference_uuid": [
+                            "69fa8889-8e08-429a-bebc-1ddf5ca14145"
+                        ]
+                    },
+                    {
+                        "uuid": "83fa4235-6e69-45d6-990e-6e640940d577",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_66b555b6-4e90-4b0e-a8c4-099668aead3d",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "0e87e3bd-e674-4792-93c6-baae3d155533",
+                        "original_file_reference_uuid": [
+                            "66b555b6-4e90-4b0e-a8c4-099668aead3d"
+                        ]
+                    },
+                    {
+                        "uuid": "a7fd5a9d-3e7d-4362-95b2-72936756e033",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_2cd0c70d-b8fc-4766-acb5-254e3060456b",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "f29f2e0e-9cc7-45f9-98dd-a80cf733c6b6",
+                        "original_file_reference_uuid": [
+                            "2cd0c70d-b8fc-4766-acb5-254e3060456b"
+                        ]
+                    },
+                    {
+                        "uuid": "b2a60947-9989-409f-80b5-35badbee6900",
+                        "version": 0,
+                        "model": {
+                            "type_name": "Image",
+                            "version": 1
+                        },
+                        "attribute": [
+                            {
+                                "provenance": "bia_conversion",
+                                "name": "attributes_from_file_reference_2ef5eab0-b745-47bd-8257-83cf23c54487",
+                                "value": {
+                                    "attributes": {}
+                                }
+                            }
+                        ],
+                        "submission_dataset_uuid": "c5c0751b-f8a6-482b-92aa-d47628a00507",
+                        "creation_process_uuid": "2c4a3f34-0229-49f4-b707-020550dc86b0",
+                        "original_file_reference_uuid": [
+                            "2ef5eab0-b745-47bd-8257-83cf23c54487"
+                        ]
+                    }
+                ],
+                "file_count": 20,
+                "image_count": 5,
+                "file_type_aggregation": [
+                    ".tif"
+                ]
+            }
+        ]
+    }
+}

--- a/bia-export/test/conftest.py
+++ b/bia-export/test/conftest.py
@@ -18,7 +18,7 @@ def pytest_configure(config: pytest.Config):
 def data_in_api():
     setttings = Settings()
 
-    input_file_dir = Path(__file__).parent / "input_data"
+    input_file_dir = Path(__file__).parent / "input_data" / "**" / "*.json"
     file_path_list = glob(str(input_file_dir), recursive=True)
 
     object_list = []

--- a/bia-export/test/conftest.py
+++ b/bia-export/test/conftest.py
@@ -26,10 +26,6 @@ def data_in_api():
         if os.path.isfile(path):
             with open(path, "r") as object_file:
                 json_dict = json.load(object_file)
-                try:
-                    json_dict["model"]["type_name"]
-                except KeyError:
-                    continue
                 object_list.append(json_dict)
 
     add_objects_to_api(setttings.api_base_url, object_list)

--- a/bia-export/test/conftest.py
+++ b/bia-export/test/conftest.py
@@ -6,6 +6,7 @@ from bia_export.settings import Settings
 from pathlib import Path
 import json
 import os
+from glob import glob
 
 
 def pytest_configure(config: pytest.Config):
@@ -18,113 +19,17 @@ def data_in_api():
     setttings = Settings()
 
     input_file_dir = Path(__file__).parent / "input_data"
-
-    # Note order is *very* important due to uuid references needing to exist.
-    file_path_list = [
-        # Studies don't depend on anything
-        input_file_dir
-        / "study"
-        / "S-BIADTEST"
-        / "a2fdbd58-ee11-4cd9-bc6a-f3d3da7fff71.json",
-        # Datasets only depend on studies
-        input_file_dir
-        / "dataset"
-        / "S-BIADTEST"
-        / "47a4ab60-c76d-4424-bfaa-c2a024de720c.json",
-        input_file_dir
-        / "dataset"
-        / "S-BIADTEST"
-        / "850a1ca3-9681-4a8a-b625-477936fcb954.json",
-        input_file_dir
-        / "dataset"
-        / "S-BIADTEST"
-        / "21999a9f-6f16-45d4-91c9-ed46cbfe015c.json",
-        # File references only depend on Datasets
-        input_file_dir
-        / "file_reference"
-        / "S-BIADTEST"
-        / "4bb8c5a4-d39f-4d9e-a112-334e859a5c22.json",
-        input_file_dir
-        / "file_reference"
-        / "S-BIADTEST"
-        / "42cdf779-56c5-4a9e-9813-840f49071f79.json",
-        input_file_dir
-        / "file_reference"
-        / "S-BIADTEST"
-        / "ed89fa57-46a4-4ace-8d01-cc4504eb98e1.json",
-        input_file_dir
-        / "file_reference"
-        / "S-BIADTEST"
-        / "fe7b5598-d089-4624-bbd6-21e68a0fe506.json",
-        # Biosample can require protocol. Specimen Requires Biosample & specimen_imaging_preparation_protocol
-        input_file_dir
-        / "protocol"
-        / "S-BIADTEST"
-        / "a2ce3950-3b28-40b3-a6a5-23c4f7864912.json",
-        input_file_dir
-        / "bio_sample"
-        / "S-BIADTEST"
-        / "64a67727-4e7c-469a-91c4-6219ae072e99.json",
-        input_file_dir
-        / "bio_sample"
-        / "S-BIADTEST"
-        / "6950718c-4917-47a1-a807-11b874e80a23.json",
-        input_file_dir
-        / "specimen_imaging_preparation_protocol"
-        / "S-BIADTEST"
-        / "7199d730-29f1-4ad8-b599-e9089cbb2d7b.json",
-        input_file_dir
-        / "image_acquisition_protocol"
-        / "S-BIADTEST"
-        / "c2e44a1b-a43c-476e-8ddf-8587f4c955b3.json",
-        input_file_dir
-        / "specimen"
-        / "S-BIADTEST"
-        / "dcc18482-fa1a-468f-878f-c00f9cd46376.json",
-        input_file_dir
-        / "annotation_method"
-        / "S-BIADTEST"
-        / "ef019f5d-d3e0-4122-89ae-1d1d07d2830f.json",
-        # Creation processes can depend on images & images depend on creation processes, so this order is most important to get right.
-        input_file_dir
-        / "creation_process"
-        / "S-BIADTEST"
-        / "2447db96-dd23-44eb-ad47-1086c9be1cba.json",
-        input_file_dir
-        / "image"
-        / "S-BIADTEST"
-        / "e7322131-8e27-455d-b9fc-8add0719af70.json",
-        input_file_dir
-        / "creation_process"
-        / "S-BIADTEST"
-        / "8444ff28-e32b-4c6f-9677-d9ff597b0c29.json",
-        input_file_dir
-        / "image"
-        / "S-BIADTEST"
-        / "7966aa52-e3db-4ce3-801e-44c524b73ee3.json",
-        # Image representations just depend on Images
-        input_file_dir
-        / "image_representation"
-        / "S-BIADTEST"
-        / "8bfef1ff-18ec-4de7-8a10-2c19d552c150.json",
-        input_file_dir
-        / "image_representation"
-        / "S-BIADTEST"
-        / "570a177d-de5d-4bee-bbd1-fd2dcbec9e2a.json",
-        input_file_dir
-        / "image_representation"
-        / "S-BIADTEST"
-        / "677d5571-8ca3-4478-9e9f-cfeb3b012703.json",
-    ]
+    file_path_list = glob(str(input_file_dir), recursive=True)
 
     object_list = []
-    for file_path in file_path_list:
-        with open(file_path, "r") as object_file:
-            json_dict = json.load(object_file)
-            try:
-                json_dict["model"]["type_name"]
-            except KeyError:
-                continue
-            object_list.append(json_dict)
+    for path in file_path_list:
+        if os.path.isfile(path):
+            with open(path, "r") as object_file:
+                json_dict = json.load(object_file)
+                try:
+                    json_dict["model"]["type_name"]
+                except KeyError:
+                    continue
+                object_list.append(json_dict)
 
     add_objects_to_api(setttings.api_base_url, object_list)

--- a/bia-test-data/bia_test_data/data_to_api.py
+++ b/bia-test-data/bia_test_data/data_to_api.py
@@ -41,9 +41,9 @@ def get_object_creation_client(
     return private_api
 
 
-
-
-def calculate_dependency_chain_length(object_by_type: dict[str, dict[str, dict]]) -> dict[str, int]:
+def calculate_dependency_chain_length(
+    object_by_type: dict[str, dict[str, dict]]
+) -> dict[str, int]:
     # Images need their creation process to be added to the api before they can be added
     # Some creation processes need images to be added to the api before they can be added
     # dependecy_chain_length is the maximum number of times a change in type of object being added to the api has to occur before this object can be added to the api.
@@ -53,27 +53,49 @@ def calculate_dependency_chain_length(object_by_type: dict[str, dict[str, dict]]
 
     for uuid, creation_process in object_by_type["CreationProcess"].items():
         if uuid not in dependecy_chain_length.keys():
-            creation_process_dependency_chain_length(creation_process, dependecy_chain_length, object_by_type["Image"], object_by_type["CreationProcess"])
-        
+            creation_process_dependency_chain_length(
+                creation_process,
+                dependecy_chain_length,
+                object_by_type["Image"],
+                object_by_type["CreationProcess"],
+            )
+
     for uuid, image in object_by_type["Image"].items():
         if uuid not in dependecy_chain_length.keys():
-            image_dependency_chain_length(image, dependecy_chain_length, object_by_type["Image"], object_by_type["CreationProcess"])
+            image_dependency_chain_length(
+                image,
+                dependecy_chain_length,
+                object_by_type["Image"],
+                object_by_type["CreationProcess"],
+            )
     return dependecy_chain_length
 
 
-
-def creation_process_dependency_chain_length(creation_process: dict, dependency_chain_length: dict, images: dict[str, dict], creation_processes: dict[str, dict]) -> int:
-    uuid = creation_process['uuid']
+def creation_process_dependency_chain_length(
+    creation_process: dict,
+    dependency_chain_length: dict,
+    images: dict[str, dict],
+    creation_processes: dict[str, dict],
+) -> int:
+    uuid = creation_process["uuid"]
 
     # Creation processes either do not depend on any images (in which case dependency chain length is 0)
     # Or they need to be created after the last image they depend on gets created (so max(image dependency chain length) + 1)
     if uuid not in dependency_chain_length.keys():
-        if not creation_process['input_image_uuid'] or len(creation_process['input_image_uuid']) == 0:
+        if (
+            not creation_process["input_image_uuid"]
+            or len(creation_process["input_image_uuid"]) == 0
+        ):
             dependency_chain_length[uuid] = 0
         else:
             max_length = 0
-            for image_uuid in creation_process['input_image_uuid']:
-                img_chain_length = image_dependency_chain_length(images[image_uuid], dependency_chain_length, images, creation_processes)
+            for image_uuid in creation_process["input_image_uuid"]:
+                img_chain_length = image_dependency_chain_length(
+                    images[image_uuid],
+                    dependency_chain_length,
+                    images,
+                    creation_processes,
+                )
                 if img_chain_length > max_length:
                     max_length = img_chain_length
             dependency_chain_length[uuid] = max_length + 1
@@ -81,33 +103,48 @@ def creation_process_dependency_chain_length(creation_process: dict, dependency_
     return dependency_chain_length[uuid]
 
 
-def image_dependency_chain_length(image: dict, dependency_chain_length: dict, images: dict[str, dict], creation_processes: dict[str, dict]) -> int:
-    uuid = image['uuid']
+def image_dependency_chain_length(
+    image: dict,
+    dependency_chain_length: dict,
+    images: dict[str, dict],
+    creation_processes: dict[str, dict],
+) -> int:
+    uuid = image["uuid"]
 
     # Images depend on at least 1 creation process, so always have a dependency chain length of: creation process dependcy chain length + 1
     if uuid not in dependency_chain_length.keys():
         if image["creation_process_uuid"] in dependency_chain_length.keys():
-            dependency_chain_length[uuid] = dependency_chain_length[image["creation_process_uuid"]] + 1
+            dependency_chain_length[uuid] = (
+                dependency_chain_length[image["creation_process_uuid"]] + 1
+            )
         else:
             cp_uuid = image["creation_process_uuid"]
-            cp_chain_length = creation_process_dependency_chain_length(creation_processes[cp_uuid], dependency_chain_length, images, creation_processes)
+            cp_chain_length = creation_process_dependency_chain_length(
+                creation_processes[cp_uuid],
+                dependency_chain_length,
+                images,
+                creation_processes,
+            )
             dependency_chain_length[uuid] = cp_chain_length + 1
-    
+
     return dependency_chain_length[uuid]
 
 
-
-def add_simple_dependecy_object(object_type: str, object_by_type: dict[str, dict], ordered_object_list: list) -> None:
+def add_simple_dependecy_object(
+    object_type: str, object_by_type: dict[str, dict], ordered_object_list: list
+) -> None:
     if object_type in object_by_type.keys():
         for study in object_by_type[object_type].values():
             ordered_object_list.append(study)
 
 
-def add_creation_processes_and_images(object_by_type: dict[str,dict], ordered_object_list: list[dict]):
+def add_creation_processes_and_images(
+    object_by_type: dict[str, dict], ordered_object_list: list[dict]
+):
     if "CreationProcess" in object_by_type.keys() and "Image" in object_by_type.keys():
 
         dependecy_chain_length = calculate_dependency_chain_length(object_by_type)
-    
+
         uuid_order: dict[int, list[str]] = {}
         max_chain_length = 0
         for uuid, chain_length in dependecy_chain_length.items():
@@ -117,6 +154,7 @@ def add_creation_processes_and_images(object_by_type: dict[str,dict], ordered_ob
             if chain_length > max_chain_length:
                 max_chain_length = chain_length
 
+        chain_length = 0
         while chain_length <= max_chain_length:
             for uuid in uuid_order[chain_length]:
                 if uuid in object_by_type["CreationProcess"].keys():
@@ -126,11 +164,11 @@ def add_creation_processes_and_images(object_by_type: dict[str,dict], ordered_ob
             chain_length += 1
 
     elif "CreationProcess" in object_by_type.keys():
-        add_simple_dependecy_object("CreationProcess", object_by_type, ordered_object_list)
+        add_simple_dependecy_object(
+            "CreationProcess", object_by_type, ordered_object_list
+        )
     elif "Image" in object_by_type.keys():
         add_simple_dependecy_object("Image", object_by_type, ordered_object_list)
-
-
 
 
 def order_object_for_api(object_list: list[dict]):
@@ -141,7 +179,7 @@ def order_object_for_api(object_list: list[dict]):
         object_type = object["model"]["type_name"]
         if object_type not in object_by_type:
             object_by_type[object_type] = {}
-        object_by_type[object_type][object['uuid']] = object
+        object_by_type[object_type][object["uuid"]] = object
 
     ordered_object_list = []
 
@@ -150,16 +188,21 @@ def order_object_for_api(object_list: list[dict]):
     add_simple_dependecy_object("FileReference", object_by_type, ordered_object_list)
     add_simple_dependecy_object("Protocol", object_by_type, ordered_object_list)
     add_simple_dependecy_object("BioSample", object_by_type, ordered_object_list)
-    add_simple_dependecy_object("SpecimenImagingPreparationProtocol", object_by_type, ordered_object_list)
+    add_simple_dependecy_object(
+        "SpecimenImagingPreparationProtocol", object_by_type, ordered_object_list
+    )
     add_simple_dependecy_object("Specimen", object_by_type, ordered_object_list)
-    add_simple_dependecy_object("ImageAcquisitionProtocol", object_by_type, ordered_object_list)
+    add_simple_dependecy_object(
+        "ImageAcquisitionProtocol", object_by_type, ordered_object_list
+    )
     add_simple_dependecy_object("AnnotationMethod", object_by_type, ordered_object_list)
     # Only images and creation process can depend on one another
     add_creation_processes_and_images(object_by_type, ordered_object_list)
-    add_simple_dependecy_object("ImageRepresentation", object_by_type, ordered_object_list)
+    add_simple_dependecy_object(
+        "ImageRepresentation", object_by_type, ordered_object_list
+    )
 
     return ordered_object_list
-
 
 
 def add_objects_to_api(api_base_url, object_list: list[dict]):

--- a/bia-test-data/bia_test_data/data_to_api.py
+++ b/bia-test-data/bia_test_data/data_to_api.py
@@ -6,7 +6,7 @@ from pydantic.alias_generators import to_snake
 import bia_integrator_api.models as api_models
 
 
-def test_user_creation_details() -> dict:
+def test_user_creation_details() -> dict[str, str]:
     env_path = Path(__file__).parents[2] / "api" / ".env_compose"
     container_env = dotenv_values(env_path)
     user_creation_token = container_env.get("USER_CREATE_SECRET_TOKEN")
@@ -29,7 +29,7 @@ def get_object_creation_client(
             username=user_dict["email"], password=user_dict["password_plain"]
         )
     except exceptions.UnauthorizedException:
-        private_api.register_user(user_dict)
+        private_api.register_user(api_models.BodyRegisterUser(**user_dict))
         access_token = private_api.login_for_access_token(
             username=user_dict["email"], password=user_dict["password_plain"]
         )
@@ -41,12 +41,133 @@ def get_object_creation_client(
     return private_api
 
 
-def add_objects_to_api(api_base_url, object_list=list[dict]):
+
+
+def calculate_dependency_chain_length(object_by_type: dict[str, dict[str, dict]]) -> dict[str, int]:
+    # Images need their creation process to be added to the api before they can be added
+    # Some creation processes need images to be added to the api before they can be added
+    # dependecy_chain_length is the maximum number of times a change in type of object being added to the api has to occur before this object can be added to the api.
+    # E.g. with the chain:  IMG2 -> CP2, CP2 -> [IMG1], IMG1 -> CP1
+    # dependecy_chain_length = { CP1.uuid: 0, IMG1.uuid: 1, CP2.uuid: 2, IMG2.uuid: 3} (note images are always odd, creation processes are even inc. 0 )
+    dependecy_chain_length = {}
+
+    for uuid, creation_process in object_by_type["CreationProcess"].items():
+        if uuid not in dependecy_chain_length.keys():
+            creation_process_dependency_chain_length(creation_process, dependecy_chain_length, object_by_type["Image"], object_by_type["CreationProcess"])
+        
+    for uuid, image in object_by_type["Image"].items():
+        if uuid not in dependecy_chain_length.keys():
+            image_dependency_chain_length(image, dependecy_chain_length, object_by_type["Image"], object_by_type["CreationProcess"])
+    return dependecy_chain_length
+
+
+
+def creation_process_dependency_chain_length(creation_process: dict, dependency_chain_length: dict, images: dict[str, dict], creation_processes: dict[str, dict]) -> int:
+    uuid = creation_process['uuid']
+
+    # Creation processes either do not depend on any images (in which case dependency chain length is 0)
+    # Or they need to be created after the last image they depend on gets created (so max(image dependency chain length) + 1)
+    if uuid not in dependency_chain_length.keys():
+        if not creation_process['input_image_uuid'] or len(creation_process['input_image_uuid']) == 0:
+            dependency_chain_length[uuid] = 0
+        else:
+            max_length = 0
+            for image_uuid in creation_process['input_image_uuid']:
+                img_chain_length = image_dependency_chain_length(images[image_uuid], dependency_chain_length, images, creation_processes)
+                if img_chain_length > max_length:
+                    max_length = img_chain_length
+            dependency_chain_length[uuid] = max_length + 1
+
+    return dependency_chain_length[uuid]
+
+
+def image_dependency_chain_length(image: dict, dependency_chain_length: dict, images: dict[str, dict], creation_processes: dict[str, dict]) -> int:
+    uuid = image['uuid']
+
+    # Images depend on at least 1 creation process, so always have a dependency chain length of: creation process dependcy chain length + 1
+    if uuid not in dependency_chain_length.keys():
+        if image["creation_process_uuid"] in dependency_chain_length.keys():
+            dependency_chain_length[uuid] = dependency_chain_length[image["creation_process_uuid"]] + 1
+        else:
+            cp_uuid = image["creation_process_uuid"]
+            cp_chain_length = creation_process_dependency_chain_length(creation_processes[cp_uuid], dependency_chain_length, images, creation_processes)
+            dependency_chain_length[uuid] = cp_chain_length + 1
+    
+    return dependency_chain_length[uuid]
+
+
+
+def add_simple_dependecy_object(object_type: str, object_by_type: dict[str, dict], ordered_object_list: list) -> None:
+    if object_type in object_by_type.keys():
+        for study in object_by_type[object_type].values():
+            ordered_object_list.append(study)
+
+
+def add_creation_processes_and_images(object_by_type: dict[str,dict], ordered_object_list: list[dict]):
+    if "CreationProcess" in object_by_type.keys() and "Image" in object_by_type.keys():
+
+        dependecy_chain_length = calculate_dependency_chain_length(object_by_type)
+    
+        uuid_order: dict[int, list[str]] = {}
+        max_chain_length = 0
+        for uuid, chain_length in dependecy_chain_length.items():
+            if chain_length not in uuid_order.keys():
+                uuid_order[chain_length] = []
+            uuid_order[chain_length].append(uuid)
+            if chain_length > max_chain_length:
+                max_chain_length = chain_length
+
+        while chain_length <= max_chain_length:
+            for uuid in uuid_order[chain_length]:
+                if uuid in object_by_type["CreationProcess"].keys():
+                    ordered_object_list.append(object_by_type["CreationProcess"][uuid])
+                else:
+                    ordered_object_list.append(object_by_type["Image"][uuid])
+            chain_length += 1
+
+    elif "CreationProcess" in object_by_type.keys():
+        add_simple_dependecy_object("CreationProcess", object_by_type, ordered_object_list)
+    elif "Image" in object_by_type.keys():
+        add_simple_dependecy_object("Image", object_by_type, ordered_object_list)
+
+
+
+
+def order_object_for_api(object_list: list[dict]):
+
+    # Dictionary of form: { "object type": { "objecy_uuid": { ...object data... } } }
+    object_by_type: dict[str, dict] = {}
+    for object in object_list:
+        object_type = object["model"]["type_name"]
+        if object_type not in object_by_type:
+            object_by_type[object_type] = {}
+        object_by_type[object_type][object['uuid']] = object
+
+    ordered_object_list = []
+
+    add_simple_dependecy_object("Study", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("Dataset", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("FileReference", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("Protocol", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("BioSample", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("SpecimenImagingPreparationProtocol", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("Specimen", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("ImageAcquisitionProtocol", object_by_type, ordered_object_list)
+    add_simple_dependecy_object("AnnotationMethod", object_by_type, ordered_object_list)
+    # Only images and creation process can depend on one another
+    add_creation_processes_and_images(object_by_type, ordered_object_list)
+    add_simple_dependecy_object("ImageRepresentation", object_by_type, ordered_object_list)
+
+    return ordered_object_list
+
+
+
+def add_objects_to_api(api_base_url, object_list: list[dict]):
     private_client = get_object_creation_client(api_base_url)
 
-    # TODO: write clever function for ordering objects correctly by type & dependencies: 
+    ordered_object_list = order_object_for_api(object_list)
 
-    for bia_object_dict in object_list:
+    for bia_object_dict in ordered_object_list:
         bia_object_type = bia_object_dict["model"]["type_name"]
         post_method_name = "post_" + to_snake(bia_object_type)
         post_function = private_client.__getattribute__(post_method_name)

--- a/bia-test-data/bia_test_data/data_to_api.py
+++ b/bia-test-data/bia_test_data/data_to_api.py
@@ -44,11 +44,13 @@ def get_object_creation_client(
 def calculate_dependency_chain_length(
     object_by_type: dict[str, dict[str, dict]]
 ) -> dict[str, int]:
-    # Images need their creation process to be added to the api before they can be added
-    # Some creation processes need images to be added to the api before they can be added
-    # dependecy_chain_length is the maximum number of times a change in type of object being added to the api has to occur before this object can be added to the api.
-    # E.g. with the chain:  IMG2 -> CP2, CP2 -> [IMG1], IMG1 -> CP1
-    # dependecy_chain_length = { CP1.uuid: 0, IMG1.uuid: 1, CP2.uuid: 2, IMG2.uuid: 3} (note images are always odd, creation processes are even inc. 0 )
+    """
+    Images need their creation process to be added to the api before they can be added
+    Some creation processes need images to be added to the api before they can be added
+    dependecy_chain_length is the maximum number of times a change in type of object being added to the api has to occur before this object can be added to the api.
+    E.g. with the chain:  IMG2 -> CP2, CP2 -> [IMG1], IMG1 -> CP1
+    dependecy_chain_length = { CP1.uuid: 0, IMG1.uuid: 1, CP2.uuid: 2, IMG2.uuid: 3} (note images are always odd, creation processes are even inc. 0 )
+    """
     dependecy_chain_length = {}
 
     for uuid, creation_process in object_by_type["CreationProcess"].items():


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/8697fg88f

Functionality allows us to just throw a bunch of files at the api (e.g. during test setup) and they will get created in the correct order.

Errors will be thrown if something is dodgy with the chain of dependencies