### PR TITLE
Process default file lists + tests

### DIFF
--- a/bia-ingest/bia_ingest/biostudies/biostudies_default/default_dataset.py
+++ b/bia-ingest/bia_ingest/biostudies/biostudies_default/default_dataset.py
@@ -46,8 +46,6 @@ def get_dataset_overview(
     study_attr_dict = attributes_to_dict(study_section.attributes)
     submission_attr_dict = attributes_to_dict(submission.attributes)
 
-    # if there is more than one study or if there is not study title, 
-    # take title from submission
     if (num_studies == 1) & ("Title" in study_attr_dict):
         study_title = study_attr_dict["Title"]
     elif "Title" in submission_attr_dict:

--- a/bia-ingest/bia_ingest/biostudies/biostudies_default/default_file_reference.py
+++ b/bia-ingest/bia_ingest/biostudies/biostudies_default/default_file_reference.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from bia_ingest.persistence_strategy import PersistenceStrategy
 from bia_ingest.biostudies.submission_parsing_utils import (
-    find_files_and_file_lists_in_submission, 
+    find_files_and_file_lists_in_default_submission, 
     attributes_to_dict,
 )
 from bia_ingest.bia_object_creation_utils import (
@@ -34,7 +34,7 @@ def get_file_reference_for_default_template_datasets(
     Assumed one dataset per submission, currently.
     """
     
-    all_files = find_files_and_file_lists_in_submission(submission)
+    all_files = find_files_and_file_lists_in_default_submission(submission)
     if not all_files:
         logger.warning("No files were found.")
         result_summary[submission.accno].__setattr__(

--- a/bia-ingest/bia_ingest/biostudies/biostudies_default/default_file_reference.py
+++ b/bia-ingest/bia_ingest/biostudies/biostudies_default/default_file_reference.py
@@ -34,7 +34,7 @@ def get_file_reference_for_default_template_datasets(
     Assumed one dataset per submission, currently.
     """
     
-    all_files = find_files_and_file_lists_in_default_submission(submission)
+    all_files = find_files_and_file_lists_in_default_submission(submission, result_summary)
     if not all_files:
         logger.warning("No files were found.")
         result_summary[submission.accno].__setattr__(

--- a/bia-ingest/bia_ingest/biostudies/submission_parsing_utils.py
+++ b/bia-ingest/bia_ingest/biostudies/submission_parsing_utils.py
@@ -33,7 +33,8 @@ def attributes_to_dict(
 
 
 def find_file_lists_in_section(
-    section: Section, flists: List[Dict[str, Union[str, None, List[str]]]]
+    section: Section, 
+    flists: List[Dict[str, Union[str, None, List[str]]]], 
 ) -> List[Dict[str, Union[str, None, List[str]]]]:
     """
     Find all of the File Lists in a Section, recursively descending through the subsections.
@@ -93,27 +94,14 @@ def find_files_in_submission_file_lists(submission: Submission) -> List[File]:
     return sum(file_lists, [])
 
 
-def find_files_and_file_lists_in_submission(
-        submission: Submission
-) -> List:
-    """Find all of the files in a submission, both attached directly to
-    the submission and as file lists."""
-
-    # TODO: deal with file lists. 
-
-    #all_files_and_file_lists = []
-    #all_file_lists = find_files_in_submission_file_lists(submission)
-
-    all_files = find_files_in_submission(submission.section, [])
-
-    return all_files
-
 def find_files_in_submission(
     section: Section, 
     files_list: List[File]
-) -> List:
+) -> List[File]:
     """Find files in a submission that are attached directly, 
     not in file lists."""
+
+    # ASSOCIATIONS IN DIRECT FILES?
 
     section_type = type(section)
     if section_type == Section:
@@ -122,7 +110,7 @@ def find_files_in_submission(
                 files_list += file
             else:
                 files_list.append(file)
-
+        
         for subsection in section.subsections:
             find_files_in_submission(subsection, files_list)
 
@@ -132,6 +120,19 @@ def find_files_in_submission(
         )
     
     return files_list
+
+
+def find_files_and_file_lists_in_default_submission(
+        submission: Submission
+) -> List[File]:
+    """Find all of the files in a submission, both attached directly to
+    the submission and as file lists."""
+
+    all_files_and_file_lists = find_files_in_submission_file_lists(submission)
+    all_files_and_file_lists = (find_files_in_submission(submission.section, all_files_and_file_lists))
+
+    return all_files_and_file_lists
+
 
 def mattributes_to_dict(
     attributes: List[Attribute], reference_dict: Dict[str, Any]

--- a/bia-ingest/bia_ingest/biostudies/v4/file_reference.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/file_reference.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from bia_ingest.persistence_strategy import PersistenceStrategy
 from bia_ingest.biostudies.submission_parsing_utils import (
     find_datasets_with_file_lists,
-    find_files_and_file_lists_in_submission, 
     attributes_to_dict,
 )
 from bia_ingest.bia_object_creation_utils import (

--- a/bia-ingest/bia_ingest/cli.py
+++ b/bia-ingest/bia_ingest/cli.py
@@ -189,6 +189,7 @@ def determine_biostudies_processing_version(submission: Submission):
         "S-BIAD1076": BioStudiesProcessingVersion.V4,
         "S-BIAD1244": BioStudiesProcessingVersion.V4,
         "S-BIAD650": BioStudiesProcessingVersion.FALLBACK,  # Uses v4 template but doesn't actually have rembi components
+        "S-BSST567": BioStudiesProcessingVersion.V4, 
     }
     accession_id = submission.accno
     if accession_id in override_map:

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -7,20 +7,11 @@ from bia_ingest.biostudies.api import Submission, SubmissionTable, requests
 from bia_test_data.mock_objects.mock_object_constants import accession_id, accession_id_biostudies_default
 from bia_ingest.cli_logging import IngestionResult
 from bia_test_data import bia_test_data_dir
+
 from bia_ingest.biostudies.biostudies_processing_version import (
     BioStudiesProcessingVersion,
 )
 
-from unittest.mock import Mock
-from typing import Dict
-from pathlib import Path
-import json
-import pytest
-from bia_ingest.biostudies.api import Submission, SubmissionTable, requests
-from bia_test_data.mock_objects.mock_object_constants import accession_id
-from bia_ingest.cli_logging import IngestionResult
-from bia_test_data import bia_test_data_dir
-from bia_ingest.biostudies.api import SearchResult, SearchPage
 
 @pytest.fixture
 def test_submission() -> Submission:

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import json
 import pytest
 from bia_ingest.biostudies.api import Submission, SubmissionTable, requests
-from bia_test_data.mock_objects.mock_object_constants import accession_id
+from bia_test_data.mock_objects.mock_object_constants import accession_id, accession_id_default
 from bia_ingest.cli_logging import IngestionResult
 from bia_test_data import bia_test_data_dir
 
@@ -33,6 +33,11 @@ def test_submission_table() -> SubmissionTable:
 @pytest.fixture
 def ingestion_result_summary():
     result_summary = {accession_id: IngestionResult()}
+    return result_summary
+
+@pytest.fixture
+def ingestion_result_summary_default():
+    result_summary = {accession_id_default: IngestionResult()}
     return result_summary
 
 @pytest.fixture

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -11,6 +11,16 @@ from bia_ingest.biostudies.biostudies_processing_version import (
     BioStudiesProcessingVersion,
 )
 
+from unittest.mock import Mock
+from typing import Dict
+from pathlib import Path
+import json
+import pytest
+from bia_ingest.biostudies.api import Submission, SubmissionTable, requests
+from bia_test_data.mock_objects.mock_object_constants import accession_id
+from bia_ingest.cli_logging import IngestionResult
+from bia_test_data import bia_test_data_dir
+from bia_ingest.biostudies.api import SearchResult, SearchPage
 
 @pytest.fixture
 def test_submission() -> Submission:

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -16,6 +16,12 @@ def test_submission() -> Submission:
     submission = Submission.model_validate(json_data)
     return submission
 
+@pytest.fixture
+def test_submission_default() -> Submission:
+    submission_path = bia_test_data_dir / "default_biostudies" / "S-BSSTTEST.json"
+    json_data = json.loads(submission_path.read_text())
+    submission = Submission.model_validate(json_data)
+    return submission
 
 @pytest.fixture
 def test_submission_table() -> SubmissionTable:
@@ -24,12 +30,10 @@ def test_submission_table() -> SubmissionTable:
     submission = SubmissionTable.model_validate(json_data)
     return submission
 
-
 @pytest.fixture
 def ingestion_result_summary():
     result_summary = {accession_id: IngestionResult()}
     return result_summary
-
 
 @pytest.fixture
 def mock_request_get(monkeypatch):

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -4,9 +4,12 @@ from pathlib import Path
 import json
 import pytest
 from bia_ingest.biostudies.api import Submission, SubmissionTable, requests
-from bia_test_data.mock_objects.mock_object_constants import accession_id, accession_id_default
+from bia_test_data.mock_objects.mock_object_constants import accession_id, accession_id_biostudies_default
 from bia_ingest.cli_logging import IngestionResult
 from bia_test_data import bia_test_data_dir
+from bia_ingest.biostudies.biostudies_processing_version import (
+    BioStudiesProcessingVersion,
+)
 
 
 @pytest.fixture
@@ -17,7 +20,7 @@ def test_submission() -> Submission:
     return submission
 
 @pytest.fixture
-def test_default_submission_direct_files() -> Submission:
+def test_submission_biostudies_default_direct_files() -> Submission:
     submission_path = bia_test_data_dir / "default_biostudies" / "S-BSSTTEST_files_direct.json"
     json_data = json.loads(submission_path.read_text())
     submission = Submission.model_validate(json_data)
@@ -36,8 +39,11 @@ def ingestion_result_summary():
     return result_summary
 
 @pytest.fixture
-def ingestion_result_summary_default():
-    result_summary = {accession_id_default: IngestionResult()}
+def ingestion_result_summary_biostudies_default():
+
+    result_summary = {}
+    result_summary[accession_id_biostudies_default] = IngestionResult()
+    result_summary[accession_id_biostudies_default].ProcessingVersion = BioStudiesProcessingVersion.BIOSTUDIES_DEFAULT
     return result_summary
 
 @pytest.fixture

--- a/bia-ingest/test/conftest.py
+++ b/bia-ingest/test/conftest.py
@@ -17,8 +17,8 @@ def test_submission() -> Submission:
     return submission
 
 @pytest.fixture
-def test_submission_default() -> Submission:
-    submission_path = bia_test_data_dir / "default_biostudies" / "S-BSSTTEST.json"
+def test_default_submission_direct_files() -> Submission:
+    submission_path = bia_test_data_dir / "default_biostudies" / "S-BSSTTEST_files_direct.json"
     json_data = json.loads(submission_path.read_text())
     submission = Submission.model_validate(json_data)
     return submission

--- a/bia-ingest/test/test_biostudies_conversion.py
+++ b/bia-ingest/test/test_biostudies_conversion.py
@@ -20,6 +20,7 @@ from bia_ingest.biostudies.v4 import (
     annotation_method,
     specimen_imaging_preparation_protocol,
 )
+from bia_ingest.biostudies.biostudies_default import default_dataset
 
 
 def test_create_models_specimen_imaging_preparation_protocol(
@@ -128,6 +129,18 @@ def test_create_models_dataset(
 
     assert expected == created
 
+def test_create_models_default_dataset(
+    test_submission_default, 
+    ingestion_result_summary, 
+):
+    expected = mock_dataset.get_default_dataset()
+    created = default_dataset.get_dataset_overview(
+        test_submission_default,
+        mock_object_constants.study_uuid,
+        ingestion_result_summary,
+    )
+    
+    assert expected == created
 
 def test_create_models_study(test_submission, ingestion_result_summary):
     expected = mock_study.get_study()

--- a/bia-ingest/test/test_biostudies_conversion.py
+++ b/bia-ingest/test/test_biostudies_conversion.py
@@ -129,18 +129,20 @@ def test_create_models_dataset(
 
     assert expected == created
 
+
 def test_create_models_default_dataset(
-    test_submission_default, 
+    test_default_submission_direct_files, 
     ingestion_result_summary_default, 
 ):
     expected = mock_dataset.get_default_dataset()
     created = default_dataset.get_dataset_overview(
-        test_submission_default,
+        test_default_submission_direct_files,
         mock_object_constants.study_uuid_default,
         ingestion_result_summary_default,
     )
     
     assert expected == created
+
 
 def test_create_models_study(test_submission, ingestion_result_summary):
     expected = mock_study.get_study()

--- a/bia-ingest/test/test_biostudies_conversion.py
+++ b/bia-ingest/test/test_biostudies_conversion.py
@@ -131,13 +131,13 @@ def test_create_models_dataset(
 
 def test_create_models_default_dataset(
     test_submission_default, 
-    ingestion_result_summary, 
+    ingestion_result_summary_default, 
 ):
     expected = mock_dataset.get_default_dataset()
     created = default_dataset.get_dataset_overview(
         test_submission_default,
-        mock_object_constants.study_uuid,
-        ingestion_result_summary,
+        mock_object_constants.study_uuid_default,
+        ingestion_result_summary_default,
     )
     
     assert expected == created

--- a/bia-ingest/test/test_biostudies_conversion.py
+++ b/bia-ingest/test/test_biostudies_conversion.py
@@ -130,15 +130,15 @@ def test_create_models_dataset(
     assert expected == created
 
 
-def test_create_models_default_dataset(
-    test_default_submission_direct_files, 
-    ingestion_result_summary_default, 
+def test_create_models_dataset_biostudies_default(
+    test_submission_biostudies_default_direct_files, 
+    ingestion_result_summary_biostudies_default, 
 ):
-    expected = mock_dataset.get_default_dataset()
+    expected = mock_dataset.get_dataset_biostudies_default()
     created = default_dataset.get_dataset_overview(
-        test_default_submission_direct_files,
-        mock_object_constants.study_uuid_default,
-        ingestion_result_summary_default,
+        test_submission_biostudies_default_direct_files,
+        mock_object_constants.study_uuid_biostudies_default,
+        ingestion_result_summary_biostudies_default,
     )
     
     assert expected == created

--- a/bia-ingest/test/test_file_reference.py
+++ b/bia-ingest/test/test_file_reference.py
@@ -1,11 +1,22 @@
 import pytest
-from bia_test_data.mock_objects import mock_file_reference, mock_dataset
+from bia_test_data.mock_objects import (
+    mock_file_reference, 
+    mock_dataset, 
+    mock_object_constants, 
+)
+from bia_ingest.biostudies import submission_parsing_utils
+from bia_ingest.biostudies.biostudies_default import default_file_reference
 from bia_ingest.biostudies.v4 import (
     file_reference,
 )
 from bia_ingest.biostudies.api import File
 from bia_shared_datamodels.bia_data_model import Dataset
-from bia_test_data.mock_objects.mock_object_constants import study_uuid, accession_id
+from bia_test_data.mock_objects.mock_object_constants import (
+    study_uuid, 
+    study_uuid_default, 
+    accession_id, 
+    accession_id_default, 
+)
 
 
 @pytest.fixture
@@ -15,11 +26,22 @@ def dataset_in_submission() -> Dataset:
     """
     return mock_dataset.get_dataset()[1]
 
+@pytest.fixture
+def dataset_in_default_submission() -> Dataset:
+    return mock_dataset.get_default_dataset()
 
 @pytest.fixture
 def biostudies_api_files():
     file_list_data = mock_file_reference.get_file_list_data(
         "biad_v4/file_list_study_component_2.json"
+    )
+    files_in_filelist = [File.model_validate(f) for f in file_list_data]
+    return files_in_filelist
+
+@pytest.fixture
+def default_biostudies_api_files_listed():
+    file_list_data = mock_file_reference.get_file_list_data(
+        "default_biostudies/file_list_default.json"
     )
     files_in_filelist = [File.model_validate(f) for f in file_list_data]
     return files_in_filelist
@@ -95,3 +117,40 @@ def test_create_file_reference_for_study_component_when_no_matching_sc_in_file_l
 
     for expected in expected_log_message:
         assert expected in caplog.text
+
+
+def test_get_direct_file_list_for_default_submission_dataset(
+        test_default_submission_direct_files, 
+        dataset_in_default_submission, 
+):
+    file_path = "default_biostudies/files_direct_default.json"
+    expected = mock_file_reference.get_default_file_reference_data(file_path)
+    
+    file_list = submission_parsing_utils.find_files_and_file_lists_in_default_submission(
+        test_default_submission_direct_files
+    )
+    created = default_file_reference.get_file_reference_dicts_for_submission_dataset(
+        accession_id_default, 
+        study_uuid_default, 
+        dataset_in_default_submission,
+        file_list, 
+    )
+
+    assert created == expected
+
+
+def test_get_listed_file_list_for_default_submission_dataset(
+        default_biostudies_api_files_listed, 
+        dataset_in_default_submission, 
+):
+    file_path = "default_biostudies/file_list_default.json"
+    expected = mock_file_reference.get_default_file_reference_data(file_path)
+    
+    created = default_file_reference.get_file_reference_dicts_for_submission_dataset(
+        accession_id_default, 
+        study_uuid_default, 
+        dataset_in_default_submission,
+        default_biostudies_api_files_listed, 
+    )
+
+    assert created == expected

--- a/bia-ingest/test/test_file_reference.py
+++ b/bia-ingest/test/test_file_reference.py
@@ -10,15 +10,12 @@ from bia_ingest.biostudies.v4 import (
     file_reference,
 )
 from bia_ingest.biostudies.api import File
-from bia_ingest.biostudies.biostudies_processing_version import (
-    BioStudiesProcessingVersion,
-)
 from bia_shared_datamodels.bia_data_model import Dataset
 from bia_test_data.mock_objects.mock_object_constants import (
     study_uuid, 
-    study_uuid_default, 
+    study_uuid_biostudies_default, 
     accession_id, 
-    accession_id_default, 
+    accession_id_biostudies_default, 
 )
 from bia_ingest.cli_logging import IngestionResult
 
@@ -31,8 +28,8 @@ def dataset_in_submission() -> Dataset:
     return mock_dataset.get_dataset()[1]
 
 @pytest.fixture
-def dataset_in_default_submission() -> Dataset:
-    return mock_dataset.get_default_dataset()
+def dataset_in_submission_biostudies_default() -> Dataset:
+    return mock_dataset.get_dataset_biostudies_default()
 
 @pytest.fixture
 def biostudies_api_files():
@@ -43,21 +40,13 @@ def biostudies_api_files():
     return files_in_filelist
 
 @pytest.fixture
-def default_biostudies_api_files_listed():
+def biostudies_default_api_files_listed():
     file_list_data = mock_file_reference.get_file_list_data(
         "default_biostudies/file_list_default.json"
     )
     files_in_filelist = [File.model_validate(f) for f in file_list_data]
     return files_in_filelist
 
-
-@pytest.fixture
-def default_ingestion_result_summary():
-
-    result_summary = {}
-    result_summary[accession_id_default] = IngestionResult()
-    result_summary[accession_id_default].ProcessingVersion = BioStudiesProcessingVersion.BIOSTUDIES_DEFAULT
-    return result_summary
 
 def test_get_file_reference_for_submission_dataset(
     dataset_in_submission, biostudies_api_files
@@ -131,40 +120,40 @@ def test_create_file_reference_for_study_component_when_no_matching_sc_in_file_l
         assert expected in caplog.text
 
 
-def test_get_direct_file_list_for_default_submission_dataset(
-        test_default_submission_direct_files, 
-        dataset_in_default_submission, 
-        default_ingestion_result_summary
+def test_get_direct_file_list_for_biostudies_default_submission_dataset(
+        test_submission_biostudies_default_direct_files, 
+        dataset_in_submission_biostudies_default, 
+        ingestion_result_summary_biostudies_default, 
 ):
     file_path = "default_biostudies/files_direct_default.json"
-    expected = mock_file_reference.get_default_file_reference_data(file_path)
+    expected = mock_file_reference.get_file_reference_data_biostudies_default(file_path)
     
     file_list = submission_parsing_utils.find_files_and_file_lists_in_default_submission(
-        test_default_submission_direct_files, 
-        default_ingestion_result_summary
+        test_submission_biostudies_default_direct_files, 
+        ingestion_result_summary_biostudies_default
     )
     created = default_file_reference.get_file_reference_dicts_for_submission_dataset(
-        accession_id_default, 
-        study_uuid_default, 
-        dataset_in_default_submission,
+        accession_id_biostudies_default, 
+        study_uuid_biostudies_default, 
+        dataset_in_submission_biostudies_default,
         file_list, 
     )
 
     assert created == expected
 
 
-def test_get_listed_file_list_for_default_submission_dataset(
-        default_biostudies_api_files_listed, 
-        dataset_in_default_submission, 
+def test_get_listed_file_list_for_biostudies_default_submission_dataset(
+        biostudies_default_api_files_listed, 
+        dataset_in_submission_biostudies_default, 
 ):
     file_path = "default_biostudies/file_list_default.json"
-    expected = mock_file_reference.get_default_file_reference_data(file_path)
+    expected = mock_file_reference.get_file_reference_data_biostudies_default(file_path)
     
     created = default_file_reference.get_file_reference_dicts_for_submission_dataset(
-        accession_id_default, 
-        study_uuid_default, 
-        dataset_in_default_submission,
-        default_biostudies_api_files_listed, 
+        accession_id_biostudies_default, 
+        study_uuid_biostudies_default, 
+        dataset_in_submission_biostudies_default,
+        biostudies_default_api_files_listed, 
     )
 
     assert created == expected

--- a/bia-ingest/test/test_file_reference.py
+++ b/bia-ingest/test/test_file_reference.py
@@ -10,6 +10,9 @@ from bia_ingest.biostudies.v4 import (
     file_reference,
 )
 from bia_ingest.biostudies.api import File
+from bia_ingest.biostudies.biostudies_processing_version import (
+    BioStudiesProcessingVersion,
+)
 from bia_shared_datamodels.bia_data_model import Dataset
 from bia_test_data.mock_objects.mock_object_constants import (
     study_uuid, 
@@ -17,6 +20,7 @@ from bia_test_data.mock_objects.mock_object_constants import (
     accession_id, 
     accession_id_default, 
 )
+from bia_ingest.cli_logging import IngestionResult
 
 
 @pytest.fixture
@@ -46,6 +50,14 @@ def default_biostudies_api_files_listed():
     files_in_filelist = [File.model_validate(f) for f in file_list_data]
     return files_in_filelist
 
+
+@pytest.fixture
+def default_ingestion_result_summary():
+
+    result_summary = {}
+    result_summary[accession_id_default] = IngestionResult()
+    result_summary[accession_id_default].ProcessingVersion = BioStudiesProcessingVersion.BIOSTUDIES_DEFAULT
+    return result_summary
 
 def test_get_file_reference_for_submission_dataset(
     dataset_in_submission, biostudies_api_files
@@ -122,12 +134,14 @@ def test_create_file_reference_for_study_component_when_no_matching_sc_in_file_l
 def test_get_direct_file_list_for_default_submission_dataset(
         test_default_submission_direct_files, 
         dataset_in_default_submission, 
+        default_ingestion_result_summary
 ):
     file_path = "default_biostudies/files_direct_default.json"
     expected = mock_file_reference.get_default_file_reference_data(file_path)
     
     file_list = submission_parsing_utils.find_files_and_file_lists_in_default_submission(
-        test_default_submission_direct_files
+        test_default_submission_direct_files, 
+        default_ingestion_result_summary
     )
     created = default_file_reference.get_file_reference_dicts_for_submission_dataset(
         accession_id_default, 

--- a/bia-test-data/bia_test_data/mock_objects/mock_dataset.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_dataset.py
@@ -153,3 +153,23 @@ def get_dataset() -> List[bia_data_model.Dataset]:
         for object_dict in object_dicts
     ]
     return bia_objects
+
+def get_default_dataset() -> bia_data_model.Dataset:
+
+    study_title = "A default test study section with title greater than 25 characters"
+    description = "A study description"
+
+    dataset_dict = {
+        "uuid": create_dataset_uuid(study_title, study_uuid),
+        "title_id": study_title,
+        "description": description,
+        "submitted_in_study_uuid": study_uuid,
+        "analysis_method": [],
+        "correlation_method": [],
+        "example_image_uri": [],
+        "version": 0,
+        "attribute": []
+    }
+
+    dataset = bia_data_model.Dataset.model_validate(dataset_dict)
+    return dataset

--- a/bia-test-data/bia_test_data/mock_objects/mock_dataset.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_dataset.py
@@ -1,7 +1,7 @@
 from typing import List
 from bia_shared_datamodels import bia_data_model, semantic_models
 from bia_shared_datamodels.uuid_creation import create_dataset_uuid
-from .mock_object_constants import study_uuid, study_uuid_default
+from .mock_object_constants import study_uuid, study_uuid_biostudies_default
 from .mock_image_analysis_method import get_image_analysis_method
 from .mock_image_correlation_method import get_test_image_correlation_method
 from .mock_image_acquisition_protocol import get_image_acquisition_protocol_as_map
@@ -154,16 +154,16 @@ def get_dataset() -> List[bia_data_model.Dataset]:
     ]
     return bia_objects
 
-def get_default_dataset() -> bia_data_model.Dataset:
+def get_dataset_biostudies_default() -> bia_data_model.Dataset:
 
     study_title = "A default test study section with title greater than 25 characters"
     description = "A study description"
 
     dataset_dict = {
-        "uuid": create_dataset_uuid(study_title, study_uuid_default),
+        "uuid": create_dataset_uuid(study_title, study_uuid_biostudies_default),
         "title_id": study_title,
         "description": description,
-        "submitted_in_study_uuid": study_uuid_default,
+        "submitted_in_study_uuid": study_uuid_biostudies_default,
         "analysis_method": [],
         "correlation_method": [],
         "example_image_uri": [],

--- a/bia-test-data/bia_test_data/mock_objects/mock_dataset.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_dataset.py
@@ -1,7 +1,7 @@
 from typing import List
 from bia_shared_datamodels import bia_data_model, semantic_models
 from bia_shared_datamodels.uuid_creation import create_dataset_uuid
-from .mock_object_constants import study_uuid
+from .mock_object_constants import study_uuid, study_uuid_default
 from .mock_image_analysis_method import get_image_analysis_method
 from .mock_image_correlation_method import get_test_image_correlation_method
 from .mock_image_acquisition_protocol import get_image_acquisition_protocol_as_map
@@ -160,10 +160,10 @@ def get_default_dataset() -> bia_data_model.Dataset:
     description = "A study description"
 
     dataset_dict = {
-        "uuid": create_dataset_uuid(study_title, study_uuid),
+        "uuid": create_dataset_uuid(study_title, study_uuid_default),
         "title_id": study_title,
         "description": description,
-        "submitted_in_study_uuid": study_uuid,
+        "submitted_in_study_uuid": study_uuid_default,
         "analysis_method": [],
         "correlation_method": [],
         "example_image_uri": [],

--- a/bia-test-data/bia_test_data/mock_objects/mock_file_reference.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_file_reference.py
@@ -2,9 +2,14 @@ import json
 from typing import Dict, List
 from bia_shared_datamodels import bia_data_model, semantic_models
 from bia_test_data import bia_test_data_dir
-from .mock_object_constants import accession_id, study_uuid, accession_id_default, study_uuid_default
+from .mock_object_constants import (
+    accession_id, 
+    study_uuid, 
+    accession_id_biostudies_default, 
+    study_uuid_biostudies_default, 
+)
 from bia_shared_datamodels.uuid_creation import create_file_reference_uuid
-from .mock_dataset import get_dataset, get_default_dataset
+from .mock_dataset import get_dataset, get_dataset_biostudies_default
 
 
 def get_file_list_data(file_list_name) -> List[Dict]:
@@ -72,9 +77,9 @@ def get_file_reference(
     return file_references
 
 
-def get_default_file_reference_data(
+def get_file_reference_data_biostudies_default(
     file_list: str, 
-    dataset_uuid = get_default_dataset().uuid, 
+    dataset_uuid = get_dataset_biostudies_default().uuid, 
 ) -> List[Dict]:
     
     uri_template = "https://www.ebi.ac.uk/biostudies/files/{accession_id}/{file_path}"
@@ -93,12 +98,12 @@ def get_default_file_reference_data(
         }
         file_reference_data.append(
             {
-                "uuid": create_file_reference_uuid(fl_data["path"], study_uuid_default),
+                "uuid": create_file_reference_uuid(fl_data["path"], study_uuid_biostudies_default),
                 "file_path": fl_data["path"],
                 "format": fl_data["type"],
                 "size_in_bytes": int(fl_data["size"]),
                 "uri": uri_template.format(
-                    accession_id=accession_id_default, file_path=fl_data["path"]
+                    accession_id=accession_id_biostudies_default, file_path=fl_data["path"]
                 ),
                 "submission_dataset_uuid": dataset_uuid,
                 "version": 0,

--- a/bia-test-data/bia_test_data/mock_objects/mock_file_reference.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_file_reference.py
@@ -2,9 +2,9 @@ import json
 from typing import Dict, List
 from bia_shared_datamodels import bia_data_model, semantic_models
 from bia_test_data import bia_test_data_dir
-from .mock_object_constants import accession_id, study_uuid
+from .mock_object_constants import accession_id, study_uuid, accession_id_default, study_uuid_default
 from bia_shared_datamodels.uuid_creation import create_file_reference_uuid
-from .mock_dataset import get_dataset
+from .mock_dataset import get_dataset, get_default_dataset
 
 
 def get_file_list_data(file_list_name) -> List[Dict]:
@@ -71,3 +71,41 @@ def get_file_reference(
 
     return file_references
 
+
+def get_default_file_reference_data(
+    file_list: str, 
+    dataset_uuid = get_default_dataset().uuid, 
+) -> List[Dict]:
+    
+    uri_template = "https://www.ebi.ac.uk/biostudies/files/{accession_id}/{file_path}"
+    file_list_data = get_file_list_data(file_list)
+
+    file_reference_data = []
+
+    for fl_data in file_list_data:
+        attributes = {a["name"]: a.get("value", None) for a in fl_data["attributes"]}
+        attributes_as_attr_dict = {
+            "provenance": semantic_models.AttributeProvenance("bia_ingest"),
+            "name": "attributes_from_biostudies.File",
+            "value": {
+                "attributes": attributes,
+            },
+        }
+        file_reference_data.append(
+            {
+                "uuid": create_file_reference_uuid(fl_data["path"], study_uuid_default),
+                "file_path": fl_data["path"],
+                "format": fl_data["type"],
+                "size_in_bytes": int(fl_data["size"]),
+                "uri": uri_template.format(
+                    accession_id=accession_id_default, file_path=fl_data["path"]
+                ),
+                "submission_dataset_uuid": dataset_uuid,
+                "version": 0,
+                "attribute": [
+                    attributes_as_attr_dict,
+                ],
+            }
+        )
+
+    return file_reference_data

--- a/bia-test-data/bia_test_data/mock_objects/mock_object_constants.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_object_constants.py
@@ -1,5 +1,7 @@
 from bia_shared_datamodels.uuid_creation import create_study_uuid
 
 accession_id = "S-BIADTEST"
+accession_id_default = "S-BSSTTEST"
 
 study_uuid = create_study_uuid(accession_id)
+study_uuid_default = create_study_uuid(accession_id_default)

--- a/bia-test-data/bia_test_data/mock_objects/mock_object_constants.py
+++ b/bia-test-data/bia_test_data/mock_objects/mock_object_constants.py
@@ -1,7 +1,7 @@
 from bia_shared_datamodels.uuid_creation import create_study_uuid
 
 accession_id = "S-BIADTEST"
-accession_id_default = "S-BSSTTEST"
+accession_id_biostudies_default = "S-BSSTTEST"
 
 study_uuid = create_study_uuid(accession_id)
-study_uuid_default = create_study_uuid(accession_id_default)
+study_uuid_biostudies_default = create_study_uuid(accession_id_biostudies_default)

--- a/bia-test-data/data/default_biostudies/S-BSSTTEST.json
+++ b/bia-test-data/data/default_biostudies/S-BSSTTEST.json
@@ -1,0 +1,134 @@
+{
+  "accno" : "S-BSSTTEST",
+  "attributes" : [ {
+    "name" : "Template",
+    "value" : "Default"
+  }, {
+    "name" : "Title",
+    "value" : "A default test submission with title greater than 25 characters"
+  }, {
+    "name" : "ReleaseDate",
+    "value" : "2025-01-15"
+  }, {
+    "name" : "AttachTo",
+    "value" : "BioImages"
+  } ],
+  "section" : {
+    "type" : "Study",
+    "attributes" : [ {
+      "name" : "Title",
+      "value" : "A default test study section with title greater than 25 characters"
+    }, {
+      "name" : "Abstract",
+      "value" : "Study abstract"
+    }, {
+      "name" : "Description",
+      "value" : "A study description"
+    }, {
+      "name" : "Study variable",
+      "value" : "Study variable 1"
+    }, {
+      "name" : "Study variable",
+      "value" : "Study variable 2"
+    }, {
+      "name" : "Organism",
+      "value" : "Some sort of organism"
+    }, {
+      "name" : "Measurement type",
+      "value" : "A measuring device"
+    }, {
+      "name" : "Technology type",
+      "value" : "A techonology"
+    }, {
+      "name" : "Technology platform",
+      "value" : "A platform"
+    }, {
+      "name" : "File List",
+      "value" : "testFileList.json"
+    } ],
+    "links" : [ [ {
+      "url" : "https://www.testLink.com",
+      "attributes" : [ {
+        "name" : "Type",
+        "value" : "DOI"
+      }, {
+        "name" : "Title",
+        "value" : "Test link"
+      } ]
+    } ] ],
+    "files" : [ {
+      "path" : "path1.czi",
+      "size" : 1222831936,
+      "attributes" : [ {
+          "name" : "Description",
+          "value" : "Description 1"
+      }, {
+          "name" : "Type",
+          "value" : "Some file type"
+      } ],
+      "type" : "file"
+      }, {
+      "path" : "path2.csv",
+      "size" : 1222831936,
+      "attributes" : [ {
+          "name" : "Description",
+          "value" : "Description 2"
+      }, {
+          "name" : "Type",
+          "value" : "Some file type"
+      } ],
+      "type" : "file"
+      }, {
+      "path" : "path3.czi",
+      "size" : 1222831936,
+      "attributes" : [ {
+          "name" : "Description",
+          "value" : "Description 3"
+      }, {
+          "name" : "Type",
+          "value" : "Some file type"
+      } ],
+      "type" : "file"
+      } ],
+    "subsections" : [ {
+      "type" : "Author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Test author 1"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      }, {
+        "name" : "affiliation",
+        "value" : "o2",
+        "reference" : true
+      } ]
+    }, {
+      "type" : "Author",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Test author 2"
+      }, {
+        "name" : "affiliation",
+        "value" : "o1",
+        "reference" : true
+      } ]
+    }, {
+      "accno" : "o1",
+      "type" : "Organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Test organisation 1"
+      } ]
+    }, {
+      "accno" : "o2",
+      "type" : "Organization",
+      "attributes" : [ {
+        "name" : "Name",
+        "value" : "Test organisation 2"
+      } ]
+    } ]
+  },
+  "type" : "submission"
+}

--- a/bia-test-data/data/default_biostudies/S-BSSTTEST_files_direct.json
+++ b/bia-test-data/data/default_biostudies/S-BSSTTEST_files_direct.json
@@ -42,9 +42,6 @@
     }, {
       "name" : "Technology platform",
       "value" : "A platform"
-    }, {
-      "name" : "File List",
-      "value" : "testFileList.json"
     } ],
     "links" : [ [ {
       "url" : "https://www.testLink.com",

--- a/bia-test-data/data/default_biostudies/file_list_default.json
+++ b/bia-test-data/data/default_biostudies/file_list_default.json
@@ -1,0 +1,63 @@
+[ 
+    {
+        "path": "path4.tif",
+        "size": 8453126,
+        "attributes": [
+        {
+            "name": "metadata1_key",
+            "value": "metadata1_value"
+        }, {
+            "name": "metadata2_key",
+            "value": "metadata2_value"
+        } ],
+        "type": "file"
+    }, {
+        "path": "path5.tif",
+        "size": 8453208,
+        "attributes": [
+        {
+            "name": "metadata1_key",
+            "value": "metadata1_value"
+        }, {
+            "name": "metadata2_key",
+            "value": "metadata2_value"
+        } ],
+        "type": "file"
+    }, {
+        "path": "path6.tif",
+        "size": 8453174,
+        "attributes": [
+        {
+            "name": "metadata1_key",
+            "value": "metadata1_value"
+        }, {
+            "name": "metadata2_key",
+            "value": "metadata2_value"
+        } ],
+        "type": "file"
+    }, {
+        "path": "path7.tif",
+        "size": 8453134,
+        "attributes": [
+        {
+            "name": "metadata1_key",
+            "value": "metadata1_value"
+        }, {
+            "name": "metadata2_key",
+            "value": "metadata2_value"
+        } ],
+        "type": "file"
+    }, {
+        "path": "path8.tif",
+        "size": 8453092,
+        "attributes": [
+        {
+            "name": "metadata1_key",
+            "value": "metadata1_value"
+        }, {
+            "name": "metadata2_key",
+            "value": "metadata2_value"
+        } ],
+        "type": "file"
+    } 
+]

--- a/bia-test-data/data/default_biostudies/files_direct_default.json
+++ b/bia-test-data/data/default_biostudies/files_direct_default.json
@@ -1,0 +1,36 @@
+[ 
+    {
+        "path" : "path1.czi",
+        "size" : 1222831936,
+        "attributes" : [ {
+            "name" : "Description",
+            "value" : "Description 1"
+        }, {
+            "name" : "Type",
+            "value" : "Some file type"
+        } ],
+        "type" : "file"
+    }, {
+        "path" : "path2.csv",
+        "size" : 1222831936,
+        "attributes" : [ {
+            "name" : "Description",
+            "value" : "Description 2"
+        }, {
+            "name" : "Type",
+            "value" : "Some file type"
+        } ],
+        "type" : "file"
+    }, {
+        "path" : "path3.czi",
+        "size" : 1222831936,
+        "attributes" : [ {
+            "name" : "Description",
+            "value" : "Description 3"
+        }, {
+            "name" : "Type",
+            "value" : "Some file type"
+        } ],
+        "type" : "file"
+    } 
+]


### PR DESCRIPTION
For tickets:
https://app.clickup.com/t/8697b5yuc
https://app.clickup.com/t/8697c5vxm

To process and make tests for file references in default templates.

- Default study with a file list: https://www.ebi.ac.uk/biostudies/BioImages/studies/S-BSST51
- Default study with directly-attached files: https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BSST1075

And the unusual submission, https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BSST567, that has an effort at making associations. This, and any other studies like it (if they exist), will be caught, and a warning will be issued in the ingest output table. 
 