### PR TITLE
fix annotation method retrieval

### DIFF
--- a/bia-ingest/bia_ingest/biostudies/v4/annotation_method.py
+++ b/bia-ingest/bia_ingest/biostudies/v4/annotation_method.py
@@ -63,6 +63,7 @@ def extract_annotation_method_dicts(
         ("title_id", "Title", ""),
         ("annotation_criteria", "Annotation Criteria", None),
         ("annotation_coverage", "Annotation Coverage", None),
+        ("protocol_description", "Annotation Method", "")
     ]
 
     model_dict_map = {}
@@ -78,9 +79,6 @@ def extract_annotation_method_dicts(
         # annotation_source_indicator
         # spatial_information
         # transformation_description
-
-        model_dict["protocol_description"] = attr_dict.get("Annotation Method", "")
-
         
         annotation_types = attr_dict.get("Annotation Type", "")
         if annotation_types:


### PR DESCRIPTION
Correctly populates Annotation method regardless of capitalisation of field names (which could be anything with pagetab submissions)

Currently: https://deploy-preview-66--bia-beta-website.netlify.app/bioimage-archive/dataset/s-biad1518/

Post PR:

{
  "title_id": "Manual segmentation of scale-cleared rat kidney nuclei",
  "uuid": "4ee37535-3aa0-4d6f-87b5-c1da8bf246cf",
  "version": 0,
  "model": {
    "type_name": "AnnotationMethod",
    "version": 3
  },
  "attribute": [],
  "protocol_description": "Manual annotations were obtained using ITK-Snap (Yushkevich eat al. Neuroimage, 2006). Here we describe the specific steps in ITK-Snap we use to annotate the sub-volumes. First we use the 3D adaptive brush as a first pass for annotating a subvolume. Different “Active Labels” are used for nuclei that touch other nuclei. It is acceptable for nuclei that are far away (i.e. not touching) to have the same “Active Label.” As a result of this, as many as eight different “Active Labels” are used for each subvolume. Minor adjustments were made using a 3D round brush after the initial use of the 3D adaptive brush. The final result is a manually annotated subvolume with the same size as the original subvolume. Any background voxel, i.e. any voxel not being annotated as part of a nucleus, has a voxel intensity of 0. A voxel belonging to a nucleus will have an intensity value between 1 and m, where m is the number of “Active Labels” used during the annotation. Each intensity value between 1 and m corresponds to an “Active Label.”",
  "annotation_criteria": null,
  "annotation_coverage": null,
  "transformation_description": null,
  "spatial_information": null,
  "method_type": [
    "other"
  ],
  "annotation_source_indicator": null
}