### PR TITLE
Enable auth for elastic, add alternative viewer

### DIFF
--- a/api/.env_compose
+++ b/api/.env_compose
@@ -6,4 +6,4 @@ DB_NAME=bia_integrator
 JWT_SECRET_KEY="0123456789=="
 USER_CREATE_SECRET_TOKEN="0123456789=="
 MONGO_INDEX_PUSH=True
-ELASTIC_CONNSTRING="http://elastic:test@localhost:9200"
+ELASTIC_CONNSTRING="http://elastic:test@biaint-elastic:9200"

--- a/api/.env_compose
+++ b/api/.env_compose
@@ -6,4 +6,4 @@ DB_NAME=bia_integrator
 JWT_SECRET_KEY="0123456789=="
 USER_CREATE_SECRET_TOKEN="0123456789=="
 MONGO_INDEX_PUSH=True
-ELASTIC_CONNSTRING="http://biaint-elastic:9200"
+ELASTIC_CONNSTRING="http://elastic:test@localhost:9200"

--- a/api/.env_template
+++ b/api/.env_template
@@ -20,3 +20,5 @@ MONGO_INDEX_PUSH=False
 #   set this if behind a proxy that strips a path prefix
 # passhtrough for fastapi root_path https://fastapi.tiangolo.com/advanced/behind-a-proxy/#about-root_path
 FASTAPI_ROOT_PATH=
+
+ELASTIC_CONNSTRING="http://elastic:test@localhost:9200"

--- a/api/api/models/elastic.py
+++ b/api/api/models/elastic.py
@@ -10,7 +10,9 @@ class Elastic:
 
     async def configure(self, settings: Settings):
         index_name = "test-index"
-        self.client = AsyncElasticsearch(settings.elastic_connstring)
+        self.client = AsyncElasticsearch(
+            settings.elastic_connstring, verify_certs=False
+        )
 
         if not await self.client.indices.exists(index=index_name):
             await self.client.indices.create(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,23 +16,30 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.12.0
     environment:
       - discovery.type=single-node
-      - ELASTIC_PASSWORD=elastic123
-      - xpack.security.enabled=false
+      - ELASTIC_PASSWORD=test
+      - xpack.security.enabled=true 
+      - xpack.security.authc.api_key.enabled=true
+      - xpack.license.self_generated.type=basic
+      - http.cors.allow-origin=http://localhost:1358,http://127.0.0.1:1358
+      - http.cors.enabled=true
+      - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
+      - http.cors.allow-credentials=true
     ports:
       - 9200:9200
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=30s"]
+      test: ["CMD", "curl", "-u", "elastic:test", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=30s"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
 
-  biaint-kibana:
-    image: docker.elastic.co/kibana/kibana:8.12.0
-    environment:
-      - ELASTICSEARCH_HOSTS=http://biaint-elastic:9200
+  dejavu:
+    image: appbaseio/dejavu:3.6.0
     ports:
-      - 5601:5601
+      - "1358:1358"
+    environment:
+      - ELASTICSEARCH_URL=http://elastic:test@localhost:9200
+      - ELASTICSEARCH_INDEX=test-index
     depends_on:
       biaint-elastic:
         condition: service_healthy


### PR DESCRIPTION
https://app.clickup.com/t/8698a6z8h

Adds auth and an alternative viewer because keeping kibana meant either adding multi-step setup with an auth token or setting up separate role configs (for dev) - all overkill, might need to reconsider