### PR TITLE
Make all Optional[List[]] fields only List[]

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -255,22 +255,22 @@ class CreationProcess(semantic_models.CreationProcess, DocumentMixin):
         description="The biological specimen that is the subject of the image.",
     )
     image_acquisition_protocol_uuid: Annotated[
-        Optional[List[UUID]], ObjectReference(ImageAcquisitionProtocol)
+        List[UUID], ObjectReference(ImageAcquisitionProtocol)
     ] = Field(
         default_factory=lambda: [],
         description="The imaging protocol, describing the technique that was used to create the image.",
     )
 
-    input_image_uuid: Annotated[Optional[List[UUID]], ObjectReference(Image)] = Field(
+    input_image_uuid: Annotated[List[UUID], ObjectReference(Image)] = Field(
         default_factory=lambda: [],
         description="The images used as input data for the creation of a new image.",
     )
-    protocol_uuid: Annotated[Optional[List[UUID]], ObjectReference(Protocol)] = Field(
+    protocol_uuid: Annotated[List[UUID], ObjectReference(Protocol)] = Field(
         default_factory=lambda: [],
         description="A protocol which was followed that resulted in the creation of this new image from existing image data.",
     )
     annotation_method_uuid: Annotated[
-        Optional[List[UUID]], ObjectReference(AnnotationMethod)
+        List[UUID], ObjectReference(AnnotationMethod)
     ] = Field(
         default_factory=lambda: [],
         description="The annotation method describing the process followed to create a new image from exsiting image data.",

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -44,7 +44,7 @@ class AttributeMixin(BaseModel):
     Mixin for just the attribute field
     """
 
-    attribute: Optional[list[Attribute]] = Field(
+    attribute: List[Attribute] = Field(
         default_factory=list,
         description="""Freeform key-value pairs from user provided metadata (e.g. filelist data) and experimental fields.""",
     )
@@ -70,7 +70,7 @@ class Study(ConfiguredBaseModel, AttributeMixin):
     )
     release_date: date = Field(description="""Date of first publication""")
     description: str = Field(description="""Brief description of the study.""")
-    keyword: Optional[List[str]] = Field(
+    keyword: List[str] = Field(
         default_factory=list,
         description="""Keywords or tags used to describe the subject or context of the study.""",
     )
@@ -79,15 +79,15 @@ class Study(ConfiguredBaseModel, AttributeMixin):
         description="""Any person or group that should be acknowledged outside of the authors/main contributors to the study.""",
     )
 
-    see_also: Optional[List[ExternalReference]] = Field(
+    see_also: List[ExternalReference] = Field(
         default_factory=list,
         description="""Links to publications, github repositories, and other pages related to this Study.""",
     )
-    related_publication: Optional[List[Publication]] = Field(
+    related_publication: List[Publication] = Field(
         default_factory=list,
         description="""The publications that the work involved in the study contributed to.""",
     )
-    grant: Optional[List[Grant]] = Field(
+    grant: List[Grant] = Field(
         default_factory=list, description="""The grants that funded the study."""
     )
     funding_statement: Optional[str] = Field(
@@ -135,7 +135,7 @@ class Grant(ConfiguredBaseModel):
         description="""A unique identifier for the grant, such as an Open Funder Registry ID.""",
     )
 
-    funder: Optional[List[FundingBody]] = Field(
+    funder: List[FundingBody] = Field(
         default_factory=list,
         description="""The name of the funding body providing support for the grant.""",
     )
@@ -272,11 +272,11 @@ class Dataset(ConfiguredBaseModel, AttributeMixin):
     description: Optional[str] = Field(
         None, description="""Brief description of the dataset."""
     )
-    analysis_method: Optional[list[ImageAnalysisMethod]] = Field(
+    analysis_method: List[ImageAnalysisMethod] = Field(
         default_factory=list,
         description="""Data analysis processes performed on the images.""",
     )
-    correlation_method: Optional[list[ImageCorrelationMethod]] = Field(
+    correlation_method: List[ImageCorrelationMethod] = Field(
         default_factory=list,
         description="""Processes performed to correlate image data.""",
     )
@@ -358,7 +358,7 @@ class ImageRepresentation(ConfiguredBaseModel, AttributeMixin):
         None,
         description="""Size of temporal dimension of the data array of the image.""",
     )
-    image_viewer_setting: Optional[List[RenderedView]] = Field(
+    image_viewer_setting: List[RenderedView] = Field(
         default_factory=list,
         description="""Settings of a particular view of an image, such as a specific timestamp of a timeseries, or camera placement in a 3D model.""",
     )
@@ -375,7 +375,7 @@ class RenderedView(ConfiguredBaseModel, AttributeMixin):
     t: Optional[str] = Field(
         None, description="""A t-value for the timestamp of the image view"""
     )
-    channel_information: Optional[List[Channel]] = Field(
+    channel_information: List[Channel] = Field(
         default_factory=list,
         description="""Information about the channels involved in displaying this view of the image.""",
     )
@@ -433,11 +433,11 @@ class ImageAcquisitionProtocol(Protocol):
     imaging_instrument_description: str = Field(
         description="""Names, types, or description of how the instruments used to create the image."""
     )
-    fbbi_id: Optional[List[str]] = Field(
+    fbbi_id: List[str] = Field(
         default_factory=list,
         description="""Biological Imaging Methods Ontology id indicating the kind of imaging that was perfomed.""",
     )
-    imaging_method_name: Optional[List[str]] = Field(
+    imaging_method_name: List[str] = Field(
         default_factory=list,
         description="""Name of the kind of imaging method that was performed.""",
     )
@@ -448,7 +448,7 @@ class SpecimenImagingPreparationProtocol(Protocol):
     The process to prepare biological entity for imaging.
     """
 
-    signal_channel_information: Optional[List[SignalChannelInformation]] = Field(
+    signal_channel_information: List[SignalChannelInformation] = Field(
         default_factory=list,
         description="""Information about how channels in the image relate to image signal generation.""",
     )
@@ -586,14 +586,14 @@ class BioSample(ConfiguredBaseModel, AttributeMixin):
     biological_entity_description: str = Field(
         description="""A short description of the biological entity."""
     )
-    experimental_variable_description: Optional[List[str]] = Field(
+    experimental_variable_description: List[str] = Field(
         default_factory=list,
         description="""What is intentionally varied (e.g. time) between multiple entries in this study component""",
     )
-    extrinsic_variable_description: Optional[List[str]] = Field(
+    extrinsic_variable_description: List[str] = Field(
         default_factory=list, description="External treatment (e.g. reagent)."
     )
-    intrinsic_variable_description: Optional[List[str]] = Field(
+    intrinsic_variable_description: List[str] = Field(
         default_factory=list, description="Intrinsic (e.g. genetic) alteration."
     )
 


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/8698nhx0n

This reason for this PR was due to one of the issues encountered during getting EMPIAR data into the API / switching from the shared data models to the API models. Something should probably be changed to avoid issues, this solution is probably 1 of 2-3 options.

As an example, comparing the attribute field and the file_uri in image representations:

Generated models: 
- https://github.com/BioImage-Archive/bia-integrator/blob/main/clients/python/bia_integrator_api/models/image_representation.py

With fields:
-     attribute: Optional[List[Attribute]] = None
-     file_uri: List[StrictStr] = Field(description="URI(s) of the file(s) which together make up this image representation.")

Shared models: 
- https://github.com/BioImage-Archive/bia-integrator/blob/main/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py#L175
and 
- https://github.com/BioImage-Archive/bia-integrator/blob/main/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py#L313

With fields: 
- attribute: Optional[list[Attribute]] = Field(
        default_factory=list,
        description="""Freeform key-value pairs from user provided metadata (e.g. filelist data) and experimental fields.""",
    )
- file_uri: List[str] = Field(
        description="""URI(s) of the file(s) which together make up this image representation."""
    )

What this means is that the mock objects (and shared model tests, and anything using the shared models) expect/create a default to be created for these of [], but the API models create a default on null. Export ran into issues because BioStudies ingest used the shared models, and followed the expectations there, but EMPIAR ingest used client models - so the code had to be updated to also deal with all the null values.

A few extra points:
- I did not realise that the client creates models for sub-objects as well as the main objects! (E.g. Contributor has a class despite not being a root document)
- I did not realise that we have old models in there (e.g. experimentally_captured_image) we should delete these, but that's for a separate task.
- We should in general only use the client models, but I think that the expectations around the mock object should be better aligned with the client models

In order to resolve this potential confusion we could:

1. Make list fields non-optional. I believe this would update fastAPI to use the default_factory function. This would make our json objects easier to use: currently the website has to code defensively against both 'null' and '[]' to deal with situations where the is no data. I believe this would generally be a non-breaking change because we're just removing one possible option.
2. Make the default in the model for optional list fields None, rather than using default_factory. This would make the shared models more closely aligned with the client models. This also retains the expressiveness of 'null' vs '[]' as two different values - arguably this is similar to having checks for 'null' vs '""' for Optional strings. Our code has already been updated to deal with this case.
3. Do something to wrangle the fast api client generators to follow the shared models? (this seems unnecessarily complex, but including for completeness)

As someone who was writing the javascript for the website, I was leaning towards option 1 to make my code cleaner & general have fewer cases to worry about. I also kind of think that the promise of capturing 'user didn't provide a value for the field' and 'user intentionally provided a value that was null' rarely works out in practice & we still have to deal with cases where people fill in text fields with "N/A". 