### PR TITLE
added label field to image, and updated field names for physical dimensions of image representations

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -189,9 +189,9 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
             "file_uri": [
                 "https://dummy.uri.org",
             ],
-            "single_voxel_physical_size_x": 1,
-            "single_voxel_physical_size_y": 1,
-            "single_voxel_physical_size_z": 1,
+            "voxel_physical_size_x": 1,
+            "voxel_physical_size_y": 1,
+            "voxel_physical_size_z": 1,
             "size_x": 1,
             "size_y": 1,
             "size_z": 1,

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -168,6 +168,7 @@ def get_image_dict(completeness=Completeness.COMPLETE) -> dict:
             "original_file_reference_uuid": [
                 get_file_reference_dict()["uuid"],
             ],
+            "label": "Template image label",
         }
     return image
 
@@ -188,9 +189,9 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
             "file_uri": [
                 "https://dummy.uri.org",
             ],
-            "physical_size_x": 1,
-            "physical_size_y": 1,
-            "physical_size_z": 1,
+            "single_voxel_physical_size_x": 1,
+            "single_voxel_physical_size_y": 1,
+            "single_voxel_physical_size_z": 1,
             "size_x": 1,
             "size_y": 1,
             "size_z": 1,

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -307,7 +307,10 @@ class Image(ConfiguredBaseModel, AttributeMixin):
     The abstract notion of an image that can have many representions in different image formats. A BIA image has been created from a unique set of File References.
     """
 
-    pass
+    label: Optional[str] = Field(
+        None,
+        description="""Optional human readable label describing or titling the image.""",
+    )
 
 
 class ImageRepresentation(ConfiguredBaseModel, AttributeMixin):
@@ -326,17 +329,17 @@ class ImageRepresentation(ConfiguredBaseModel, AttributeMixin):
     total_size_in_bytes: int = Field(
         description="""Combined disc size in bytes of all the files."""
     )
-    physical_size_x: Optional[float] = Field(
+    single_voxel_physical_size_x: Optional[float] = Field(
         None,
-        description="""Size of the physical space (in meters) captured in the field of view of the image.""",
+        description="""Size of the physical space (in meters) captured by a single pixel or voxel of the image.""",
     )
-    physical_size_y: Optional[float] = Field(
+    single_voxel_physical_size_y: Optional[float] = Field(
         None,
-        description="""Size of the physical space (in meters) captured in the field of view of the image.""",
+        description="""Size of the physical space (in meters) captured by a single pixel or voxel of the image.""",
     )
-    physical_size_z: Optional[float] = Field(
+    single_voxel_physical_size_z: Optional[float] = Field(
         None,
-        description="""Size of the physical space (in meters) captured in the field of view of the image.""",
+        description="""Size of the physical space (in meters) captured by a single pixel or voxel of the image.""",
     )
     size_x: Optional[int] = Field(
         None,
@@ -356,7 +359,7 @@ class ImageRepresentation(ConfiguredBaseModel, AttributeMixin):
     )
     size_t: Optional[int] = Field(
         None,
-        description="""Size of temporal dimension of the data array of the image.""",
+        description="""Number of timesteps in the temporal dimension of the data array of the image.""",
     )
     image_viewer_setting: Optional[List[RenderedView]] = Field(
         default_factory=list,

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -329,15 +329,15 @@ class ImageRepresentation(ConfiguredBaseModel, AttributeMixin):
     total_size_in_bytes: int = Field(
         description="""Combined disc size in bytes of all the files."""
     )
-    single_voxel_physical_size_x: Optional[float] = Field(
+    voxel_physical_size_x: Optional[float] = Field(
         None,
         description="""Size of the physical space (in meters) captured by a single pixel or voxel of the image.""",
     )
-    single_voxel_physical_size_y: Optional[float] = Field(
+    voxel_physical_size_y: Optional[float] = Field(
         None,
         description="""Size of the physical space (in meters) captured by a single pixel or voxel of the image.""",
     )
-    single_voxel_physical_size_z: Optional[float] = Field(
+    voxel_physical_size_z: Optional[float] = Field(
         None,
         description="""Size of the physical space (in meters) captured by a single pixel or voxel of the image.""",
     )


### PR DESCRIPTION
Update to image representation fields to make it clear that we expect single voxel size and not the physical size captured by the whole field of view. This aligns it with the OME-ZARR data model, that only captures the information for the single pixel.

Additionally, especially for EMPIAR sumbission, adding an optional label field for images for some kind of human-reable title would be useful for the website.