### PR TITLE
changes to attributes, provenance, and adding document creator

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/attribute_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/attribute_models.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import List, Optional, Any
+from typing import Optional, Any
 from typing_extensions import Self
 
-from pydantic import BaseModel, Field, model_validator, field_validator, ValidationError
-from .semantic_models import Attribute, AttributeProvenance
+from pydantic import BaseModel, Field, model_validator, field_validator
+from .semantic_models import Attribute, Provenance
 from uuid import UUID
 
 # For shared models that are placed inside Attribute objects
@@ -38,10 +38,10 @@ class DatasetAssociationAttribute(Attribute, SubAttributeMixin):
 
     @field_validator("provenance", mode="after")
     @classmethod
-    def attribute_provenance(cls, value: AttributeProvenance) -> AttributeProvenance:
-        if value != AttributeProvenance.bia_ingest:
+    def attribute_provenance(cls, value: Provenance) -> Provenance:
+        if value != Provenance.bia_ingest:
             raise ValueError(
-                f"Provenance for this type of attribute must be {AttributeProvenance.bia_ingest}"
+                f"Provenance for this type of attribute must be {Provenance.bia_ingest}"
             )
 
         return value
@@ -74,10 +74,10 @@ class DatasetAssociatedUUIDAttribute(Attribute, SubAttributeMixin):
 
     @field_validator("provenance", mode="after")
     @classmethod
-    def attribute_provenance(cls, value: AttributeProvenance) -> AttributeProvenance:
-        if value != AttributeProvenance.bia_ingest:
+    def attribute_provenance(cls, value: Provenance) -> Provenance:
+        if value != Provenance.bia_ingest:
             raise ValueError(
-                f"Provenance for this type of attribute must be {AttributeProvenance.bia_ingest}"
+                f"Provenance for this type of attribute must be {Provenance.bia_ingest}"
             )
         return value
 

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -33,7 +33,7 @@ class DocumentMixin(BaseModel):
         description="""Unique ID (across the BIA database) used to refer to and identify a document."""
     )
     object_creator: semantic_models.Provenance = Field(
-        description="""BIA internal type to track the creator/source of the object.""",
+        description="""BIA internal type to track the source of the object.""",
     )
 
     # !!!!

--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -32,6 +32,9 @@ class DocumentMixin(BaseModel):
     uuid: UUID = Field(
         description="""Unique ID (across the BIA database) used to refer to and identify a document."""
     )
+    object_creator: semantic_models.Provenance = Field(
+        description="""BIA internal type to track the creator/source of the object.""",
+    )
 
     # !!!!
     # EXTREMELY important that this field is validated

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -31,7 +31,7 @@ def get_study_dict(completeness=Completeness.COMPLETE) -> dict:
         "release_date": "2024-06-23",
         "version": 1,
         "description": "Template description",
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_ingest,
     }
 
     if completeness == Completeness.COMPLETE:
@@ -163,7 +163,7 @@ def get_image_dict(completeness=Completeness.COMPLETE) -> dict:
         "submission_dataset_uuid": get_dataset_dict()["uuid"],
         "original_file_reference_uuid": [],
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_image_assignment,
     }
     if completeness == Completeness.COMPLETE:
         image |= {
@@ -186,7 +186,7 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
         "total_size_in_bytes": 0,
         "file_uri": [],
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_image_conversion,
     }
     if completeness == Completeness.COMPLETE:
         image_representation |= {
@@ -246,7 +246,7 @@ def get_annotation_data_dict(completeness=Completeness.COMPLETE) -> dict:
         "submission_dataset_uuid": get_dataset_dict()["uuid"],
         "original_file_reference_uuid": [],
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_curation,
     }
     if completeness == Completeness.COMPLETE:
         annotation_data |= {
@@ -269,7 +269,7 @@ def get_creation_process_dict(completeness=Completeness.COMPLETE) -> dict:
     process = {
         "uuid": uuid4(),
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_image_assignment,
     }
     if completeness == Completeness.COMPLETE:
         process |= {
@@ -298,7 +298,7 @@ def get_protocol_dict(completeness=Completeness.COMPLETE) -> dict:
         "title_id": title_id,
         "protocol_description": "Template method description",
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_ingest,
     }
     if completeness == Completeness.COMPLETE:
         protocol |= {
@@ -321,7 +321,7 @@ def get_image_acquisition_protocol_dict(completeness=Completeness.COMPLETE) -> d
         "protocol_description": "Template method description",
         "imaging_instrument_description": "Template imaging instrument",
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_ingest,
     }
     if completeness == Completeness.COMPLETE:
         image_acquisition_protocol |= {
@@ -347,7 +347,7 @@ def get_annotation_method_dict(completeness=Completeness.COMPLETE) -> dict:
         "protocol_description": "Template annotation method description",
         "method_type": [],
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_ingest,
     }
     if completeness == Completeness.COMPLETE:
         annotation_method |= {
@@ -404,7 +404,7 @@ def get_specimen_dict(completeness=Completeness.COMPLETE) -> dict:
             get_biosample_dict()["uuid"],
         ],
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_image_assignment,
     }
     if completeness == Completeness.COMPLETE:
         specimen |= {
@@ -426,7 +426,7 @@ def get_specimen_imaging_preparation_protocol_dict(
         "title_id": title_id,
         "protocol_description": "Test description",
         "version": 1,
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_ingest,
     }
     if completeness == Completeness.COMPLETE:
         specimen_imaging_preparation_protocol |= {
@@ -463,7 +463,7 @@ def get_biosample_dict(completeness=Completeness.COMPLETE) -> dict:
         "biological_entity_description": "Test biological entity description",
         "version": 1,
         "organism_classification": [],
-        "object_creator": semantic_models.Provenance.submitter,
+        "object_creator": semantic_models.Provenance.bia_ingest,
     }
     if completeness == Completeness.COMPLETE:
         biosample |= {

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -31,6 +31,7 @@ def get_study_dict(completeness=Completeness.COMPLETE) -> dict:
         "release_date": "2024-06-23",
         "version": 1,
         "description": "Template description",
+        "object_creator": semantic_models.Provenance.submitter,
     }
 
     if completeness == Completeness.COMPLETE:
@@ -47,7 +48,7 @@ def get_study_dict(completeness=Completeness.COMPLETE) -> dict:
                 "Template keyword2",
             ],
             "model": {"type_name": "Study", "version": 2},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
 
     return study_dict
@@ -109,6 +110,7 @@ def get_dataset_dict(
         "title_id": title_id,
         "example_image_uri": [],
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         dataset |= {
@@ -121,7 +123,7 @@ def get_dataset_dict(
             ],
             "example_image_uri": ["https://dummy.url.org"],
             "model": {"type_name": "Dataset", "version": 1},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return dataset
 
@@ -138,11 +140,12 @@ def get_file_reference_dict(completeness=Completeness.COMPLETE) -> dict:
         "uri": "https://dummy.uri.co",
         "submission_dataset_uuid": get_dataset_dict()["uuid"],
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         file_reference |= {
             "model": {"type_name": "FileReference", "version": 2},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return file_reference
 
@@ -160,11 +163,12 @@ def get_image_dict(completeness=Completeness.COMPLETE) -> dict:
         "submission_dataset_uuid": get_dataset_dict()["uuid"],
         "original_file_reference_uuid": [],
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         image |= {
             "model": {"type_name": "Image", "version": 1},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "original_file_reference_uuid": [
                 get_file_reference_dict()["uuid"],
             ],
@@ -182,6 +186,7 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
         "total_size_in_bytes": 0,
         "file_uri": [],
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         image_representation |= {
@@ -200,7 +205,7 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
                 get_rendered_view_dict(),
             ],
             "model": {"type_name": "ImageRepresentation", "version": 3},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return image_representation
 
@@ -214,7 +219,7 @@ def get_rendered_view_dict(completeness=Completeness.COMPLETE) -> dict:
             "channel_information": [
                 get_channel_dict(Completeness.COMPLETE),
             ],
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return rendered_view
 
@@ -228,7 +233,7 @@ def get_channel_dict(completeness=Completeness.COMPLETE) -> dict:
         channel |= {
             "scale_factor": 1.0,
             "label": "Template label",
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return channel
 
@@ -241,11 +246,12 @@ def get_annotation_data_dict(completeness=Completeness.COMPLETE) -> dict:
         "submission_dataset_uuid": get_dataset_dict()["uuid"],
         "original_file_reference_uuid": [],
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         annotation_data |= {
             "model": {"type_name": "AnnotationData", "version": 1},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "original_file_reference_uuid": [
                 get_file_reference_dict()["uuid"],
             ],
@@ -263,6 +269,7 @@ def get_creation_process_dict(completeness=Completeness.COMPLETE) -> dict:
     process = {
         "uuid": uuid4(),
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         process |= {
@@ -276,7 +283,7 @@ def get_creation_process_dict(completeness=Completeness.COMPLETE) -> dict:
             ],
             "protocol_uuid": [get_protocol_dict()["uuid"]],
             "annotation_method_uuid": [get_annotation_method_dict()["uuid"]],
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
 
     return process
@@ -291,11 +298,12 @@ def get_protocol_dict(completeness=Completeness.COMPLETE) -> dict:
         "title_id": title_id,
         "protocol_description": "Template method description",
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         protocol |= {
             "model": {"type_name": "Protocol", "version": 2},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
 
     return protocol
@@ -313,6 +321,7 @@ def get_image_acquisition_protocol_dict(completeness=Completeness.COMPLETE) -> d
         "protocol_description": "Template method description",
         "imaging_instrument_description": "Template imaging instrument",
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         image_acquisition_protocol |= {
@@ -322,7 +331,7 @@ def get_image_acquisition_protocol_dict(completeness=Completeness.COMPLETE) -> d
             "imaging_method_name": [
                 "Template imaging method name",
             ],
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "model": {"type_name": "ImageAcquisitionProtocol", "version": 2},
         }
     return image_acquisition_protocol
@@ -338,6 +347,7 @@ def get_annotation_method_dict(completeness=Completeness.COMPLETE) -> dict:
         "protocol_description": "Template annotation method description",
         "method_type": [],
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         annotation_method |= {
@@ -347,7 +357,7 @@ def get_annotation_method_dict(completeness=Completeness.COMPLETE) -> dict:
             "spatial_information": "Template spatial information",
             "method_type": [semantic_models.AnnotationMethodType.class_labels],
             "annotation_source_indicator": semantic_models.AnnotationSourceIndicator.metadata_file,
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "model": {"type_name": "AnnotationMethod", "version": 3},
         }
     return annotation_method
@@ -359,7 +369,7 @@ def get_image_analysis_method_dict(completeness=Completeness.COMPLETE) -> dict:
     }
     if completeness == Completeness.COMPLETE:
         image_analysis_method |= {
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "features_analysed": "Template features analysed",
         }
     return image_analysis_method
@@ -371,7 +381,7 @@ def get_image_correlation_method_dict(completeness=Completeness.COMPLETE) -> dic
     }
     if completeness == Completeness.COMPLETE:
         image_correlation_method |= {
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "fiducials_used": "Template fiducials used",
             "transformation_matrix": "Template transformation matrix",
         }
@@ -394,11 +404,12 @@ def get_specimen_dict(completeness=Completeness.COMPLETE) -> dict:
             get_biosample_dict()["uuid"],
         ],
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         specimen |= {
             "model": {"type_name": "Specimen", "version": 2},
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return specimen
 
@@ -415,13 +426,14 @@ def get_specimen_imaging_preparation_protocol_dict(
         "title_id": title_id,
         "protocol_description": "Test description",
         "version": 1,
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         specimen_imaging_preparation_protocol |= {
             "signal_channel_information": [
                 get_signal_channel_information_dict(Completeness.COMPLETE)
             ],
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "model": {
                 "type_name": "SpecimenImagingPreparationProtocol",
                 "version": 2,
@@ -437,7 +449,7 @@ def get_signal_channel_information_dict(completeness=Completeness.COMPLETE) -> d
             "signal_contrast_mechanism_description": "Test description",
             "channel_content_description": "Test description",
             "channel_biological_entity": "Test Entity",
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return signal_channel_information
 
@@ -451,6 +463,7 @@ def get_biosample_dict(completeness=Completeness.COMPLETE) -> dict:
         "biological_entity_description": "Test biological entity description",
         "version": 1,
         "organism_classification": [],
+        "object_creator": semantic_models.Provenance.submitter,
     }
     if completeness == Completeness.COMPLETE:
         biosample |= {
@@ -467,7 +480,7 @@ def get_biosample_dict(completeness=Completeness.COMPLETE) -> dict:
                 "Description of internal treatment",
             ],
             "growth_protocol_uuid": get_protocol_dict()["uuid"],
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
             "model": {"type_name": "BioSample", "version": 3},
         }
     return biosample
@@ -480,7 +493,7 @@ def get_taxon_dict(completeness=Completeness.COMPLETE) -> dict:
             "common_name": "Test Common Name",
             "scientific_name": "Test Scientific Name",
             "ncbi_id": "Test_NCBI_ID",
-            "attribute": [get_attribute_dict()],
+            "additional_metadata": [get_attribute_dict()],
         }
     return taxon
 
@@ -492,7 +505,7 @@ def get_taxon_dict(completeness=Completeness.COMPLETE) -> dict:
 
 def get_attribute_dict(completeness=Completeness.COMPLETE) -> dict:
     attribute = {
-        "provenance": semantic_models.AttributeProvenance.submittor,
+        "provenance": semantic_models.Provenance.submitter,
         "name": "file_list_columns",
         "value": {},
     }
@@ -501,7 +514,7 @@ def get_attribute_dict(completeness=Completeness.COMPLETE) -> dict:
 
 def get_dataset_associated_uuid_attribute(completeness=Completeness.COMPLETE) -> dict:
     attribute = {
-        "provenance": semantic_models.AttributeProvenance.bia_ingest,
+        "provenance": semantic_models.Provenance.bia_ingest,
         "name": "protocol_uuid",
         "value": {"protocol_uuid": [str(get_protocol_dict()["uuid"])]},
     }
@@ -510,7 +523,7 @@ def get_dataset_associated_uuid_attribute(completeness=Completeness.COMPLETE) ->
 
 def get_dataset_associatation_attribute(completeness=Completeness.COMPLETE) -> dict:
     attribute = {
-        "provenance": semantic_models.AttributeProvenance.bia_ingest,
+        "provenance": semantic_models.Provenance.bia_ingest,
         "name": "associations",
         "value": {"associations": []},
     }

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -47,7 +47,6 @@ class AttributeMixin(BaseModel):
     """
 
     additional_metadata: List[Attribute] = Field(
-        breaking_model_changes_2025_04
         default_factory=list,
         description="""Freeform key-value pairs that don't otherwise fit our data model, potentially from user provided metadata, BIA curation, and experimental fields.""",
     )

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -22,7 +22,9 @@ class Provenance(str, Enum):
 
     bia_ingest = "bia_ingest"
 
-    bia_conversion = "bia_conversion"
+    bia_image_assignment = "bia_image_assignment"
+
+    bia_image_conversion = "bia_image_conversion"
 
     bia_curation = "bia_curation"
 

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -46,7 +46,7 @@ class AttributeMixin(BaseModel):
     Mixin for just the attribute field
     """
 
-    additional_metadata: List[Attribute]] = Field(
+    additional_metadata: List[Attribute] = Field(
         breaking_model_changes_2025_04
         default_factory=list,
         description="""Freeform key-value pairs that don't otherwise fit our data model, potentially from user provided metadata, BIA curation, and experimental fields.""",

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -17,8 +17,8 @@ class ConfiguredBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class AttributeProvenance(str, Enum):
-    submittor = "submittor"
+class Provenance(str, Enum):
+    submitter = "submitter"
 
     bia_ingest = "bia_ingest"
 
@@ -28,7 +28,7 @@ class AttributeProvenance(str, Enum):
 
 
 class Attribute(ConfiguredBaseModel):
-    provenance: AttributeProvenance = Field(
+    provenance: Provenance = Field(
         description="The category of the source of the annotaton"
     )
     name: str = Field(
@@ -44,9 +44,9 @@ class AttributeMixin(BaseModel):
     Mixin for just the attribute field
     """
 
-    attribute: Optional[list[Attribute]] = Field(
+    additional_metadata: Optional[list[Attribute]] = Field(
         default_factory=list,
-        description="""Freeform key-value pairs from user provided metadata (e.g. filelist data) and experimental fields.""",
+        description="""Freeform key-value pairs that don't otherwise fit our data model, potentially from user provided metadata, BIA curation, and experimental fields.""",
     )
 
 


### PR DESCRIPTION
ticket: https://app.clickup.com/t/8698nhwmm

This PR aims to address our need to keep track of the source of data. Now that we have multiple ingestion sources and processes it is much less clear what the source of an object was.  We currently use AttributeProvenace to track the provenance of Attribute objects inside other objects. This extends the use of AttributeProvenance to a general Provenance enum for use on objects as well so we can capture source of objects. 

The change also includes renaming the attribute field to additional_metadata - which is somewhat more descriptive for such a general field - but importantly less confusing since attribute is an already overloaded term. 

Some areas which aren't addressed in the PR (yet) and would be good to encode in comments on the Provenance enum / would mean changes to the enum:
1. Do we want additional values to track whether something was e.g. ingested from EMPIAR vs ingested from Biostudies, or the output of image assignment from an empiar entry.
2. Additional clarity on when one value should be used vs another - should this just be based on the name of our code packages (including what source they're designed to process if it's not mentioned?)

I've not gone with making the submitter the default value (though the mock objects use it since they need _some_ value) because i suspect it won't be the default for most objects. From a discussion on Wednesday, it seems as though we may store 'what gets sent to us' separately (i.e. what's in biostudies, empiar, and in the future something else for maybe ro-crate objects?). So technically none of the objects would use the submitter value, as it would always be some part of our pipeline creating the object (and that is what we want to track). But it would still be useful to have a submitter value for tracking annotations data (in that here's some extra data written & structured by the submitter, not us)