### PR TITLE
update title_id field name to title

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -140,12 +140,6 @@ class DocumentMixin(BaseModel):
         return fields_filtered
 
 
-class UserIdentifiedObject(BaseModel):
-    title_id: str = Field(
-        description="""User provided title, which is unqiue within a submission, used to identify a part of a submission."""
-    )
-
-
 #######################################################################################################
 # Subgraph 1: Studies and links to external information (publications, grants etc)
 #######################################################################################################
@@ -168,7 +162,6 @@ class Study(
 class Dataset(
     semantic_models.Dataset,
     DocumentMixin,
-    UserIdentifiedObject,
 ):
     submitted_in_study_uuid: Annotated[UUID, ObjectReference(Study)] = Field()
 
@@ -279,14 +272,13 @@ class CreationProcess(semantic_models.CreationProcess, DocumentMixin):
     model_config = ConfigDict(model_version_latest=2)
 
 
-class Protocol(semantic_models.Protocol, DocumentMixin, UserIdentifiedObject):
+class Protocol(semantic_models.Protocol, DocumentMixin):
     model_config = ConfigDict(model_version_latest=2)
 
 
 class ImageAcquisitionProtocol(
     semantic_models.ImageAcquisitionProtocol,
     DocumentMixin,
-    UserIdentifiedObject,
 ):
     model_config = ConfigDict(model_version_latest=2)
 
@@ -294,7 +286,6 @@ class ImageAcquisitionProtocol(
 class SpecimenImagingPreparationProtocol(
     semantic_models.SpecimenImagingPreparationProtocol,
     DocumentMixin,
-    UserIdentifiedObject,
 ):
     model_config = ConfigDict(model_version_latest=2)
 
@@ -302,7 +293,6 @@ class SpecimenImagingPreparationProtocol(
 class BioSample(
     semantic_models.BioSample,
     DocumentMixin,
-    UserIdentifiedObject,
 ):
     model_config = ConfigDict(model_version_latest=3)
     growth_protocol_uuid: Annotated[Optional[UUID], ObjectReference(Protocol)] = Field(
@@ -314,7 +304,6 @@ class BioSample(
 class AnnotationMethod(
     semantic_models.AnnotationMethod,
     DocumentMixin,
-    UserIdentifiedObject,
 ):
     model_config = ConfigDict(model_version_latest=3)
 

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -100,13 +100,13 @@ def get_affiliation_dict(
 def get_dataset_dict(
     completeness=Completeness.COMPLETE,
 ) -> dict:
-    title_id = "Template experimental image dataset"
+    title = "Template experimental image dataset"
     study_uuid = get_study_dict()["uuid"]
 
     dataset = {
-        "uuid": uuid_creation.create_dataset_uuid(title_id, study_uuid),
+        "uuid": uuid_creation.create_dataset_uuid(title, study_uuid),
         "submitted_in_study_uuid": study_uuid,
-        "title_id": title_id,
+        "title": title,
         "example_image_uri": [],
         "version": 1,
     }
@@ -284,11 +284,11 @@ def get_creation_process_dict(completeness=Completeness.COMPLETE) -> dict:
 
 def get_protocol_dict(completeness=Completeness.COMPLETE) -> dict:
     study_uuid = get_study_dict()["uuid"]
-    title_id = "Template image acquisition"
+    title = "Template image acquisition"
 
     protocol = {
-        "uuid": uuid_creation.create_protocol_uuid(title_id, study_uuid),
-        "title_id": title_id,
+        "uuid": uuid_creation.create_protocol_uuid(title, study_uuid),
+        "title": title,
         "protocol_description": "Template method description",
         "version": 1,
     }
@@ -303,13 +303,11 @@ def get_protocol_dict(completeness=Completeness.COMPLETE) -> dict:
 
 def get_image_acquisition_protocol_dict(completeness=Completeness.COMPLETE) -> dict:
     study_uuid = get_study_dict()["uuid"]
-    title_id = "Template image acquisition"
+    title = "Template image acquisition"
 
     image_acquisition_protocol = {
-        "uuid": uuid_creation.create_image_acquisition_protocol_uuid(
-            title_id, study_uuid
-        ),
-        "title_id": title_id,
+        "uuid": uuid_creation.create_image_acquisition_protocol_uuid(title, study_uuid),
+        "title": title,
         "protocol_description": "Template method description",
         "imaging_instrument_description": "Template imaging instrument",
         "version": 1,
@@ -330,11 +328,11 @@ def get_image_acquisition_protocol_dict(completeness=Completeness.COMPLETE) -> d
 
 def get_annotation_method_dict(completeness=Completeness.COMPLETE) -> dict:
     study_uuid = get_study_dict()["uuid"]
-    title_id = "Template annotation method"
+    title = "Template annotation method"
 
     annotation_method = {
-        "uuid": uuid_creation.create_annotation_method_uuid(title_id, study_uuid),
-        "title_id": title_id,
+        "uuid": uuid_creation.create_annotation_method_uuid(title, study_uuid),
+        "title": title,
         "protocol_description": "Template annotation method description",
         "method_type": [],
         "version": 1,
@@ -356,6 +354,7 @@ def get_annotation_method_dict(completeness=Completeness.COMPLETE) -> dict:
 def get_image_analysis_method_dict(completeness=Completeness.COMPLETE) -> dict:
     image_analysis_method = {
         "protocol_description": "Template Analysis method",
+        "title": "Template analysis method title",
     }
     if completeness == Completeness.COMPLETE:
         image_analysis_method |= {
@@ -368,6 +367,7 @@ def get_image_analysis_method_dict(completeness=Completeness.COMPLETE) -> dict:
 def get_image_correlation_method_dict(completeness=Completeness.COMPLETE) -> dict:
     image_correlation_method = {
         "protocol_description": "Template Analysis method",
+        "title": "Template correlation method title",
     }
     if completeness == Completeness.COMPLETE:
         image_correlation_method |= {
@@ -407,12 +407,12 @@ def get_specimen_imaging_preparation_protocol_dict(
     completeness=Completeness.COMPLETE,
 ) -> dict:
     study_uuid = get_study_dict()["uuid"]
-    title_id = "Test specimen preparation protocol"
+    title = "Test specimen preparation protocol"
     specimen_imaging_preparation_protocol = {
         "uuid": uuid_creation.create_specimen_imaging_preparation_protocol_uuid(
-            title_id, study_uuid
+            title, study_uuid
         ),
-        "title_id": title_id,
+        "title": title,
         "protocol_description": "Test description",
         "version": 1,
     }
@@ -444,10 +444,10 @@ def get_signal_channel_information_dict(completeness=Completeness.COMPLETE) -> d
 
 def get_biosample_dict(completeness=Completeness.COMPLETE) -> dict:
     study_uuid = get_study_dict()["uuid"]
-    title_id = "Template BioSample"
+    title = "Template BioSample"
     biosample = {
-        "uuid": uuid_creation.create_bio_sample_uuid(title_id, study_uuid),
-        "title_id": title_id,
+        "uuid": uuid_creation.create_bio_sample_uuid(title, study_uuid),
+        "title": title,
         "biological_entity_description": "Test biological entity description",
         "version": 1,
         "organism_classification": [],

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -269,6 +269,7 @@ class Dataset(ConfiguredBaseModel, AttributeMixin):
     A logical collection of images that were created by the same acquisition and preparation procols being applied to a biosample.
     """
 
+    title: str = Field(description="""The title of a dataset.""")
     description: Optional[str] = Field(
         None, description="""Brief description of the dataset."""
     )
@@ -420,6 +421,7 @@ class Protocol(ConfiguredBaseModel, AttributeMixin):
     The description of a sequence of actions that were perfomed.
     """
 
+    title: str = Field(description="""The title of a protocol.""")
     protocol_description: str = Field(
         description="""Description of actions involved in the process."""
     )
@@ -580,6 +582,7 @@ class BioSample(ConfiguredBaseModel, AttributeMixin):
     The biological entity that has undergone preparation (as a Sample) in order to be imaged.
     """
 
+    title: str = Field(description="""The title of a bio-sample.""")
     organism_classification: List[Taxon] = Field(
         description="""The classification of th ebiological matter."""
     )


### PR DESCRIPTION
Updating title_id field to just title

The original name comes from the fact that certain objects in biostudies are referenced by their title in order to connect them to e.g. associations. However:
- Once the object is in the api, uuids are used to reference the object - the title_id only gets used as a title
- We now ingest data from other sources than biostudies, where the title is just a title, and not an id

It was also sort of being used as a way of indicating which objects a user was editing (in that it was a "user id'd object") - again this isn't the case with non-biostudies submission, and we hope to cover modelling this with this other PR: https://github.com/BioImage-Archive/bia-integrator/pull/329