### PR TITLE
added channel label to signal-channel-information

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -437,6 +437,7 @@ def get_signal_channel_information_dict(completeness=Completeness.COMPLETE) -> d
             "signal_contrast_mechanism_description": "Test description",
             "channel_content_description": "Test description",
             "channel_biological_entity": "Test Entity",
+            "channel_label": "Test label",
             "attribute": [get_attribute_dict()],
         }
     return signal_channel_information

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -469,6 +469,10 @@ class SignalChannelInformation(ConfiguredBaseModel, AttributeMixin):
     channel_biological_entity: Optional[str] = Field(
         None, description="""What molecule is stained."""
     )
+    channel_label: Optional[str] = Field(
+        default=None,
+        description="""Label in the image for the channel. Often this is some integer e.g. 1 or Channel 1""",
+    )
 
 
 class AnnotationMethod(Protocol):


### PR DESCRIPTION
Added channel label to signal channel info to allow a mapping from image data to dyes & signal frequency information - particularly useful when an image is composed of multiple channels, each from a different dye & imaging at different illumination frequencies.

ticket: https://app.clickup.com/t/8698nhwmm 