### PR TITLE
created uuid unique input attribute

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/attribute_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/attribute_models.py
@@ -107,3 +107,30 @@ class DatasetAssociatedUUIDAttribute(Attribute, SubAttributeMixin):
         return self
 
     value: dict[str, list[str]] = Field()
+
+
+class DocumentUUIDUinqueInputAttribute(Attribute, SubAttributeMixin):
+    """
+    Model for storing the string that was used to generate the uuid of the object.
+    Note this does not need to contain the type nor the study uuid, since those should be findable in the rest of the document / through object links.
+    """
+
+    @field_validator("name", mode="after")
+    @classmethod
+    def validate_attribute_name(cls, value) -> Self:
+        if value != "uuid_unique_input":
+            raise ValueError(
+                f"Name for this type of attribute must be 'uuid_unique_input'"
+            )
+        return value
+
+    @field_validator("value", mode="after")
+    @classmethod
+    def attribute_value(cls, value: dict) -> dict:
+        if len(value.keys()) != 1:
+            raise ValueError("Value dictionary should have exactly one 1 key")
+        elif "uuid_unique_input" not in value.keys():
+            raise ValueError(f'The value dictionary key must be "uuid_unique_input"')
+        return value
+
+    value: dict[str, str] = Field()

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -550,7 +550,7 @@ def get_document_uuid_uinque_input_attribute(
     completeness=Completeness.COMPLETE,
 ) -> dict:
     attribute = {
-        "provenance": semantic_models.AttributeProvenance.bia_ingest,
+        "provenance": semantic_models.Provenance.bia_ingest,
         "name": "uuid_unique_input",
         "value": {"uuid_unique_input": "Biosample-1"},
     }

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -544,3 +544,14 @@ def get_dataset_associatation_attribute(completeness=Completeness.COMPLETE) -> d
             }
         }
     return attribute
+
+
+def get_document_uuid_uinque_input_attribute(
+    completeness=Completeness.COMPLETE,
+) -> dict:
+    attribute = {
+        "provenance": semantic_models.AttributeProvenance.bia_ingest,
+        "name": "uuid_unique_input",
+        "value": {"uuid_unique_input": "Biosample-1"},
+    }
+    return attribute

--- a/bia-shared-datamodels/test/test_attribute_models.py
+++ b/bia-shared-datamodels/test/test_attribute_models.py
@@ -54,10 +54,7 @@ def test_sub_attribute_models(
         )
 
         # Check basic attribute doesn't pass validation
-        try:
+        with pytest.raises(ValidationError):
             expected_model_type.model_validate(
                 mock_objects.get_attribute_dict(model_completion)
             )
-            assert False
-        except ValidationError:
-            assert True

--- a/bia-shared-datamodels/test/test_attribute_models.py
+++ b/bia-shared-datamodels/test/test_attribute_models.py
@@ -19,6 +19,10 @@ from typing import Callable
             attribute_models.DatasetAssociationAttribute,
             mock_objects.get_dataset_associatation_attribute,
         ),
+        (
+            attribute_models.DocumentUUIDUinqueInputAttribute,
+            mock_objects.get_document_uuid_uinque_input_attribute,
+        ),
     ),
 )
 def test_sub_attribute_models(
@@ -49,7 +53,7 @@ def test_sub_attribute_models(
             sub_attribute_model
         )
 
-        # Check basic attribute doesn't pass validation 
+        # Check basic attribute doesn't pass validation
         try:
             expected_model_type.model_validate(
                 mock_objects.get_attribute_dict(model_completion)


### PR DESCRIPTION
Created sub-attribute to be used in any code that needs to create objects, in order to store the context of how the uuid was generated in the object sent to the api.

Only needed once uuid generation code has been merged from this branch.