### PR TITLE
Allow use of patterns during image assignment

### DIFF
--- a/bia-assign-image/README.md
+++ b/bia-assign-image/README.md
@@ -42,7 +42,8 @@ poetry run bia-assign-image assign-from-proposal proposals.txt
 
 This will create BIA Image objects and default representations for each proposed file reference.
 ### Manual Assignment
-To directly create a BIA Image from file references without using proposals, run:```sh
+To directly create a BIA Image from file references without using proposals, run:
+```sh
 poetry run bia-assign-image assign <STUDY ACCESSION ID> <LIST OF FILE REFERENCE UUIDS>
 ```
 E.g. Assuming the study S-BIAD1285 has been ingested:
@@ -50,11 +51,13 @@ E.g. Assuming the study S-BIAD1285 has been ingested:
 poetry run bia-assign-image assign S-BIAD1285 b768fb72-7ea2-4b80-b54d-bdf5ca280bfd
 ```
 ### Using patterns during assignment
-Multiple files (e.g. multichannel images or time series stored individually) can be assigned into one image if their filenames follow a predictable structure allowing the creation of a *file pattern*. E.g. the file pattern `image_01_channel_{%d}_slice_{%d}.tiff` can be used to combine the following four files into one 3D multichannel image:<br>
+The python [parse](https://github.com/r1chardj0n3s/parse) library is used for pattern matching. Multiple files (e.g. multichannel images or time series stored individually) can be assigned into one image if their filenames follow a predictable structure allowing the creation of a *file pattern*. E.g. the file pattern `image_01_channel_{c:d}_slice_{z:d}.tiff` can be used to combine the following four files into one 3D multichannel image:<br>
  image_01_channel_00_slice_00.tiff with uuid: 12345678-abcd-ef12-3456-012345678900<br>
  image_01_channel_01_slice_00.tiff with uuid: 12345678-abcd-ef12-3456-012345678901<br>
  image_01_channel_00_slice_01.tiff with uuid: 12345678-abcd-ef12-3456-012345678902<br>
  image_01_channel_01_slice_01.tiff with uuid: 12345678-abcd-ef12-3456-012345678903<br>
+
+ In some cases the filenames required may not follow the ideal structure above e.g. `image_01_channel_00_slice_00.tiff` and `image_01_channel_00_slice1.tiff`. In such cases empty braces can be used to capture more general parts of the filenames - in the present case `image_01_channel_{c:d}_slice{}.tiff` will suffice.
 #### Using patterns in a yaml file
 In the yaml file, the entry for the image should contain a key called `pattern` with value of the pattern. The `file_reference_uuid` key should contain all the file references separated by spaces. The `assign_from_proposal` command can then be used. E.g. the yaml for the above example will be:
 ```
@@ -63,7 +66,7 @@ In the yaml file, the entry for the image should contain a key called `pattern` 
   dataset_uuid: dummy_dataset_uuid
   file_reference_uuid: "12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903"
   name: dummy_name
-  pattern: 'image_01_channel_{%d}_slice_{%d}.tiff'
+  pattern: 'image_01_channel_{c:d}_slice_{z:d}.tiff'
   study_uuid: dummy_study_uuid
 ```
 then run:
@@ -74,7 +77,7 @@ poetry run bia-assign-image assign-from-proposal example.yaml
 #### Using a pattern directly in the cli
 To directly create a BIA Image from the above file references and pattern, run:
 ```sh
-poetry run bia-assign-image assign --pattern 'image_01_channel_{%d}_slice_{%d}.tiff' S-BIADTEST 12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903
+poetry run bia-assign-image assign --pattern 'image_01_channel_{c:d}_slice_{z:d}.tiff' S-BIADTEST 12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903
 ```
 
 ### Creating representations (without conversion of images)

--- a/bia-assign-image/README.md
+++ b/bia-assign-image/README.md
@@ -42,13 +42,39 @@ poetry run bia-assign-image assign-from-proposal proposals.txt
 
 This will create BIA Image objects and default representations for each proposed file reference.
 ### Manual Assignment
-To directly create a BIA Image from file references without using proposals, run:
-```sh
+To directly create a BIA Image from file references without using proposals, run:```sh
 poetry run bia-assign-image assign <STUDY ACCESSION ID> <LIST OF FILE REFERENCE UUIDS>
 ```
 E.g. Assuming the study S-BIAD1285 has been ingested:
 ```sh
 poetry run bia-assign-image assign S-BIAD1285 b768fb72-7ea2-4b80-b54d-bdf5ca280bfd
+```
+### Using patterns during assignment
+Multiple files (e.g. multichannel images or time series stored individually) can be assigned into one image if their filenames follow a predictable structure allowing the creation of a *file pattern*. E.g. the file pattern `image_01_channel_{%d}_slice_{%d}.tiff` can be used to combine the following four files into one 3D multichannel image:<br>
+ image_01_channel_00_slice_00.tiff with uuid: 12345678-abcd-ef12-3456-012345678900<br>
+ image_01_channel_01_slice_00.tiff with uuid: 12345678-abcd-ef12-3456-012345678901<br>
+ image_01_channel_00_slice_01.tiff with uuid: 12345678-abcd-ef12-3456-012345678902<br>
+ image_01_channel_01_slice_01.tiff with uuid: 12345678-abcd-ef12-3456-012345678903<br>
+#### Using patterns in a yaml file
+In the yaml file, the entry for the image should contain a key called `pattern` with value of the pattern. The `file_reference_uuid` key should contain all the file references separated by spaces. The `assign_from_proposal` command can then be used. E.g. the yaml for the above example will be:
+```
+---
+- accession_id: S-BIADTEST
+  dataset_uuid: dummy_dataset_uuid
+  file_reference_uuid: "12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903"
+  name: dummy_name
+  pattern: 'image_01_channel_{%d}_slice_{%d}_time{%d}'
+  study_uuid: dummy_study_uuid
+```
+then run:
+```sh
+poetry run bia-assign-image assign-from-proposal example.yaml
+```
+
+#### Using a pattern directly in the cli
+To directly create a BIA Image from the above file references and pattern, run:
+```sh
+poetry run bia-assign-image assign --pattern 'image_01_channel_{%d}_slice_{%d}_time{%d}' S-BIADTEST 12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903
 ```
 
 ### Creating representations (without conversion of images)

--- a/bia-assign-image/README.md
+++ b/bia-assign-image/README.md
@@ -63,7 +63,7 @@ In the yaml file, the entry for the image should contain a key called `pattern` 
   dataset_uuid: dummy_dataset_uuid
   file_reference_uuid: "12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903"
   name: dummy_name
-  pattern: 'image_01_channel_{%d}_slice_{%d}_time{%d}'
+  pattern: 'image_01_channel_{%d}_slice_{%d}.tiff'
   study_uuid: dummy_study_uuid
 ```
 then run:
@@ -74,7 +74,7 @@ poetry run bia-assign-image assign-from-proposal example.yaml
 #### Using a pattern directly in the cli
 To directly create a BIA Image from the above file references and pattern, run:
 ```sh
-poetry run bia-assign-image assign --pattern 'image_01_channel_{%d}_slice_{%d}_time{%d}' S-BIADTEST 12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903
+poetry run bia-assign-image assign --pattern 'image_01_channel_{%d}_slice_{%d}.tiff' S-BIADTEST 12345678-abcd-ef12-3456-012345678900 12345678-abcd-ef12-3456-012345678901 12345678-abcd-ef12-3456-012345678902 12345678-abcd-ef12-3456-012345678903
 ```
 
 ### Creating representations (without conversion of images)

--- a/bia-assign-image/bia_assign_image/cli.py
+++ b/bia-assign-image/bia_assign_image/cli.py
@@ -151,6 +151,16 @@ def assign(
         logger.info(
             f"Generated bia_data_model.Image object {bia_image.uuid} and persisted to {api_target} API"
         )
+
+    if not dryrun:
+        # Create default representation
+        create(
+            accession_id=accession_id,
+            image_uuid_list=[
+                f"{bia_image.uuid}",
+            ],
+            api_target=api_target,
+        )
     return str(bia_image.uuid)
 
 
@@ -226,7 +236,7 @@ def assign_from_proposal(
         ]
         pattern = p.get("pattern", None)
         try:
-            image_uuid = assign(
+            assign(
                 accession_id=accession_id,
                 file_reference_uuids=file_reference_uuids,
                 api_target=api_target,
@@ -238,14 +248,6 @@ def assign_from_proposal(
                 f"Could not assign image for {accession_id} with file reference(s) {file_reference_uuids}. Error was {e}"
             )
             continue
-
-        if not dryrun:
-            # Create default representation
-            create(
-                accession_id=p["accession_id"],
-                image_uuid_list=[image_uuid],
-                api_target=api_target,
-            )
 
 
 @app.command(help="Propose file references to convert for an accession")

--- a/bia-assign-image/bia_assign_image/cli.py
+++ b/bia-assign-image/bia_assign_image/cli.py
@@ -63,6 +63,9 @@ def assign(
     api_target: Annotated[
         ApiTarget, typer.Option("--api", "-a", case_sensitive=False)
     ] = ApiTarget.prod,
+    pattern: Annotated[
+        str | None, typer.Option("--pattern", "-p", case_sensitive=False)
+    ] = None,
     dryrun: Annotated[bool, typer.Option()] = False,
 ) -> str:
     api_client = get_api_client(api_target)
@@ -139,6 +142,7 @@ def assign(
         submission_dataset_uuid,
         bia_creation_process.uuid,
         file_references=file_references,
+        file_pattern=pattern,
     )
     if dryrun:
         logger.info(f"Dryrun: Created Image(s) {bia_image}, but not persisting.")
@@ -220,11 +224,13 @@ def assign_from_proposal(
         file_reference_uuids = [
             p["file_reference_uuid"],
         ]
+        pattern = p.get("pattern", None)
         try:
             image_uuid = assign(
                 accession_id=accession_id,
                 file_reference_uuids=file_reference_uuids,
                 api_target=api_target,
+                pattern=pattern,
                 dryrun=dryrun,
             )
         except AssertionError as e:

--- a/bia-assign-image/bia_assign_image/image_representation.py
+++ b/bia-assign-image/bia_assign_image/image_representation.py
@@ -34,10 +34,15 @@ def get_image_representation(
     #   - thumbnail and static display are png
     #   - interactive display is ome.zarr
     if use_type == semantic_models.ImageRepresentationUseType.UPLOADED_BY_SUBMITTER:
-        # TODO: Revisit this block of code when we start many file_refs->one_image
-        # assert len(file_references) == 1
-        image_format = get_image_extension(file_references[0].file_path)
-        total_size_in_bytes = file_references[0].size_in_bytes
+        # TODO: Confirm convention below with BIA team i.e. csv of sorted unique image formats
+        image_format_list = [get_image_extension(f.file_path) for f in file_references]
+        image_format_set = set(image_format_list)
+        image_format_list = list(image_format_set)
+        image_format_list.sort()
+        image_format = ",".join(image_format_list)
+
+        # Sum size of all file references
+        total_size_in_bytes = sum([f.size_in_bytes for f in file_references])
 
         # Copy file_pattern from image if it exists (only for UPLOADED_BY_SUBMITTER rep)
         file_pattern = next(
@@ -64,9 +69,7 @@ def get_image_representation(
     file_uri_list = []
     if file_uri == "":
         if use_type == semantic_models.ImageRepresentationUseType.UPLOADED_BY_SUBMITTER:
-            file_uri_list.append(
-                file_references[0].uri,
-            )
+            file_uri_list.extend([f.uri for f in file_references])
     else:
         file_uri_list.append(file_uri)
 

--- a/bia-assign-image/tests/conftest.py
+++ b/bia-assign-image/tests/conftest.py
@@ -7,13 +7,8 @@ import os
 from glob import glob
 
 
-@pytest.fixture(scope="session")
-def private_client():
-    return get_object_creation_client(settings.local_bia_api_basepath)
-
-
-@pytest.fixture(scope="session")
-def data_in_api(private_client):
+def data_in_api():
+    private_client = get_object_creation_client(settings.local_bia_api_basepath)
     input_file_dir = Path(__file__).parent / "input_data" / "**" / "*.json"
     file_path_list = glob(str(input_file_dir), recursive=True)
 
@@ -25,3 +20,9 @@ def data_in_api(private_client):
                 object_list.append(json_dict)
 
     add_objects_to_api(private_client, object_list)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):
+    """Runs before test modules are imported."""
+    data_in_api()

--- a/bia-assign-image/tests/data/creation_process/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/b5d98aa9-79ce-4106-90b2-d3687eac67f0.json
+++ b/bia-assign-image/tests/data/creation_process/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/b5d98aa9-79ce-4106-90b2-d3687eac67f0.json
@@ -1,0 +1,16 @@
+{
+  "uuid": "b5d98aa9-79ce-4106-90b2-d3687eac67f0",
+  "image_acquisition_protocol_uuid": [
+    "7586534d-459e-4316-b5d9-8e811ad7c321"
+  ],
+  "annotation_method_uuid": [],
+  "protocol_uuid": [],
+  "input_image_uuid": [],
+  "attribute": [],
+  "subject_specimen_uuid": "4a625c07-1615-4c1d-a834-0d2ae2955cf3",
+  "version": 0,
+  "model": {
+    "type_name": "CreationProcess",
+    "version": 2
+  }
+}

--- a/bia-assign-image/tests/data/creation_process/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/dc585a20-b308-44af-a49f-a563a1cee1ab.json
+++ b/bia-assign-image/tests/data/creation_process/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/dc585a20-b308-44af-a49f-a563a1cee1ab.json
@@ -1,0 +1,16 @@
+{
+  "uuid": "dc585a20-b308-44af-a49f-a563a1cee1ab",
+  "image_acquisition_protocol_uuid": [
+    "7586534d-459e-4316-b5d9-8e811ad7c321"
+  ],
+  "annotation_method_uuid": [],
+  "protocol_uuid": [],
+  "input_image_uuid": [],
+  "attribute": [],
+  "subject_specimen_uuid": "22fac32b-c8af-4ff3-a315-3e24cd16c51d",
+  "version": 0,
+  "model": {
+    "type_name": "CreationProcess",
+    "version": 2
+  }
+}

--- a/bia-assign-image/tests/data/image/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/5c429763-a56e-4650-ad91-291cdfe6d153.json
+++ b/bia-assign-image/tests/data/image/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/5c429763-a56e-4650-ad91-291cdfe6d153.json
@@ -1,0 +1,142 @@
+{
+  "uuid": "5c429763-a56e-4650-ad91-291cdfe6d153",
+  "version": 0,
+  "model": {
+    "type_name": "Image",
+    "version": 1
+  },
+
+  "attribute": [
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_0797dc78-5993-4add-b0fc-235c52055b97",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_30c35145-fb29-4be6-b438-d44158e02ce1",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_000_time0001.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_480ca5fc-abd1-419b-b7f1-0cb2f66ff308",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_002_time0000.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_78d5dabb-c948-4233-aca1-e446876b8050",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_002_time0001.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_8743d16e-b639-4574-86c4-b248458e4fb5",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_000_time0000.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_90fd9721-66ed-47f2-9b52-47c7d35df197",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_000_time0001.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_b9e8e936-d87f-4aa5-9a20-c83c68c3b051",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_002_time0000.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_c325bf71-2fcc-4149-be89-9ce80f94c667",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_002_time0001.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_df5f6399-71f8-42ec-a124-d22a8d35719d",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_001_time0000.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_e2632976-ec5d-4ab1-83c6-aa8692211a50",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_000_time0000.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_e88cefb7-7c5f-4f4f-8dd3-85229f72d68a",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_001_time0001.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "attributes_from_file_reference_fde8d9bc-0bef-47e9-8416-b5f0533d2956",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_001_time0001.tiff"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_conversion",
+      "name": "file_pattern",
+      "value": {
+        "file_pattern": "image_01_channel{%d}_slice{%d}_time{%d}"
+      }
+    }
+  ],
+  "original_file_reference_uuid": [
+    "0797dc78-5993-4add-b0fc-235c52055b97",
+    "30c35145-fb29-4be6-b438-d44158e02ce1",
+    "480ca5fc-abd1-419b-b7f1-0cb2f66ff308",
+    "78d5dabb-c948-4233-aca1-e446876b8050",
+    "8743d16e-b639-4574-86c4-b248458e4fb5",
+    "90fd9721-66ed-47f2-9b52-47c7d35df197",
+    "b9e8e936-d87f-4aa5-9a20-c83c68c3b051",
+    "c325bf71-2fcc-4149-be89-9ce80f94c667",
+    "df5f6399-71f8-42ec-a124-d22a8d35719d",
+    "e2632976-ec5d-4ab1-83c6-aa8692211a50",
+    "e88cefb7-7c5f-4f4f-8dd3-85229f72d68a",
+    "fde8d9bc-0bef-47e9-8416-b5f0533d2956"
+  ],
+  "creation_process_uuid": "dc585a20-b308-44af-a49f-a563a1cee1ab",
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/data/image/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/e5faf3a7-ead5-4c92-95e9-38408d285c06.json
+++ b/bia-assign-image/tests/data/image/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/e5faf3a7-ead5-4c92-95e9-38408d285c06.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "5c429763-a56e-4650-ad91-291cdfe6d153",
+  "uuid": "e5faf3a7-ead5-4c92-95e9-38408d285c06",
   "version": 0,
   "model": {
     "type_name": "Image",
@@ -13,33 +13,6 @@
       "value": {
         "attributes": [
           "3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff"
-        ]
-      }
-    },
-    {
-      "provenance": "bia_conversion",
-      "name": "attributes_from_file_reference_30c35145-fb29-4be6-b438-d44158e02ce1",
-      "value": {
-        "attributes": [
-          "3d_multichannel_time_series/image_01_channel_01_slice_000_time0001.tiff"
-        ]
-      }
-    },
-    {
-      "provenance": "bia_conversion",
-      "name": "attributes_from_file_reference_480ca5fc-abd1-419b-b7f1-0cb2f66ff308",
-      "value": {
-        "attributes": [
-          "3d_multichannel_time_series/image_01_channel_01_slice_002_time0000.tiff"
-        ]
-      }
-    },
-    {
-      "provenance": "bia_conversion",
-      "name": "attributes_from_file_reference_78d5dabb-c948-4233-aca1-e446876b8050",
-      "value": {
-        "attributes": [
-          "3d_multichannel_time_series/image_01_channel_01_slice_002_time0001.tiff"
         ]
       }
     },
@@ -81,24 +54,6 @@
     },
     {
       "provenance": "bia_conversion",
-      "name": "attributes_from_file_reference_df5f6399-71f8-42ec-a124-d22a8d35719d",
-      "value": {
-        "attributes": [
-          "3d_multichannel_time_series/image_01_channel_01_slice_001_time0000.tiff"
-        ]
-      }
-    },
-    {
-      "provenance": "bia_conversion",
-      "name": "attributes_from_file_reference_e2632976-ec5d-4ab1-83c6-aa8692211a50",
-      "value": {
-        "attributes": [
-          "3d_multichannel_time_series/image_01_channel_01_slice_000_time0000.tiff"
-        ]
-      }
-    },
-    {
-      "provenance": "bia_conversion",
       "name": "attributes_from_file_reference_e88cefb7-7c5f-4f4f-8dd3-85229f72d68a",
       "value": {
         "attributes": [
@@ -108,35 +63,20 @@
     },
     {
       "provenance": "bia_conversion",
-      "name": "attributes_from_file_reference_fde8d9bc-0bef-47e9-8416-b5f0533d2956",
-      "value": {
-        "attributes": [
-          "3d_multichannel_time_series/image_01_channel_01_slice_001_time0001.tiff"
-        ]
-      }
-    },
-    {
-      "provenance": "bia_conversion",
       "name": "file_pattern",
       "value": {
-        "file_pattern": "image_01_channel_{%d}_slice_{%d}_time{%d}"
+        "file_pattern": "image_01_channel_00_slice_{%d}_time{%d}"
       }
     }
   ],
   "original_file_reference_uuid": [
     "0797dc78-5993-4add-b0fc-235c52055b97",
-    "30c35145-fb29-4be6-b438-d44158e02ce1",
-    "480ca5fc-abd1-419b-b7f1-0cb2f66ff308",
-    "78d5dabb-c948-4233-aca1-e446876b8050",
     "8743d16e-b639-4574-86c4-b248458e4fb5",
     "90fd9721-66ed-47f2-9b52-47c7d35df197",
     "b9e8e936-d87f-4aa5-9a20-c83c68c3b051",
     "c325bf71-2fcc-4149-be89-9ce80f94c667",
-    "df5f6399-71f8-42ec-a124-d22a8d35719d",
-    "e2632976-ec5d-4ab1-83c6-aa8692211a50",
-    "e88cefb7-7c5f-4f4f-8dd3-85229f72d68a",
-    "fde8d9bc-0bef-47e9-8416-b5f0533d2956"
+    "e88cefb7-7c5f-4f4f-8dd3-85229f72d68a"
   ],
-  "creation_process_uuid": "dc585a20-b308-44af-a49f-a563a1cee1ab",
+  "creation_process_uuid": "b5d98aa9-79ce-4106-90b2-d3687eac67f0",
   "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
 }

--- a/bia-assign-image/tests/data/image_representation/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/7d6bd948-8732-4694-b655-831e4d1fc144.json
+++ b/bia-assign-image/tests/data/image_representation/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/7d6bd948-8732-4694-b655-831e4d1fc144.json
@@ -1,0 +1,44 @@
+{
+  "uuid": "7d6bd948-8732-4694-b655-831e4d1fc144",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 3
+  },
+  "attribute": [
+    {
+      "provenance": "bia_conversion",
+      "name": "file_pattern",
+      "value": {
+        "file_pattern": "image_01_channel{%d}_slice{%d}_time{%d}"
+      }
+    }
+  ],
+  "image_format": ".tiff",
+  "use_type": "UPLOADED_BY_SUBMITTER",
+  "file_uri": [
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_000_time0001.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_002_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_002_time0001.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_000_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_000_time0001.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_002_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_002_time0001.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_001_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_000_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_001_time0001.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_001_time0001.tiff"
+  ],
+  "total_size_in_bytes": 70848,
+  "physical_size_x": null,
+  "physical_size_y": null,
+  "physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "5c429763-a56e-4650-ad91-291cdfe6d153"
+}

--- a/bia-assign-image/tests/data/image_representation/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/7d6bd948-8732-4694-b655-831e4d1fc144.json
+++ b/bia-assign-image/tests/data/image_representation/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/7d6bd948-8732-4694-b655-831e4d1fc144.json
@@ -10,7 +10,7 @@
       "provenance": "bia_conversion",
       "name": "file_pattern",
       "value": {
-        "file_pattern": "image_01_channel{%d}_slice{%d}_time{%d}"
+        "file_pattern": "image_01_channel_{%d}_slice_{%d}_time{%d}"
       }
     }
   ],

--- a/bia-assign-image/tests/data/image_representation/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/f9d6f935-37ad-4015-b3f1-be21d361e1ab.json
+++ b/bia-assign-image/tests/data/image_representation/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/f9d6f935-37ad-4015-b3f1-be21d361e1ab.json
@@ -1,0 +1,38 @@
+{
+  "uuid": "f9d6f935-37ad-4015-b3f1-be21d361e1ab",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 3
+  },
+  "attribute": [
+    {
+      "provenance": "bia_conversion",
+      "name": "file_pattern",
+      "value": {
+        "file_pattern": "image_01_channel_00_slice_{%d}_time{%d}"
+      }
+    }
+  ],
+  "image_format": ".tiff",
+  "use_type": "UPLOADED_BY_SUBMITTER",
+  "file_uri": [
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_000_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_000_time0001.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_002_time0000.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_002_time0001.tiff",
+    "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_001_time0001.tiff"
+  ],
+  "total_size_in_bytes": 35424,
+  "physical_size_x": null,
+  "physical_size_y": null,
+  "physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "e5faf3a7-ead5-4c92-95e9-38408d285c06"
+}

--- a/bia-assign-image/tests/data/specimen/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/22fac32b-c8af-4ff3-a315-3e24cd16c51d.json
+++ b/bia-assign-image/tests/data/specimen/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/22fac32b-c8af-4ff3-a315-3e24cd16c51d.json
@@ -1,0 +1,15 @@
+{
+  "uuid": "22fac32b-c8af-4ff3-a315-3e24cd16c51d",
+  "version": 0,
+  "model": {
+    "type_name": "Specimen",
+    "version": 2
+  },
+  "imaging_preparation_protocol_uuid": [
+    "a9dcc027-4afc-46e6-9ec0-42308c7b84c7"
+  ],
+  "sample_of_uuid": [
+    "6e882215-590f-473a-8ae5-1bf5d3a3f8f9"
+  ],
+  "attribute": []
+}

--- a/bia-assign-image/tests/data/specimen/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/4a625c07-1615-4c1d-a834-0d2ae2955cf3.json
+++ b/bia-assign-image/tests/data/specimen/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/4a625c07-1615-4c1d-a834-0d2ae2955cf3.json
@@ -1,0 +1,15 @@
+{
+  "uuid": "4a625c07-1615-4c1d-a834-0d2ae2955cf3",
+  "version": 0,
+  "model": {
+    "type_name": "Specimen",
+    "version": 2
+  },
+  "imaging_preparation_protocol_uuid": [
+    "a9dcc027-4afc-46e6-9ec0-42308c7b84c7"
+  ],
+  "sample_of_uuid": [
+    "6e882215-590f-473a-8ae5-1bf5d3a3f8f9"
+  ],
+  "attribute": []
+}

--- a/bia-assign-image/tests/input_data/bio_sample/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/6e882215-590f-473a-8ae5-1bf5d3a3f8f9.json
+++ b/bia-assign-image/tests/input_data/bio_sample/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/6e882215-590f-473a-8ae5-1bf5d3a3f8f9.json
@@ -1,0 +1,29 @@
+{
+    "title_id": "Test Biosample 1",
+    "uuid": "6e882215-590f-473a-8ae5-1bf5d3a3f8f9",
+    "organism_classification": [
+        {
+            "common_name": "human",
+            "scientific_name": "Homo sapiens",
+            "ncbi_id": null,
+            "attribute": []
+        }
+    ],
+    "model": {
+        "type_name": "BioSample",
+        "version": 3
+    },
+    "biological_entity_description": "Test biological entity 1",
+    "experimental_variable_description": [
+        "Test experimental entity 1"
+    ],
+    "extrinsic_variable_description": [
+        "Test extrinsic variable 1"
+    ],
+    "intrinsic_variable_description": [
+        "Test intrinsic variable 1\\nwith escaped character"
+    ],
+    "growth_protocol_uuid": "71371fc5-1ce0-4612-a912-9436fc5f7237",
+    "attribute": [],
+    "version": 0
+}

--- a/bia-assign-image/tests/input_data/dataset/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/ae32e92d-84f9-4119-82d1-70cb36477bc0.json
+++ b/bia-assign-image/tests/input_data/dataset/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/ae32e92d-84f9-4119-82d1-70cb36477bc0.json
@@ -1,0 +1,54 @@
+{
+    "title_id": "3D multichannel time series in separate files",
+    "uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0",
+    "description": "Study component with files of the form image_{%d}_channel{%d}_slice{%d}_time{%d} to test assigning and converting images with patterns",
+    "attribute": [
+        {
+            "provenance": "bia_ingest",
+            "name": "image_acquisition_protocol_uuid",
+            "value": {
+                "image_acquisition_protocol_uuid": ["7586534d-459e-4316-b5d9-8e811ad7c321"]
+            }
+        },
+        {
+            "provenance": "bia_ingest",
+            "name": "specimen_imaging_preparation_protocol_uuid",
+            "value": {
+                "specimen_imaging_preparation_protocol_uuid": ["a9dcc027-4afc-46e6-9ec0-42308c7b84c7"]
+            }
+        },
+        {
+            "provenance": "bia_ingest",
+            "name": "bio_sample_uuid",
+            "value": {
+                "bio_sample_uuid": ["6e882215-590f-473a-8ae5-1bf5d3a3f8f9"]
+            }
+        },
+        {
+            "value": {
+                "image_analysis": "Test image analysis",
+                "image_correlation": null,
+                "biosample": "Test Biosample 1",
+                "image_acquisition": "Test Primary Screen Image Acquisition",
+                "specimen": "Test specimen 1"
+            },
+            "name": "associations",
+            "provenance": "bia_ingest"
+        }
+    ],
+    "model": {
+        "type_name": "Dataset",
+        "version": 1
+    },
+    "analysis_method": [
+        {
+            "protocol_description": "Test image analysis",
+            "features_analysed": "Test image analysis overview",
+            "attribute": []
+        }
+    ],
+    "submitted_in_study_uuid": "03fd49d1-3172-46f9-aa5a-93bffef07aa6",
+    "correlation_method": [],
+    "example_image_uri": [],
+    "version": 0
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/01b75166-45de-496e-a127-9042113c8e0f.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/01b75166-45de-496e-a127-9042113c8e0f.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "01b75166-45de-496e-a127-9042113c8e0f",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_00_slice_001_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_00_slice_001_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_00_slice_001_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/0797dc78-5993-4add-b0fc-235c52055b97.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/0797dc78-5993-4add-b0fc-235c52055b97.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "0797dc78-5993-4add-b0fc-235c52055b97",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/30c35145-fb29-4be6-b438-d44158e02ce1.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/30c35145-fb29-4be6-b438-d44158e02ce1.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "30c35145-fb29-4be6-b438-d44158e02ce1",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_01_slice_000_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_000_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_000_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3728a72d-1538-4940-bafe-91c71687dffd.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3728a72d-1538-4940-bafe-91c71687dffd.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "3728a72d-1538-4940-bafe-91c71687dffd",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_00_slice_001_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_00_slice_001_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_00_slice_001_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/411e5125-104e-4c6d-bee9-b7f627554592.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/411e5125-104e-4c6d-bee9-b7f627554592.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "411e5125-104e-4c6d-bee9-b7f627554592",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_00_slice_000_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_00_slice_000_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_00_slice_000_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/45a86472-c3fc-4511-b0ec-87d76640c334.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/45a86472-c3fc-4511-b0ec-87d76640c334.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "45a86472-c3fc-4511-b0ec-87d76640c334",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_01_slice_000_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_01_slice_000_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_01_slice_000_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/480ca5fc-abd1-419b-b7f1-0cb2f66ff308.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/480ca5fc-abd1-419b-b7f1-0cb2f66ff308.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "480ca5fc-abd1-419b-b7f1-0cb2f66ff308",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_01_slice_002_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_002_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_002_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/6e9a1900-e443-4f4a-ad46-476fe10c261d.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/6e9a1900-e443-4f4a-ad46-476fe10c261d.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "6e9a1900-e443-4f4a-ad46-476fe10c261d",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_01_slice_002_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_01_slice_002_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_01_slice_002_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/78d5dabb-c948-4233-aca1-e446876b8050.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/78d5dabb-c948-4233-aca1-e446876b8050.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "78d5dabb-c948-4233-aca1-e446876b8050",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_01_slice_002_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_002_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_002_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/78f6d9e8-d181-49f1-b745-76e2ad851b54.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/78f6d9e8-d181-49f1-b745-76e2ad851b54.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "78f6d9e8-d181-49f1-b745-76e2ad851b54",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_01_slice_001_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_01_slice_001_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_01_slice_001_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/8743d16e-b639-4574-86c4-b248458e4fb5.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/8743d16e-b639-4574-86c4-b248458e4fb5.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "8743d16e-b639-4574-86c4-b248458e4fb5",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_00_slice_000_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_000_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_000_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/90fd9721-66ed-47f2-9b52-47c7d35df197.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/90fd9721-66ed-47f2-9b52-47c7d35df197.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "90fd9721-66ed-47f2-9b52-47c7d35df197",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_00_slice_000_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_000_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_000_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/b59a25b9-a811-4541-9fde-ba9f17a08029.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/b59a25b9-a811-4541-9fde-ba9f17a08029.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "b59a25b9-a811-4541-9fde-ba9f17a08029",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_00_slice_000_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_00_slice_000_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_00_slice_000_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/b9e8e936-d87f-4aa5-9a20-c83c68c3b051.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/b9e8e936-d87f-4aa5-9a20-c83c68c3b051.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "b9e8e936-d87f-4aa5-9a20-c83c68c3b051",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_00_slice_002_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_002_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_002_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/c325bf71-2fcc-4149-be89-9ce80f94c667.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/c325bf71-2fcc-4149-be89-9ce80f94c667.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "c325bf71-2fcc-4149-be89-9ce80f94c667",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_00_slice_002_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_002_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_002_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/c8e4cdfb-0031-4828-8b4f-ee0045eb18f5.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/c8e4cdfb-0031-4828-8b4f-ee0045eb18f5.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "c8e4cdfb-0031-4828-8b4f-ee0045eb18f5",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_00_slice_002_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_00_slice_002_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_00_slice_002_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/cd1efd77-8d26-4cb4-9935-948b79e0d93a.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/cd1efd77-8d26-4cb4-9935-948b79e0d93a.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "cd1efd77-8d26-4cb4-9935-948b79e0d93a",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_00_slice_002_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_00_slice_002_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_00_slice_002_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/d6722e2a-a8df-4790-a0f0-919160c3b8c6.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/d6722e2a-a8df-4790-a0f0-919160c3b8c6.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "d6722e2a-a8df-4790-a0f0-919160c3b8c6",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_01_slice_001_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_01_slice_001_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_01_slice_001_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/dccb683e-f951-4c86-8e69-e62b3b6a1fc1.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/dccb683e-f951-4c86-8e69-e62b3b6a1fc1.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "dccb683e-f951-4c86-8e69-e62b3b6a1fc1",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_01_slice_002_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_01_slice_002_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_01_slice_002_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/df5f6399-71f8-42ec-a124-d22a8d35719d.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/df5f6399-71f8-42ec-a124-d22a8d35719d.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "df5f6399-71f8-42ec-a124-d22a8d35719d",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_01_slice_001_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_001_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_001_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/e2632976-ec5d-4ab1-83c6-aa8692211a50.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/e2632976-ec5d-4ab1-83c6-aa8692211a50.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "e2632976-ec5d-4ab1-83c6-aa8692211a50",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_01_slice_000_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_000_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_000_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/e88cefb7-7c5f-4f4f-8dd3-85229f72d68a.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/e88cefb7-7c5f-4f4f-8dd3-85229f72d68a.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "e88cefb7-7c5f-4f4f-8dd3-85229f72d68a",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_00_slice_001_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_00_slice_001_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_00_slice_001_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/fbd64f19-a00f-471e-a0a7-9c88c34ea53b.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/fbd64f19-a00f-471e-a0a7-9c88c34ea53b.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "fbd64f19-a00f-471e-a0a7-9c88c34ea53b",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_02_channel_01_slice_000_time0000.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_02_channel_01_slice_000_time0000.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_02_channel_01_slice_000_time0000.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/fde8d9bc-0bef-47e9-8416-b5f0533d2956.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/fde8d9bc-0bef-47e9-8416-b5f0533d2956.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "fde8d9bc-0bef-47e9-8416-b5f0533d2956",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 2
+  },
+  "file_path": "3d_multichannel_time_series/image_01_channel_01_slice_001_time0001.tiff",
+  "format": "file",
+  "size_in_bytes": 5904,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/3d_multichannel_time_series/image_01_channel_01_slice_001_time0001.tiff",
+  "attribute": [
+    {
+      "provenance": "bia_ingest",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "attributes": [
+          "3d_multichannel_time_series/image_01_channel_01_slice_001_time0001.tiff"
+        ]
+      }
+    }
+  ],
+  "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0"
+}

--- a/bia-assign-image/tests/input_data/image_acquisition_protocol/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/7586534d-459e-4316-b5d9-8e811ad7c321.json
+++ b/bia-assign-image/tests/input_data/image_acquisition_protocol/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/7586534d-459e-4316-b5d9-8e811ad7c321.json
@@ -1,0 +1,14 @@
+{
+    "title_id": "Test Primary Screen Image Acquisition",
+    "uuid": "7586534d-459e-4316-b5d9-8e811ad7c321",
+    "protocol_description": "Test image acquisition parameters 1",
+    "imaging_instrument_description": "Test imaging instrument 1",
+    "fbbi_id": [],
+    "attribute": [],
+    "imaging_method_name": ["confocal microscopy"],
+    "version": 0,
+    "model": {
+        "type_name": "ImageAcquisitionProtocol",
+        "version": 2
+    }
+}

--- a/bia-assign-image/tests/input_data/protocol/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/71371fc5-1ce0-4612-a912-9436fc5f7237.json
+++ b/bia-assign-image/tests/input_data/protocol/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/71371fc5-1ce0-4612-a912-9436fc5f7237.json
@@ -1,0 +1,11 @@
+{
+    "title_id": "Test sample growth protocol",
+    "uuid": "71371fc5-1ce0-4612-a912-9436fc5f7237",
+    "protocol_description": "Test sample growth protocol 1",
+    "attribute": [],
+    "model": {
+        "type_name": "Protocol",
+        "version": 2
+    },
+    "version": 0
+}

--- a/bia-assign-image/tests/input_data/specimen_imaging_preparation_protocol/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/a9dcc027-4afc-46e6-9ec0-42308c7b84c7.json
+++ b/bia-assign-image/tests/input_data/specimen_imaging_preparation_protocol/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/a9dcc027-4afc-46e6-9ec0-42308c7b84c7.json
@@ -1,0 +1,12 @@
+{
+    "title_id": "Test specimen 1",
+    "uuid": "a9dcc027-4afc-46e6-9ec0-42308c7b84c7",
+    "protocol_description": "Test sample preparation protocol 1",
+    "signal_channel_information": [],
+    "version": 0,
+    "model": {
+        "type_name": "SpecimenImagingPreparationProtocol",
+        "version": 2
+    },
+    "attribute": []
+}

--- a/bia-assign-image/tests/input_data/study/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/03fd49d1-3172-46f9-aa5a-93bffef07aa6.json
+++ b/bia-assign-image/tests/input_data/study/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/03fd49d1-3172-46f9-aa5a-93bffef07aa6.json
@@ -5,7 +5,7 @@
         "type_name": "Study",
         "version": 2
     },
-    "accession_id": "S-BIADTEST-BIA-ASSIGN-IMAGE-WITH-STUDY",
+    "accession_id": "S-BIADTEST-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST",
     "licence": "CC0",
     "author": [
         {

--- a/bia-assign-image/tests/input_data/study/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/03fd49d1-3172-46f9-aa5a-93bffef07aa6.json
+++ b/bia-assign-image/tests/input_data/study/S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST/03fd49d1-3172-46f9-aa5a-93bffef07aa6.json
@@ -1,0 +1,79 @@
+{
+    "uuid": "03fd49d1-3172-46f9-aa5a-93bffef07aa6",
+    "version": 0,
+    "model": {
+        "type_name": "Study",
+        "version": 2
+    },
+    "accession_id": "S-BIADTEST-BIA-ASSIGN-IMAGE-WITH-STUDY",
+    "licence": "CC0",
+    "author": [
+        {
+            "rorid": null,
+            "address": null,
+            "website": null,
+            "orcid": "0000-0000-0000-0000",
+            "display_name": "Test Author1",
+            "affiliation": [
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "display_name": "Test College 1"
+                }
+            ],
+            "contact_email": "test_author1@ebi.ac.uk",
+            "role": "corresponding author"
+        },
+        {
+            "rorid": null,
+            "address": null,
+            "website": null,
+            "orcid": "1111-1111-1111-1111",
+            "display_name": "Test Author2",
+            "affiliation": [
+                {
+                    "rorid": null,
+                    "address": null,
+                    "website": null,
+                    "display_name": "Test College 2"
+                }
+            ],
+            "contact_email": "test_author2@ebi.ac.uk",
+            "role": "first author"
+        }
+    ],
+    "title": "A test submission with images of the form image_{%d}_channel{%d}_slice{%d}_time{%d} to test assigning and converting images with patterns",
+    "release_date": "2024-02-13",
+    "keyword": [
+        "Test keyword1",
+        "Test keyword2",
+        "Test keyword3"
+    ],
+    "acknowledgement": "We thank you",
+    "description": "A test submission to allow testing without retrieving from bia server",
+    "see_also": [],
+    "related_publication": [],
+    "grant": [
+        {
+            "id": "TESTFUNDS1",
+            "funder": [
+                {
+                    "display_name": "Test funding body1",
+                    "id": null
+                }
+            ]
+        },
+        {
+            "id": "TESTFUNDS2",
+            "funder": [
+                {
+                    "display_name": "Test funding body2",
+                    "id": null
+                }
+            ]
+        }
+    ],
+    "funding_statement": "This work was funded by the EBI",
+    "attribute": []
+}

--- a/bia-assign-image/tests/test_assign_image_with_pattern.py
+++ b/bia-assign-image/tests/test_assign_image_with_pattern.py
@@ -15,7 +15,7 @@ expected_data_base_path = Path(__file__).parent / "data"
 def dataset() -> bia_data_model.Dataset:
     # Return Dataset specially created for testing images created from
     # multiple file references. Dataset has file references with pattern
-    # "image_{%d}_channel{%d}_slice{%d}_time{%d}"
+    # "image_{%d}_channel_{%d}_slice_{%d}_time{%d}"
     dataset_dir = input_data_base_path / "dataset" / accession_id
     dataset_path = next(dataset_dir.glob("*.json"))
     return bia_data_model.Dataset.model_validate_json(dataset_path.read_text())
@@ -40,17 +40,11 @@ def bio_sample_uuid(dataset) -> List[UUID]:
     return dataset.attribute[3].value["bio_sample_uuid"]
 
 
-# @pytest.fixture
-# def expected_creation_process() -> bia_data_model.CreationProcess:
-#    obj_dir = expected_data_base_path / "creation_process" / accession_id
-#    obj_path = next(obj_dir.glob("*.json"))
-#    return bia_data_model.CreationProcess.model_validate_json(obj_path.read_text())
-
-
 @pytest.fixture
 def expected_image() -> bia_data_model.Image:
-    dir = expected_data_base_path / "image" / accession_id
-    image_path = next(dir.glob("*.json"))
+    # This is uuid of image with 2 channels
+    image_uuid = "5c429763-a56e-4650-ad91-291cdfe6d153"
+    image_path = expected_data_base_path / "image" / accession_id / f"{image_uuid}.json"
     return bia_data_model.Image.model_validate_json(image_path.read_text())
 
 
@@ -69,7 +63,7 @@ def file_references() -> List[bia_data_model.FileReference]:
 
 
 def test_bia_image_with_pattern(dataset, file_references, expected_image):
-    file_pattern = "image_01_channel{%d}_slice{%d}_time{%d}"
+    file_pattern = "image_01_channel_{%d}_slice_{%d}_time{%d}"
     created_image = image.get_image(
         submission_dataset_uuid=dataset.uuid,
         creation_process_uuid=expected_image.creation_process_uuid,
@@ -78,3 +72,5 @@ def test_bia_image_with_pattern(dataset, file_references, expected_image):
     )
 
     assert expected_image == created_image
+
+    # TODO: When use of RO crate complete also check CreationProcess and Specimen

--- a/bia-assign-image/tests/test_assign_image_with_pattern.py
+++ b/bia-assign-image/tests/test_assign_image_with_pattern.py
@@ -1,0 +1,80 @@
+from typing import List
+from uuid import UUID
+from pathlib import Path
+import pytest
+from bia_assign_image import image
+from bia_shared_datamodels import bia_data_model
+
+input_data_base_path = Path(__file__).parent / "input_data"
+accession_id = "S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST"
+
+expected_data_base_path = Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def dataset() -> bia_data_model.Dataset:
+    # Return Dataset specially created for testing images created from
+    # multiple file references. Dataset has file references with pattern
+    # "image_{%d}_channel{%d}_slice{%d}_time{%d}"
+    dataset_dir = input_data_base_path / "dataset" / accession_id
+    dataset_path = next(dataset_dir.glob("*.json"))
+    return bia_data_model.Dataset.model_validate_json(dataset_path.read_text())
+
+
+@pytest.fixture
+def image_acquisition_protocol_uuid(
+    dataset,
+) -> List[UUID]:
+    return dataset.attribute[1].value["image_acquisition_protocol_uuid"]
+
+
+@pytest.fixture
+def specimen_imaging_preparation_protocol_uuid(
+    dataset,
+) -> List[UUID]:
+    return dataset.attribute[2].value["specimen_imaging_preparation_protocol_uuid"]
+
+
+@pytest.fixture
+def bio_sample_uuid(dataset) -> List[UUID]:
+    return dataset.attribute[3].value["bio_sample_uuid"]
+
+
+# @pytest.fixture
+# def expected_creation_process() -> bia_data_model.CreationProcess:
+#    obj_dir = expected_data_base_path / "creation_process" / accession_id
+#    obj_path = next(obj_dir.glob("*.json"))
+#    return bia_data_model.CreationProcess.model_validate_json(obj_path.read_text())
+
+
+@pytest.fixture
+def expected_image() -> bia_data_model.Image:
+    dir = expected_data_base_path / "image" / accession_id
+    image_path = next(dir.glob("*.json"))
+    return bia_data_model.Image.model_validate_json(image_path.read_text())
+
+
+@pytest.fixture
+def file_references() -> List[bia_data_model.FileReference]:
+    file_reference_list = []
+    obj_dir = input_data_base_path / "file_reference" / accession_id
+    for obj_path in obj_dir.glob("*.json"):
+        file_reference = bia_data_model.FileReference.model_validate_json(
+            obj_path.read_text()
+        )
+        if "image_01" in file_reference.file_path:
+            file_reference_list.append(file_reference)
+        file_reference_list.sort(key=lambda f: str(f.uuid))
+    return file_reference_list
+
+
+def test_bia_image_with_pattern(dataset, file_references, expected_image):
+    file_pattern = "image_01_channel{%d}_slice{%d}_time{%d}"
+    created_image = image.get_image(
+        submission_dataset_uuid=dataset.uuid,
+        creation_process_uuid=expected_image.creation_process_uuid,
+        file_references=file_references,
+        file_pattern=file_pattern,
+    )
+
+    assert expected_image == created_image

--- a/bia-assign-image/tests/test_bia_assign_image_cli.py
+++ b/bia-assign-image/tests/test_bia_assign_image_cli.py
@@ -74,7 +74,7 @@ def test_api_client():
 
 
 @pytest.mark.parametrize("format", ("tsv", "yaml"))
-def test_cli_propose_images_command(format, data_in_api, tmpdir):
+def test_cli_propose_images_command(format, tmpdir):
     max_items = 2
     propose_output_path = Path(tmpdir) / f"propose_S-BIADTEST.{format}"
 
@@ -111,7 +111,6 @@ def test_cli_propose_images_command(format, data_in_api, tmpdir):
     ),
 )
 def test_cli_assign_from_proposal_command(
-    data_in_api,
     test_api_client,
     format,
     assign_from_proposal_input_path_tsv,
@@ -126,11 +125,6 @@ def test_cli_assign_from_proposal_command(
         assign_from_proposal_input_path = f"{assign_from_proposal_input_path_tsv}"
     elif format == "yaml":
         assign_from_proposal_input_path = f"{assign_from_proposal_input_path_yaml}"
-
-    # result = cli.assign_from_proposal(
-    #       Path(assign_from_proposal_input_path),
-    #       "local",
-    # )
 
     result = runner.invoke(
         cli.app,

--- a/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
+++ b/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
@@ -1,3 +1,13 @@
+"""Test assigning images with patterns from CLI directly and from CLI with proposal yaml
+
+Test with CLI directly uses pattern for 1 channel
+Test with CLI using proposal yaml uses pattern for 2 channels
+
+"""
+
+from typing import Type
+from pydantic import BaseModel
+from pydantic.alias_generators import to_snake
 from pathlib import Path
 from typer.testing import CliRunner
 from ruamel.yaml import YAML
@@ -8,40 +18,81 @@ from bia_assign_image import cli
 from bia_assign_image.api_client import get_api_client
 
 accession_id = "S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST"
+pattern_2channels = "image_01_channel_{%d}_slice_{%d}_time{%d}"
+pattern_1channel = "image_01_channel_00_slice_{%d}_time{%d}"
+
+
+def get_expected_object(object_type: str, uuid: str) -> Type[BaseModel]:
+    object_path = (
+        Path(__file__).parent
+        / "data"
+        / to_snake(object_type)
+        / accession_id
+        / f"{uuid}.json"
+    )
+    obj = getattr(bia_data_model, object_type)
+    return obj.model_validate_json(object_path.read_text())
 
 
 @pytest.fixture()
-def expected_bia_image() -> bia_data_model.Image:
-    dir = Path(__file__).parent / "data" / "image" / accession_id
-    image_path = next(dir.glob("*.json"))
-    return bia_data_model.Image.model_validate_json(image_path.read_text())
+def expected_bia_image_2channels() -> bia_data_model.Image:
+    return get_expected_object("Image", "5c429763-a56e-4650-ad91-291cdfe6d153")
 
 
 @pytest.fixture()
-def expected_uploaded_by_submitter_representation() -> (
+def expected_bia_image_1channel() -> bia_data_model.Image:
+    return get_expected_object("Image", "e5faf3a7-ead5-4c92-95e9-38408d285c06")
+
+
+@pytest.fixture()
+def expected_uploaded_by_submitter_representation_2channels() -> (
     bia_data_model.ImageRepresentation
 ):
-    dir = Path(__file__).parent / "data" / "image_representation" / accession_id
-    object_path = next(dir.glob("*.json"))
-    return bia_data_model.ImageRepresentation.model_validate_json(
-        object_path.read_text()
+    return get_expected_object(
+        "ImageRepresentation", "7d6bd948-8732-4694-b655-831e4d1fc144"
+    )
+
+
+@pytest.fixture()
+def expected_uploaded_by_submitter_representation_1channel() -> (
+    bia_data_model.ImageRepresentation
+):
+    return get_expected_object(
+        "ImageRepresentation", "f9d6f935-37ad-4015-b3f1-be21d361e1ab"
     )
 
 
 @pytest.fixture
-def assign_from_proposal_input_path_yaml(tmpdir, expected_bia_image) -> Path:
+def file_reference_uuid_2channels(expected_bia_image_2channels) -> str:
+    return " ".join(
+        [
+            str(f_uuid)
+            for f_uuid in expected_bia_image_2channels.original_file_reference_uuid
+        ]
+    )
+
+
+@pytest.fixture
+def file_reference_uuid_1channel(expected_bia_image_1channel) -> str:
+    return " ".join(
+        [
+            str(f_uuid)
+            for f_uuid in expected_bia_image_1channel.original_file_reference_uuid
+        ]
+    )
+
+
+@pytest.fixture
+def assign_from_proposal_input_path_yaml(tmpdir, file_reference_uuid_2channels) -> Path:
     """Return path to a yaml file with proposal details to create mock image"""
 
-    file_reference_uuids = " ".join(
-        [str(f_uuid) for f_uuid in expected_bia_image.original_file_reference_uuid]
-    )
     proposal_details_for_input = {
         "accession_id": accession_id,
         "study_uuid": "dummy_study_uuid",
         "dataset_uuid": "dummy_dataset_uuid",
         "name": "dummy_name",
-        "file_reference_uuid": file_reference_uuids,
-        "pattern": "image_01_channel{%d}_slice{%d}_time{%d}",
+        "file_reference_uuid": file_reference_uuid_2channels,
+        "pattern": pattern_2channels,
     }
     yaml = YAML(typ="safe")
     proposal_path = Path(tmpdir) / "proposal_details.yaml"
@@ -64,8 +115,8 @@ def test_cli_assign_from_proposal_command(
     data_in_api,
     test_api_client,
     assign_from_proposal_input_path_yaml,
-    expected_bia_image,
-    expected_uploaded_by_submitter_representation,
+    expected_bia_image_2channels,
+    expected_uploaded_by_submitter_representation_2channels,
 ):
     # This implicitly tests the 'assign' and 'create' commands
     runner = CliRunner(mix_stderr=False)
@@ -97,14 +148,14 @@ def test_cli_assign_from_proposal_command(
     #     <AttributeProvenance.BIA_CONVERSION: 'bia_conversion' (api)
     # so convert returned value to bia_data_model.* before comparison)
     created_bia_image_dict = test_api_client.get_image(
-        str(expected_bia_image.uuid)
+        str(expected_bia_image_2channels.uuid)
     ).model_dump()
     created_bia_image = bia_data_model.Image.model_validate(created_bia_image_dict)
-    assert created_bia_image == expected_bia_image
+    assert created_bia_image == expected_bia_image_2channels
 
     created_uploaded_by_submitter_representation_dict = (
         test_api_client.get_image_representation(
-            str(expected_uploaded_by_submitter_representation.uuid)
+            str(expected_uploaded_by_submitter_representation_2channels.uuid)
         ).model_dump()
     )
     created_uploaded_by_submitter_representation = (
@@ -114,5 +165,79 @@ def test_cli_assign_from_proposal_command(
     )
     assert (
         created_uploaded_by_submitter_representation
-        == expected_uploaded_by_submitter_representation
+        == expected_uploaded_by_submitter_representation_2channels
+    )
+
+
+def test_cli_assign_command_with_pattern(
+    data_in_api,
+    test_api_client,
+    file_reference_uuid_1channel,
+    expected_bia_image_1channel,
+    expected_uploaded_by_submitter_representation_1channel,
+):
+    # This implicitly tests the 'assign' and 'create' commands
+    runner = CliRunner(mix_stderr=False)
+
+    # result = cli.assign(
+    #       accession_id=accession_id,
+    #       file_reference_uuids=file_reference_uuids.split(" "),
+    #       api_target="local",
+    #       pattern=pattern,
+    # )
+
+    for_cli = [
+        "assign",
+        "--api",
+        "local",
+        "--pattern",
+        pattern_1channel,
+        accession_id,
+    ]
+    for_cli.append(file_reference_uuid_1channel)
+    result = runner.invoke(
+        cli.app,
+        for_cli,
+        # [
+        #    "assign",
+        #    "--api",
+        #    "local",
+        #    "--dryrun",
+        #    "--pattern",
+        #    pattern,
+        #    accession_id,
+        #    file_reference_uuids,
+        # ],
+    )
+
+    assert result.exit_code == 0
+
+    # Check BIA image and UPLOADED_BY_SUBMITTER representation objects created.
+    #
+    # TODO: Investigate issue commented on below.
+    # At time of writing test (21/02/2025), there are subtle differences in
+    # API models and bia_data_models (e.g. Pydantic serializer warnings around type of
+    # AttributeProvenance which may be leading to:
+    #     <AttributeProvenance.bia_conversion: 'bia_conversion' (bia_data_model) vs
+    #     <AttributeProvenance.BIA_CONVERSION: 'bia_conversion' (api)
+    # so convert returned value to bia_data_model.* before comparison)
+    created_bia_image_dict = test_api_client.get_image(
+        str(expected_bia_image_1channel.uuid)
+    ).model_dump()
+    created_bia_image = bia_data_model.Image.model_validate(created_bia_image_dict)
+    assert created_bia_image == expected_bia_image_1channel
+
+    created_uploaded_by_submitter_representation_dict = (
+        test_api_client.get_image_representation(
+            str(expected_uploaded_by_submitter_representation_1channel.uuid)
+        ).model_dump()
+    )
+    created_uploaded_by_submitter_representation = (
+        bia_data_model.ImageRepresentation.model_validate(
+            created_uploaded_by_submitter_representation_dict
+        )
+    )
+    assert (
+        created_uploaded_by_submitter_representation
+        == expected_uploaded_by_submitter_representation_1channel
     )

--- a/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
+++ b/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
@@ -115,7 +115,6 @@ def test_api_client():
 
 # TODO: When use of RO crate complete also check CreationProcess and Specimen in all tests below
 def test_cli_assign_from_proposal_command(
-    data_in_api,
     test_api_client,
     assign_from_proposal_input_path_yaml,
     expected_bia_image_2channels,
@@ -168,7 +167,6 @@ def test_cli_assign_from_proposal_command(
 
 
 def test_cli_assign_command_with_pattern(
-    data_in_api,
     test_api_client,
     file_reference_uuids_1channel,
     expected_bia_image_1channel,

--- a/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
+++ b/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
@@ -63,7 +63,7 @@ def expected_uploaded_by_submitter_representation_1channel() -> (
 
 
 @pytest.fixture
-def file_reference_uuid_2channels(expected_bia_image_2channels) -> str:
+def file_reference_uuids_2channels(expected_bia_image_2channels) -> str:
     return " ".join(
         [
             str(f_uuid)
@@ -73,7 +73,7 @@ def file_reference_uuid_2channels(expected_bia_image_2channels) -> str:
 
 
 @pytest.fixture
-def file_reference_uuid_1channel(expected_bia_image_1channel) -> str:
+def file_reference_uuids_1channel(expected_bia_image_1channel) -> str:
     return " ".join(
         [
             str(f_uuid)
@@ -83,7 +83,9 @@ def file_reference_uuid_1channel(expected_bia_image_1channel) -> str:
 
 
 @pytest.fixture
-def assign_from_proposal_input_path_yaml(tmpdir, file_reference_uuid_2channels) -> Path:
+def assign_from_proposal_input_path_yaml(
+    tmpdir, file_reference_uuids_2channels
+) -> Path:
     """Return path to a yaml file with proposal details to create mock image"""
 
     proposal_details_for_input = {
@@ -91,7 +93,7 @@ def assign_from_proposal_input_path_yaml(tmpdir, file_reference_uuid_2channels) 
         "study_uuid": "dummy_study_uuid",
         "dataset_uuid": "dummy_dataset_uuid",
         "name": "dummy_name",
-        "file_reference_uuid": file_reference_uuid_2channels,
+        "file_reference_uuid": file_reference_uuids_2channels,
         "pattern": pattern_2channels,
     }
     yaml = YAML(typ="safe")
@@ -111,6 +113,7 @@ def test_api_client():
     return get_api_client("local")
 
 
+# TODO: When use of RO crate complete also check CreationProcess and Specimen in all tests below
 def test_cli_assign_from_proposal_command(
     data_in_api,
     test_api_client,
@@ -120,11 +123,6 @@ def test_cli_assign_from_proposal_command(
 ):
     # This implicitly tests the 'assign' and 'create' commands
     runner = CliRunner(mix_stderr=False)
-
-    # result = cli.assign_from_proposal(
-    #       Path(assign_from_proposal_input_path),
-    #       "local",
-    # )
 
     result = runner.invoke(
         cli.app,
@@ -172,42 +170,24 @@ def test_cli_assign_from_proposal_command(
 def test_cli_assign_command_with_pattern(
     data_in_api,
     test_api_client,
-    file_reference_uuid_1channel,
+    file_reference_uuids_1channel,
     expected_bia_image_1channel,
     expected_uploaded_by_submitter_representation_1channel,
 ):
     # This implicitly tests the 'assign' and 'create' commands
     runner = CliRunner(mix_stderr=False)
 
-    # result = cli.assign(
-    #       accession_id=accession_id,
-    #       file_reference_uuids=file_reference_uuids.split(" "),
-    #       api_target="local",
-    #       pattern=pattern,
-    # )
-
-    for_cli = [
-        "assign",
-        "--api",
-        "local",
-        "--pattern",
-        pattern_1channel,
-        accession_id,
-    ]
-    for_cli.append(file_reference_uuid_1channel)
     result = runner.invoke(
         cli.app,
-        for_cli,
-        # [
-        #    "assign",
-        #    "--api",
-        #    "local",
-        #    "--dryrun",
-        #    "--pattern",
-        #    pattern,
-        #    accession_id,
-        #    file_reference_uuids,
-        # ],
+        [
+            "assign",
+            "--api",
+            "local",
+            "--pattern",
+            pattern_1channel,
+            accession_id,
+            file_reference_uuids_1channel,
+        ],
     )
 
     assert result.exit_code == 0

--- a/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
+++ b/bia-assign-image/tests/test_bia_assign_image_with_pattern_cli.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from typer.testing import CliRunner
+from ruamel.yaml import YAML
+
+import pytest
+from bia_shared_datamodels import bia_data_model
+from bia_assign_image import cli
+from bia_assign_image.api_client import get_api_client
+
+accession_id = "S-BIAD-BIA-ASSIGN-IMAGE-WITH-PATTERN-TEST"
+
+
+@pytest.fixture()
+def expected_bia_image() -> bia_data_model.Image:
+    dir = Path(__file__).parent / "data" / "image" / accession_id
+    image_path = next(dir.glob("*.json"))
+    return bia_data_model.Image.model_validate_json(image_path.read_text())
+
+
+@pytest.fixture()
+def expected_uploaded_by_submitter_representation() -> (
+    bia_data_model.ImageRepresentation
+):
+    dir = Path(__file__).parent / "data" / "image_representation" / accession_id
+    object_path = next(dir.glob("*.json"))
+    return bia_data_model.ImageRepresentation.model_validate_json(
+        object_path.read_text()
+    )
+
+
+@pytest.fixture
+def assign_from_proposal_input_path_yaml(tmpdir, expected_bia_image) -> Path:
+    """Return path to a yaml file with proposal details to create mock image"""
+
+    file_reference_uuids = " ".join(
+        [str(f_uuid) for f_uuid in expected_bia_image.original_file_reference_uuid]
+    )
+    proposal_details_for_input = {
+        "accession_id": accession_id,
+        "study_uuid": "dummy_study_uuid",
+        "dataset_uuid": "dummy_dataset_uuid",
+        "name": "dummy_name",
+        "file_reference_uuid": file_reference_uuids,
+        "pattern": "image_01_channel{%d}_slice{%d}_time{%d}",
+    }
+    yaml = YAML(typ="safe")
+    proposal_path = Path(tmpdir) / "proposal_details.yaml"
+    yaml.dump(
+        [
+            proposal_details_for_input,
+        ],
+        proposal_path,
+    )
+
+    return proposal_path
+
+
+@pytest.fixture
+def test_api_client():
+    return get_api_client("local")
+
+
+def test_cli_assign_from_proposal_command(
+    data_in_api,
+    test_api_client,
+    assign_from_proposal_input_path_yaml,
+    expected_bia_image,
+    expected_uploaded_by_submitter_representation,
+):
+    # This implicitly tests the 'assign' and 'create' commands
+    runner = CliRunner(mix_stderr=False)
+
+    # result = cli.assign_from_proposal(
+    #       Path(assign_from_proposal_input_path),
+    #       "local",
+    # )
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "assign-from-proposal",
+            f"{assign_from_proposal_input_path_yaml}",
+            "--api",
+            "local",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    # Check BIA image and UPLOADED_BY_SUBMITTER representation objects created.
+    #
+    # TODO: Investigate issue commented on below.
+    # At time of writing test (21/02/2025), there are subtle differences in
+    # API models and bia_data_models (e.g. Pydantic serializer warnings around type of
+    # AttributeProvenance which may be leading to:
+    #     <AttributeProvenance.bia_conversion: 'bia_conversion' (bia_data_model) vs
+    #     <AttributeProvenance.BIA_CONVERSION: 'bia_conversion' (api)
+    # so convert returned value to bia_data_model.* before comparison)
+    created_bia_image_dict = test_api_client.get_image(
+        str(expected_bia_image.uuid)
+    ).model_dump()
+    created_bia_image = bia_data_model.Image.model_validate(created_bia_image_dict)
+    assert created_bia_image == expected_bia_image
+
+    created_uploaded_by_submitter_representation_dict = (
+        test_api_client.get_image_representation(
+            str(expected_uploaded_by_submitter_representation.uuid)
+        ).model_dump()
+    )
+    created_uploaded_by_submitter_representation = (
+        bia_data_model.ImageRepresentation.model_validate(
+            created_uploaded_by_submitter_representation_dict
+        )
+    )
+    assert (
+        created_uploaded_by_submitter_representation
+        == expected_uploaded_by_submitter_representation
+    )

--- a/bia-assign-image/tests/test_image_representation.py
+++ b/bia-assign-image/tests/test_image_representation.py
@@ -49,3 +49,8 @@ def test_create_representation_of_single_image(
     )
 
     assert created == expected
+
+
+# TODO: Write test for creation of image representation where
+# Image has original_file_references with more than one format
+# e.g. file1.hdr and file1.img

--- a/bia-assign-image/tests/test_store_object_in_api_idempotent.py
+++ b/bia-assign-image/tests/test_store_object_in_api_idempotent.py
@@ -15,13 +15,15 @@ from bia_assign_image.api_client import (
 def new_study_object() -> bia_data_model.Study:
     # Create unique uuid based on current timestamp
     timestamp = datetime.strftime(datetime.now(), "%d-%m-%Y-%H:%M:%S:%f")
-    study_uuid = uuid_creation.create_study_uuid(timestamp)
+    accession_id = f"S-BIAD-TEST-STORE-OBJECT-IN-API-IDEMPOTENT-{timestamp}"
+    study_uuid = uuid_creation.create_study_uuid(accession_id)
 
-    # Load study from test data
+    # Load a random study from test data
     study_path = Path(__file__).parent / "input_data" / "study"
     study_json = next(p for p in study_path.rglob("./*/*.json"))
     study = bia_data_model.Study.model_validate_json(study_json.read_text())
     study.uuid = study_uuid
+    study.accession_id = accession_id
     return study
 
 


### PR DESCRIPTION
Modifications and tests to allow inclusion of pattern when assigning images and changes to make image assignment handle many file references -> 1 image. See [Clickup ticket](https://app.clickup.com/t/8698pbu90)