### PR TITLE
Save WIP - write mapping function for image representation

### DIFF
--- a/bia-assign-image/README.md
+++ b/bia-assign-image/README.md
@@ -67,3 +67,6 @@ value for the `--reps-to-create` option. E.g. to create THUMBNAIL and STATIC_DIS
 ```sh
 $ poetry run bia-assign-image representations create --reps-to-create THUMBNAIL --reps-to-create STATIC_DISPLAY S-BIAD1285 92fd093d-c8d2-4d89-ba28-9a9891cec73f
 ```
+
+### Migrating images and image representations to 2025/04 models
+In April 2025 the BIA models were updated. The [scripts](./scripts) directory contains functions and a cli script to enable migration of Image and ImageRepresentation models to the 2025/04 versions.

--- a/bia-assign-image/bia_assign_image/api_client.py
+++ b/bia-assign-image/bia_assign_image/api_client.py
@@ -103,6 +103,9 @@ def store_object_in_api_idempotent(api_client, model_object):
     # different versions of exactly the same object)
     equivalent_api_object.version = api_copy_of_object.version
     if equivalent_api_object == api_copy_of_object:
+        logger.info(
+            f"Exact copy of {model_name} with UUID {model_object_uuid} already in API. Nothing to do."
+        )
         return
     else:
         equivalent_api_object.version = api_copy_of_object.version + 1

--- a/bia-assign-image/bia_assign_image/api_client.py
+++ b/bia-assign-image/bia_assign_image/api_client.py
@@ -98,10 +98,14 @@ def store_object_in_api_idempotent(api_client, model_object):
         post_func(equivalent_api_object)
         return
 
+    # Negate the difference in value of the version field.
+    # We want to compare differences in actual values (we can have
+    # different versions of exactly the same object)
+    equivalent_api_object.version = api_copy_of_object.version
     if equivalent_api_object == api_copy_of_object:
         return
     else:
-        model_object.version += 1
+        equivalent_api_object.version = api_copy_of_object.version + 1
 
         logger.info(f"Updating {model_name} with UUID {model_object_uuid} in API")
-        post_func(model_object)
+        post_func(equivalent_api_object)

--- a/bia-assign-image/bia_assign_image/cli.py
+++ b/bia-assign-image/bia_assign_image/cli.py
@@ -115,13 +115,8 @@ def assign(
         bia_specimen = specimen.get_specimen(
             study_uuid,
             image_uuid,
-            # TODO: Discuss if these should be saved to dataset additional_metadata as lists
-            [
-                image_preparation_protocol_uuid,
-            ],
-            [
-                bio_sample_uuid,
-            ],
+            image_preparation_protocol_uuid,
+            bio_sample_uuid,
         )
         if dryrun:
             logger.info(
@@ -138,9 +133,7 @@ def assign(
         study_uuid,
         image_uuid,
         bia_specimen.uuid,
-        [
-            image_acquisition_protocol_uuid,
-        ],
+        image_acquisition_protocol_uuid,
     )
     if dryrun:
         logger.info(

--- a/bia-assign-image/scripts/README.md
+++ b/bia-assign-image/scripts/README.md
@@ -1,0 +1,15 @@
+## Description
+In April 2025 the BIA models were updated. This directory contains functions and a cli script to enable migration of Image and ImageRepresentation models to the 2025/04 versions.
+
+## Usage
+### Pre-requisites
+1. The parent study of an Image to be migrated must have been ingested
+2. A file containing the json dump of the Image(s) and associated FileReference and ImageRepresentation objects exists. The structure expected can be seen in [test-file-reference-mapping.json](../tests/test_data/migrate_to_2025_04_models/pre_2025_04_models/test-file-reference-mapping.json).
+
+### Command
+Assuming location is `bia-integrator/bia-assign-image`
+```sh
+poetry run bia-assign-image propose-images S-BIAD1423 proposals.txt --max-items 5
+```
+
+This will create the 2025/04 version of Images in the json file and associated representations for what used to be called `UPLOADED_BY_SUBMITTER` and `INTERACTIVE_DISPLAY` representations. The urls of the former `THUMBNAIL` and `STATIC_DISPLAY` representations will be attributes in the `additional_metadata` field of the resulting Image object.

--- a/bia-assign-image/scripts/map_image_related_artefacts_to_2025_04_models.py
+++ b/bia-assign-image/scripts/map_image_related_artefacts_to_2025_04_models.py
@@ -1,36 +1,70 @@
-from bia_shared_datamodels import bia_data_model, semantic_models, uuid_creation
-import re
+from bia_shared_datamodels import bia_data_model, uuid_creation
+import copy
+from bia_assign_image.cli import assign
+from bia_assign_image.api_client import get_api_client
+
+
+def map_image_to_2025_04_model(
+    old_image_dict: dict,
+    accession_id: str,
+    file_reference_uuids_2025_04: list,
+    dataset_uuid_2025_04: str,
+    api_target,
+) -> bia_data_model.Image:
+    image_dict = copy.deepcopy(old_image_dict)
+    image_dict["model"] = {"type_name": "Image", "version": 2}
+
+    # Make file_reference_uuids a list of strings (because of quirky
+    # way the typer cli arguments are implemented in bia_assign_image.cli.assign)
+    file_reference_uuids = [
+        " ".join([str(f) for f in file_reference_uuids_2025_04]),
+    ]
+
+    image_uuid = assign(accession_id, file_reference_uuids, api_target)
+
+    api_client = get_api_client(api_target)
+    mapped_image = api_client.get_image(image_uuid)
+    return bia_data_model.Image.model_validate(mapped_image.to_dict())
 
 
 def map_image_representation_to_2025_04_model(
-    image_representation_dict: dict, image_2025_04_uuid: str
+    old_image_representation_dict: dict,
+    image_2025_04_uuid: str,
+    accession_id: str,
 ) -> bia_data_model.ImageRepresentation:
+    image_representation_dict = copy.deepcopy(old_image_representation_dict)
+
     # Get study accession ID from file uri
-    pattern = r"^.*/(S-[A-Za-z0-9_\-]+)/.*$"
-    matcher = re.compile(pattern)
-    file_uri = ",".join(image_representation_dict["file_uri"])
-    accession_id = matcher.findall(file_uri)[0]
+    # pattern = r"^.*/(S-[A-Za-z0-9_\-]+)/.*$"
+    # matcher = re.compile(pattern)
+    # file_uri = ",".join(image_representation_dict["file_uri"])
+    # accession_id = matcher.findall(file_uri)[0]
     study_uuid = uuid_creation.create_study_uuid(accession_id)
 
-    # TODO: Discuss what unique_str for image_rep uuid should be with Team.
-    # For now using str(use_type)+format as unique string
-    if isinstance(
-        image_representation_dict["use_type"],
-        semantic_models.ImageRepresentationUseType,
-    ):
-        use_type = image_representation_dict["use_type"].value
+    image_representation_dict["model"] = {
+        "type_name": "ImageRepresentation",
+        "version": 4,
+    }
+
+    use_type = image_representation_dict.pop("use_type")
+    if use_type == "UPLOADED_BY_SUBMITTER":
+        unique_string = f"{image_2025_04_uuid}"
+        object_creator = "bia_image_assignment"
+    elif use_type == "INTERACTIVE_DISPLAY":
+        conversion_function = {
+            "conversion_function": "map_image_representation_to_2025_04_model"
+        }
+        unique_string = f"{conversion_function}"
+        object_creator = "bia_image_conversion"
     else:
-        use_type = image_representation_dict["use_type"]
-    unique_string = f"{use_type}{image_representation_dict['image_format']}"
+        raise Exception(f"Use type{use_type} is not mapped to 2025/04 models")
     image_representation_uuid = uuid_creation.create_image_representation_uuid(
         study_uuid, unique_string
     )
 
     image_representation_dict["uuid"] = image_representation_uuid
     image_representation_dict["representation_of_uuid"] = image_2025_04_uuid
-    image_representation_dict["object_creator"] = (
-        semantic_models.Provenance.bia_image_conversion
-    )
+    image_representation_dict["object_creator"] = object_creator
     image_representation_dict["voxel_physical_size_x"] = image_representation_dict.pop(
         "physical_size_x"
     )
@@ -47,10 +81,10 @@ def map_image_representation_to_2025_04_model(
     )
     image_representation_dict["additional_metadata"].append(
         {
-            "provenance": semantic_models.Provenance.bia_ingest,
+            "provenance": object_creator,
             "name": "uuid_unique_input",
             "value": {
-                "uuid_unique_input": f"{use_type}{image_representation_dict['image_format']}"
+                "uuid_unique_input": unique_string,
             },
         }
     )

--- a/bia-assign-image/scripts/map_image_related_artefacts_to_2025_04_models.py
+++ b/bia-assign-image/scripts/map_image_related_artefacts_to_2025_04_models.py
@@ -1,0 +1,58 @@
+from bia_shared_datamodels import bia_data_model, semantic_models, uuid_creation
+import re
+
+
+def map_image_representation_to_2025_04_model(
+    image_representation_dict: dict, image_2025_04_uuid: str
+) -> bia_data_model.ImageRepresentation:
+    # Get study accession ID from file uri
+    pattern = r"^.*/(S-[A-Za-z0-9_\-]+)/.*$"
+    matcher = re.compile(pattern)
+    file_uri = ",".join(image_representation_dict["file_uri"])
+    accession_id = matcher.findall(file_uri)[0]
+    study_uuid = uuid_creation.create_study_uuid(accession_id)
+
+    # TODO: Discuss what unique_str for image_rep uuid should be with Team.
+    # For now using str(use_type)+format as unique string
+    if isinstance(
+        image_representation_dict["use_type"],
+        semantic_models.ImageRepresentationUseType,
+    ):
+        use_type = image_representation_dict["use_type"].value
+    else:
+        use_type = image_representation_dict["use_type"]
+    unique_string = f"{use_type}{image_representation_dict['image_format']}"
+    image_representation_uuid = uuid_creation.create_image_representation_uuid(
+        study_uuid, unique_string
+    )
+
+    image_representation_dict["uuid"] = image_representation_uuid
+    image_representation_dict["representation_of_uuid"] = image_2025_04_uuid
+    image_representation_dict["object_creator"] = (
+        semantic_models.Provenance.bia_image_conversion
+    )
+    image_representation_dict["voxel_physical_size_x"] = image_representation_dict.pop(
+        "physical_size_x"
+    )
+    image_representation_dict["voxel_physical_size_y"] = image_representation_dict.pop(
+        "physical_size_y"
+    )
+    image_representation_dict["voxel_physical_size_z"] = image_representation_dict.pop(
+        "physical_size_z"
+    )
+
+    # TODO: Map attributes and add DocumentUUIDUinqueInputAttribute
+    image_representation_dict["additional_metadata"] = image_representation_dict.pop(
+        "attribute"
+    )
+    image_representation_dict["additional_metadata"].append(
+        {
+            "provenance": semantic_models.Provenance.bia_ingest,
+            "name": "uuid_unique_input",
+            "value": {
+                "uuid_unique_input": f"{use_type}{image_representation_dict['image_format']}"
+            },
+        }
+    )
+
+    return bia_data_model.ImageRepresentation.model_validate(image_representation_dict)

--- a/bia-assign-image/scripts/script_cli.py
+++ b/bia-assign-image/scripts/script_cli.py
@@ -1,0 +1,101 @@
+import re
+from pathlib import Path
+import json
+from typing import Annotated
+import typer
+from bia_assign_image.api_client import (
+    ApiTarget,
+)
+from scripts.map_image_related_artefacts_to_2025_04_models import (
+    map_image_related_artefacts_to_2025_04_models,
+)
+
+# For read only client
+
+import logging
+
+app = typer.Typer()
+map_app = typer.Typer()
+app.add_typer(
+    map_app,
+    name="map",
+    help="Map image related artefacts to 2025/04 models",
+)
+
+logging.basicConfig(
+    #    level=logging.INFO, format="%(message)s", handlers=[RichHandler(show_time=False)]
+    level=logging.INFO,
+    format="%(message)s",
+)
+
+logger = logging.getLogger()
+
+
+def _get_accession_id(file_reference_mapping: dict) -> str | None:
+    """Return the accession ID associated with the mapping"""
+
+    pattern = r"^.*/(S-[A-Za-z0-9_\-]+)/.*$"
+    matcher = re.compile(pattern)
+
+    file_references = file_reference_mapping.get("file_reference")
+    if file_references:
+        accession_id = matcher.findall(file_references[0]["uri"])
+        if accession_id:
+            return accession_id[0]
+
+    image_representations = file_reference_mapping.get("image_representation")
+    if image_representations:
+        for image_representation in image_representations:
+            accession_id = matcher.findall(image_representation["file_uri"][0])
+            if accession_id:
+                return accession_id[0]
+
+    return None
+
+
+@app.command(help="Map image related artefacts to 2025/04 models")
+def map2(
+    file_reference_mapping_path: Annotated[Path, typer.Argument()],
+    api_target: Annotated[
+        ApiTarget, typer.Option("--api", "-a", case_sensitive=False)
+    ] = ApiTarget.local,
+    dryrun: Annotated[bool, typer.Option()] = False,
+) -> str:
+    file_reference_mappings = json.loads(file_reference_mapping_path.read_text())
+
+    for file_reference_mapping in file_reference_mappings.values():
+        # file_references = image_to_process.pop("file_references", {})
+        # image_representations = image_to_process.pop("image_representation", {})
+        accession_id = _get_accession_id(file_reference_mapping)
+
+        if accession_id:
+            # mapped_artefacts = map_image_related_artefacts_to_2025_04_models(
+            map_image_related_artefacts_to_2025_04_models(
+                file_reference_mapping,
+                accession_id,
+                api_target,
+            )
+
+
+@map_app.command(help="Map image related artefacts to 2025/04 models")
+def map(
+    file_reference_mapping_path: Annotated[Path, typer.Argument()],
+    api_target: Annotated[
+        ApiTarget, typer.Option("--api", "-a", case_sensitive=False)
+    ] = ApiTarget.prod,
+    dryrun: Annotated[bool, typer.Option()] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
+) -> None:
+    """Map image related artefacts to 2025/04 models"""
+
+    if verbose:
+        logger.setLevel(logging.DEBUG)
+
+
+@app.callback()
+def main() -> None:
+    return
+
+
+if __name__ == "__main__":
+    app()

--- a/bia-assign-image/scripts/script_cli.py
+++ b/bia-assign-image/scripts/script_cli.py
@@ -12,8 +12,6 @@ from scripts.map_image_related_artefacts_to_2025_04_models import (
     map_image_related_artefacts_to_2025_04_models,
 )
 
-# For read only client
-
 import logging
 
 app = typer.Typer()

--- a/bia-assign-image/tests/input_data/bio_sample/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/231efe62-9369-4009-adc6-3dadb3497105.json
+++ b/bia-assign-image/tests/input_data/bio_sample/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/231efe62-9369-4009-adc6-3dadb3497105.json
@@ -1,0 +1,39 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "231efe62-9369-4009-adc6-3dadb3497105",
+  "version": 0,
+  "model": {
+    "type_name": "BioSample",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Biosample-1"
+      }
+    }
+  ],
+  "title": "Template BioSample",
+  "organism_classification": [
+    {
+      "additional_metadata": [
+      ],
+      "common_name": "Test Common Name",
+      "scientific_name": "Test Scientific Name",
+      "ncbi_id": "Test_NCBI_ID"
+    }
+  ],
+  "biological_entity_description": "Test biological entity description",
+  "experimental_variable_description": [
+    "Description of experimental variable"
+  ],
+  "extrinsic_variable_description": [
+    "Description of external treatment"
+  ],
+  "intrinsic_variable_description": [
+    "Description of internal treatment"
+  ],
+  "growth_protocol_uuid": "c52eeff8-91cd-4d39-a2ac-540f31251df6"
+}

--- a/bia-assign-image/tests/input_data/bio_sample/S-BIAD609/b33e4038-34c2-44d1-9a03-b9cc125a1198.json
+++ b/bia-assign-image/tests/input_data/bio_sample/S-BIAD609/b33e4038-34c2-44d1-9a03-b9cc125a1198.json
@@ -16,7 +16,7 @@
   ],
   "organism_classification": [
     {
-      "attribute": [],
+      "additional_metadata": [],
       "common_name": "mouse",
       "scientific_name": "Mus musculus",
       "ncbi_id": null

--- a/bia-assign-image/tests/input_data/bio_sample/S-BIAD609/b33e4038-34c2-44d1-9a03-b9cc125a1198.json
+++ b/bia-assign-image/tests/input_data/bio_sample/S-BIAD609/b33e4038-34c2-44d1-9a03-b9cc125a1198.json
@@ -1,0 +1,30 @@
+{
+  "object_creator": "bia_ingest",
+  "title": "Biosamples",
+  "uuid": "b33e4038-34c2-44d1-9a03-b9cc125a1198",
+  "version": 0,
+  "model": {
+    "type_name": "BioSample",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+        "provenance": "bia_ingest",
+        "name": "uuid_unique_input",
+        "value": {"uuid_unique_input": "Biosample-1"}
+    }
+  ],
+  "organism_classification": [
+    {
+      "attribute": [],
+      "common_name": "mouse",
+      "scientific_name": "Mus musculus",
+      "ncbi_id": null
+    }
+  ],
+  "biological_entity_description": "Adult mice choroid plexus, Cerebellum, Cortex, Hippocampus, Olfactory bulb, Striatum, Brainstem and primary choroid plexus epithelial cells.",
+  "experimental_variable_description": [],
+  "extrinsic_variable_description": [],
+  "intrinsic_variable_description": [],
+  "growth_protocol_uuid": null
+}

--- a/bia-assign-image/tests/input_data/dataset/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/df381b39-0768-493e-90ed-7c653f012f1f.json
+++ b/bia-assign-image/tests/input_data/dataset/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/df381b39-0768-493e-90ed-7c653f012f1f.json
@@ -1,0 +1,64 @@
+{
+  "object_creator": "submitter",
+  "uuid": "df381b39-0768-493e-90ed-7c653f012f1f",
+  "version": 0,
+  "model": {
+    "type_name": "Dataset",
+    "version": 2
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "image_acquisition_protocol_uuid",
+      "value": {
+        "image_acquisition_protocol_uuid": "caeee34b-eb73-4e39-a071-f0d3a7845bf5"
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "specimen_imaging_preparation_protocol_uuid",
+      "value": {
+        "specimen_imaging_preparation_protocol_uuid": "114e708b-7ee2-434a-9bc0-73c44610cc55"
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "bio_sample_uuid",
+      "value": {
+        "bio_sample_uuid": "231efe62-9369-4009-adc6-3dadb3497105"
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Study Component-1"
+      }
+    }
+  ],
+  "title": "Dataset to test mapping of Image to 2025/04 models",
+  "description": "Template description",
+  "analysis_method": [
+    {
+      "additional_metadata": [
+      ],
+      "title": "Template analysis method title",
+      "protocol_description": "Template Analysis method",
+      "features_analysed": "Template features analysed"
+    }
+  ],
+  "correlation_method": [
+    {
+      "additional_metadata": [
+      ],
+      "title": "Template correlation method title",
+      "protocol_description": "Template Analysis method",
+      "fiducials_used": "Template fiducials used",
+      "transformation_matrix": "Template transformation matrix"
+    }
+  ],
+  "example_image_uri": [
+    "https://dummy.url.org"
+  ],
+  "submitted_in_study_uuid": "8cdee837-8a13-44b7-82a1-cf26509095d0"
+}

--- a/bia-assign-image/tests/input_data/dataset/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/df381b39-0768-493e-90ed-7c653f012f1f.json
+++ b/bia-assign-image/tests/input_data/dataset/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/df381b39-0768-493e-90ed-7c653f012f1f.json
@@ -11,21 +11,21 @@
       "provenance": "bia_ingest",
       "name": "image_acquisition_protocol_uuid",
       "value": {
-        "image_acquisition_protocol_uuid": "caeee34b-eb73-4e39-a071-f0d3a7845bf5"
+        "image_acquisition_protocol_uuid": ["caeee34b-eb73-4e39-a071-f0d3a7845bf5"]
       }
     },
     {
       "provenance": "bia_ingest",
       "name": "specimen_imaging_preparation_protocol_uuid",
       "value": {
-        "specimen_imaging_preparation_protocol_uuid": "114e708b-7ee2-434a-9bc0-73c44610cc55"
+        "specimen_imaging_preparation_protocol_uuid": ["114e708b-7ee2-434a-9bc0-73c44610cc55"]
       }
     },
     {
       "provenance": "bia_ingest",
       "name": "bio_sample_uuid",
       "value": {
-        "bio_sample_uuid": "231efe62-9369-4009-adc6-3dadb3497105"
+        "bio_sample_uuid": ["231efe62-9369-4009-adc6-3dadb3497105"]
       }
     },
     {

--- a/bia-assign-image/tests/input_data/dataset/S-BIAD-TEST-ASSIGN-IMAGE/618a79d1-696b-462d-a678-d0dc021a302c.json
+++ b/bia-assign-image/tests/input_data/dataset/S-BIAD-TEST-ASSIGN-IMAGE/618a79d1-696b-462d-a678-d0dc021a302c.json
@@ -16,21 +16,21 @@
       "provenance": "bia_ingest",
       "name": "image_acquisition_protocol_uuid",
       "value": {
-        "image_acquisition_protocol_uuid": "beaf6bca-b65f-402e-a9d0-e31ec2af28ad"
+        "image_acquisition_protocol_uuid": ["beaf6bca-b65f-402e-a9d0-e31ec2af28ad"]
       }
     },
     {
       "provenance": "bia_ingest",
       "name": "specimen_imaging_preparation_protocol_uuid",
       "value": {
-        "specimen_imaging_preparation_protocol_uuid": "7c516081-fd9c-4919-bc88-6b92580a59a0"
+        "specimen_imaging_preparation_protocol_uuid": ["7c516081-fd9c-4919-bc88-6b92580a59a0"]
       }
     },
     {
       "provenance": "bia_ingest",
       "name": "bio_sample_uuid",
       "value": {
-        "bio_sample_uuid": "52a37650-ea4c-479d-9aa2-3ba106ac6285"
+        "bio_sample_uuid": ["52a37650-ea4c-479d-9aa2-3ba106ac6285"]
       }
     }
   ],

--- a/bia-assign-image/tests/input_data/dataset/S-BIAD609/abf9ca35-01ce-4b46-83cb-071e2967ce07.json
+++ b/bia-assign-image/tests/input_data/dataset/S-BIAD609/abf9ca35-01ce-4b46-83cb-071e2967ce07.json
@@ -1,0 +1,66 @@
+{
+  "object_creator": "submitter",
+  "title": "Fluorescent images",
+  "uuid": "abf9ca35-01ce-4b46-83cb-071e2967ce07",
+  "version": 0,
+  "model": {
+    "type_name": "Dataset",
+    "version": 2
+  },
+  "additional_metadata": [
+    {
+        "provenance": "bia_ingest",
+        "name": "uuid_unique_input",
+        "value": {"uuid_unique_input": "Study Component-6"}
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "associations",
+      "value": {
+        "associations": [
+          {
+            "image_analysis": null,
+            "image_correlation": null,
+            "biosample": "Biosamples",
+            "image_acquisition": "Image acquisition",
+            "specimen": "Specimen"
+          }
+        ]
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "image_acquisition_protocol_uuid",
+      "value": {
+        "image_acquisition_protocol_uuid": [
+          "34d47349-b111-4218-abc8-467a38e74ce3"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "specimen_imaging_preparation_protocol_uuid",
+      "value": {
+        "specimen_imaging_preparation_protocol_uuid": [
+          "f40d51dd-cd38-4dcf-9bab-9ad6ccaff7c0"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "bio_sample_uuid",
+      "value": {
+        "bio_sample_uuid": [
+          "b33e4038-34c2-44d1-9a03-b9cc125a1198"
+        ]
+      }
+    }
+  ],
+  "description": "In this study, we investigated the impact of gut microbiota and SCFAs on brain barrier integrity and Alzheimer's disease pathology via different immunostainings.",
+  "analysis_method": [],
+  "correlation_method": [],
+  "example_image_uri": [
+    "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/6ff7b0a8-6cc4-4131-bd1b-b78fb8e276f0/ed9f6d05-23ca-4d95-9b8d-6db70e499402.png"
+  ],
+  "submitted_in_study_uuid": "88d36abc-c77f-4127-9551-b8409cb5d4a6"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/80ef897d-571f-401e-aeab-73c5da842c3b.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/80ef897d-571f-401e-aeab-73c5da842c3b.json
@@ -1,0 +1,29 @@
+{
+  "object_creator": "submitter",
+  "uuid": "80ef897d-571f-401e-aeab-73c5da842c3b",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "submitter",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "file_list_col1": "col1value",
+        "file_list_col2": "col2value"
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {"uuid_unique_input": "S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/file_reference1.tif3000"}
+    }
+  ],
+  "file_path": "S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/file_reference1.tif",
+  "format": "Dummy format",
+  "size_in_bytes": 3000,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/file_reference1.tif",
+  "submission_dataset_uuid": "df381b39-0768-493e-90ed-7c653f012f1f"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD-TEST-ASSIGN-IMAGE/278ffc50-3924-4b8a-bad6-d017c503e5dd.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD-TEST-ASSIGN-IMAGE/278ffc50-3924-4b8a-bad6-d017c503e5dd.json
@@ -1,0 +1,29 @@
+{
+  "object_creator": "submitter",
+  "uuid": "278ffc50-3924-4b8a-bad6-d017c503e5dd",
+  "version": 0,
+  "model": {
+    "type_name": "FileReference",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "submitter",
+      "name": "attributes_from_biostudies.File",
+      "value": {
+        "file_list_col1": "col1value",
+        "file_list_col2": "col2value"
+      }
+    },
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {"uuid_unique_input": "S-BIAD-TEST-ASSIGN-IMAGE/file_reference1.tif1000"}
+    }
+  ],
+  "file_path": "S-BIAD-TEST-ASSIGN-IMAGE/file_reference1.tif",
+  "format": "Dummy format",
+  "size_in_bytes": 1000,
+  "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD-TEST-ASSIGN-IMAGE/file_reference1.tif",
+  "submission_dataset_uuid": "618a79d1-696b-462d-a678-d0dc021a302c"
+}

--- a/bia-assign-image/tests/input_data/file_reference/S-BIAD609/6be24196-7921-4e4d-801e-df06878ee56c.json
+++ b/bia-assign-image/tests/input_data/file_reference/S-BIAD609/6be24196-7921-4e4d-801e-df06878ee56c.json
@@ -1,0 +1,34 @@
+{
+    "object_creator": "submitter",
+    "uuid": "6be24196-7921-4e4d-801e-df06878ee56c",
+    "version": 0,
+    "model": {
+        "type_name": "FileReference",
+        "version": 3
+    },
+    "additional_metadata": [
+        {
+            "provenance": "bia_ingest",
+            "name": "attributes_from_biostudies.File",
+            "value": {
+                "attributes": {
+                    "Type": "Raw image",
+                    "Tissue": "Striatum",
+                    "Genotype": "wildtype"
+                }
+            }
+        },
+        {
+            "provenance": "bia_ingest",
+            "name": "uuid_unique_input",
+            "value": {
+                "uuid_unique_input": "EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif5110968"
+            }
+        }
+    ],
+    "file_path": "EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif",
+    "format": "file",
+    "size_in_bytes": 5110968,
+    "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD609/EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif",
+    "submission_dataset_uuid": "abf9ca35-01ce-4b46-83cb-071e2967ce07"
+}

--- a/bia-assign-image/tests/input_data/image_acquisition_protocol/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/caeee34b-eb73-4e39-a071-f0d3a7845bf5.json
+++ b/bia-assign-image/tests/input_data/image_acquisition_protocol/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/caeee34b-eb73-4e39-a071-f0d3a7845bf5.json
@@ -1,0 +1,27 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "caeee34b-eb73-4e39-a071-f0d3a7845bf5",
+  "version": 0,
+  "model": {
+    "type_name": "ImageAcquisitionProtocol",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Image acquisition-3"
+      }
+    }
+  ],
+  "title": "Template image acquisition",
+  "protocol_description": "Template method description",
+  "imaging_instrument_description": "Template imaging instrument",
+  "fbbi_id": [
+    "Test FBBI ID"
+  ],
+  "imaging_method_name": [
+    "Template imaging method name"
+  ]
+}

--- a/bia-assign-image/tests/input_data/image_acquisition_protocol/S-BIAD609/34d47349-b111-4218-abc8-467a38e74ce3.json
+++ b/bia-assign-image/tests/input_data/image_acquisition_protocol/S-BIAD609/34d47349-b111-4218-abc8-467a38e74ce3.json
@@ -1,0 +1,25 @@
+{
+  "object_creator": "bia_ingest",
+  "title": "Image acquisition",
+  "uuid": "34d47349-b111-4218-abc8-467a38e74ce3",
+  "version": 0,
+  "model": {
+    "type_name": "ImageAcquisitionProtocol",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Image acquisition-3"
+      }
+    }
+  ],
+  "protocol_description": "For tight junction (TJ) stainings, the imaging was done with the  Plan-Apochromat 40×/1.4 Oil DIC M27 objective using confocal microscopy.\nFor the Aβ plaques staining, imaging of whole brain sections was conducted with Plan-Apochromat 20×/0.8 M27 objective using Axioscan Z.1.\nFor synaptic staining, imaging was done with the Plan-Apochromat 63×/1.4 Oil DIC M27 objective with the 3× zoom using confocal microscopy.",
+  "imaging_instrument_description": "Zeiss LSM780 confocal microscope and Zeiss Axioscan Z.1 ",
+  "fbbi_id": [],
+  "imaging_method_name": [
+    "fluorescence microscopy"
+  ]
+}

--- a/bia-assign-image/tests/input_data/protocol/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/c52eeff8-91cd-4d39-a2ac-540f31251df6.json
+++ b/bia-assign-image/tests/input_data/protocol/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/c52eeff8-91cd-4d39-a2ac-540f31251df6.json
@@ -1,0 +1,20 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "c52eeff8-91cd-4d39-a2ac-540f31251df6",
+  "version": 0,
+  "model": {
+    "type_name": "Protocol",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Specimen-1"
+      }
+    }
+  ],
+  "title": "Template growth protocol",
+  "protocol_description": "Template method description"
+}

--- a/bia-assign-image/tests/input_data/specimen_imaging_preparation_protocol/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/114e708b-7ee2-434a-9bc0-73c44610cc55.json
+++ b/bia-assign-image/tests/input_data/specimen_imaging_preparation_protocol/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/114e708b-7ee2-434a-9bc0-73c44610cc55.json
@@ -1,0 +1,35 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "114e708b-7ee2-434a-9bc0-73c44610cc55",
+  "version": 0,
+  "model": {
+    "type_name": "SpecimenImagingPreparationProtocol",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Specimen-1"
+      }
+    }
+  ],
+  "title": "Test specimen preparation protocol",
+  "protocol_description": "Test description",
+  "signal_channel_information": [
+    {
+      "additional_metadata": [
+        {
+          "provenance": "submitter",
+          "name": "file_list_columns",
+          "value": {}
+        }
+      ],
+      "signal_contrast_mechanism_description": "Test description",
+      "channel_content_description": "Test description",
+      "channel_biological_entity": "Test Entity",
+      "channel_label": "Test label"
+    }
+  ]
+}

--- a/bia-assign-image/tests/input_data/specimen_imaging_preparation_protocol/S-BIAD609/f40d51dd-cd38-4dcf-9bab-9ad6ccaff7c0.json
+++ b/bia-assign-image/tests/input_data/specimen_imaging_preparation_protocol/S-BIAD609/f40d51dd-cd38-4dcf-9bab-9ad6ccaff7c0.json
@@ -1,0 +1,21 @@
+{
+  "object_creator": "bia_ingest",
+  "title": "Specimen",
+  "uuid": "f40d51dd-cd38-4dcf-9bab-9ad6ccaff7c0",
+  "version": 0,
+  "model": {
+    "type_name": "SpecimenImagingPreparationProtocol",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Specimen-2"
+      }
+    }
+  ],
+  "protocol_description": "Primary mouse choroid plexus epithelial cells were isolated from P2-P7 pups as previously described (Balusu, Van Wonterghem et al., 2016). Choroid plexus tissue was isolated from the lateral and fourth ventricles, pooled and digested with pronase (Sigma-Aldrich) for 7 min. For monolayer cultures, cells were plated on 24-well plate or Transwell polyester inserts (pore size, 0.4 μm; surface area, 33.6 mm2; Corning) coated with laminin (Sigma-Aldrich). Cells were grown in DMEM/F12 medium supplemented with 10% FBS, 2 mM L-Glutamine (Gibco), 1% penicillin/streptomycin at 37°C and 5% CO2 for 1 to 2 weeks until their trans-epithelial electrical resistance (TEER) values reached a plateau.\n\nFor immunostainings on brain sections, mice were transcardially perfused with ice-cold 4% PFA in PBS. Subsequently, brains were carefully separated from the skull and split into two halves (mid-sagittal). The right hemispheres were embedded in Frozen Section Medium (Thermo Scientific) immediately in cryomolds (Sakura) that were frozen on dry ice and stored at -80°C until further use. The left hemispheres were post-fixed overnight with 4% PFA in PBS at 4°C. After dehydration, samples were embedded in paraffin in cryomolds and stored at RT until further use. The brains were cut into 5 μm slices paraffin sections (HM 340 E, Thermo Scientific) or 20 μm cryosections (CryoStar NX70, Thermo Scientific). These brain samples were cut from the sagittal superior sinus towards the border of the cerebral hemisphere. Sections were collected serially for TJ staining when the choroid plexus was initially present and and for other staining when the entire hippocampus was initially present (Fig S13). One section per mouse was analyzed. For immunofluorescence staining, sections were permeabilized in PBS containing 0.3-0.5% Triton X-100. Following being blocked with goat immunomix (GIM) (5% goat serum, 0.1% BSA, 0.3-0.5% Triton X-100 in PBS) at RT for 1 h, sections were incubated with primary Abs in GIM at 4°C overnight. After washing with PBS, sections were stained with fluorophore-conjugated secondary Abs in PBS or PBS containing 0.1% Triton X-100 at RT for 1-1.5 h. Counterstaining was done with Hoechst reagent (Sigma-Aldrich, 1:1000 in PBS). Primary antibody Occludin (cat. no. 33-1500, Thermo Scientific); E-cadherin (cat. no. 610181, BD Biosciences); IBA1 (cat. no. 019-19741, Wako); GFAP (cat. no. ab53554, Abcam); Synaptophysin (cat. no. ab32127); PSD-95 (cat. no. MA1-045, Thermo Scientific) and 6E10 (cat. no. 803001, Biolegend) were used on paraffin sections; ZO-1 (cat. no. 61-7300, Thermo Scientific) and Claudin-1 (cat. no. 51-9000, Thermo Scientific) were used on cryosections; CD31 (cat. no. DIA-310, Dianova) was used on both paraffin sections and cryosections. For immunostainings on primary cells, cells were fixed with 2% PFA for 20 min on ice. Next, cells were washed three times with PBS and permeabilized with 0.1% Triton X-100 for 10 min on ice. Samples were washed with blocking buffer (1% BSA in PBS) and incubated with primary Abs (diluted in blocking buffer) for 2 h at RT/overnight at 4°C. After washing with PBS, cells were stained with fluorophore-conjugated secondary Abs in PBS for 1 h at RT. Next, samples were counterstained with Hoechst and the sections were mounted.",
+  "signal_channel_information": []
+}

--- a/bia-assign-image/tests/input_data/study/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/8cdee837-8a13-44b7-82a1-cf26509095d0.json
+++ b/bia-assign-image/tests/input_data/study/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/8cdee837-8a13-44b7-82a1-cf26509095d0.json
@@ -1,0 +1,44 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "8cdee837-8a13-44b7-82a1-cf26509095d0",
+  "version": 0,
+  "model": {
+    "type_name": "Study",
+    "version": 3
+  },
+  "additional_metadata": [
+  ],
+  "accession_id": "S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST",
+  "licence": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "author": [
+    {
+      "rorid": "None",
+      "address": "None",
+      "website": "https://www.none.com/",
+      "orcid": "None",
+      "display_name": "Contributor1",
+      "affiliation": [
+        {
+          "rorid": "None",
+          "address": "None",
+          "website": "https://www.none.com/",
+          "display_name": "Template Affiliation Organisation"
+        }
+      ],
+      "contact_email": "contributor1@org1.ac.uk",
+      "role": "contributing author"
+    }
+  ],
+  "title": "Test study to test mapping of assigned images to 2025/04 models",
+  "release_date": "2024-06-23",
+  "description": "Template description",
+  "keyword": [
+    "Template keyword1",
+    "Template keyword2"
+  ],
+  "acknowledgement": "Template acknowledgement",
+  "see_also": [],
+  "related_publication": [],
+  "grant": [],
+  "funding_statement": "Template funding statement"
+}

--- a/bia-assign-image/tests/input_data/study/S-BIAD609/88d36abc-c77f-4127-9551-b8409cb5d4a6.json
+++ b/bia-assign-image/tests/input_data/study/S-BIAD609/88d36abc-c77f-4127-9551-b8409cb5d4a6.json
@@ -1,0 +1,173 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "88d36abc-c77f-4127-9551-b8409cb5d4a6",
+  "version": 0,
+  "model": {
+    "type_name": "Study",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "biostudies json/pagetab entry",
+      "value": {
+        "json": "https://www.ebi.ac.uk/biostudies/files/S-BIAD609/S-BIAD609.json",
+        "pagetab": "https://www.ebi.ac.uk/biostudies/files/S-BIAD609/S-BIAD609.tsv"
+      }
+    }
+  ],
+  "accession_id": "S-BIAD609",
+  "licence": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "author": [
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Junhua Xie",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "junhuax@irc.vib-ugent.be",
+      "role": "first author"
+    },
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Arnout Bruggeman",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "Arnout.Bruggeman@irc.vib-ugent.be",
+      "role": null
+    },
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Clint De Nolf",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "clint.denolf@irc.vib-ugent.be",
+      "role": null
+    },
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Charysse Vandendriessche",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "charyssevdd@irc.vib-ugent.be",
+      "role": null
+    },
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Griet Van Imschoot",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "grietv@irc.vib-ugent.be",
+      "role": null
+    },
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Elien Van Wonterghem",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "elienvw@irc.ugent.be",
+      "role": null
+    },
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Lars Vereecke",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "lars.vereecke@irc.vib-ugent.be",
+      "role": null
+    },
+    {
+      "rorid": null,
+      "address": null,
+      "website": null,
+      "orcid": null,
+      "display_name": "Roosmarijn E. Vandenbroucke",
+      "affiliation": [
+        {
+          "rorid": null,
+          "address": null,
+          "website": null,
+          "display_name": "VIB-UGent Center for Inflammation Research"
+        }
+      ],
+      "contact_email": "Roosmarijn.Vandenbroucke@irc.vib-ugent.be",
+      "role": "corresponding author"
+    }
+  ],
+  "title": "The importance of the blood-cerebrospinal fluid interface in the gut-brain axis and Aβ pathology",
+  "release_date": "2022-12-14",
+  "description": "In this study, we found that mice lacking gut microbiota displayed increased blood-cerebrospinal fluid (CSF) barrier permeability associated with disorganized tight junctions (TJs), which can be rescued by recolonization with gut microbiota or supplementation with short-chain fatty acids (SCFAs). We further confirmed that the vagus nerve plays an important role in this process but SCFAs can also bypass the vagus nerve and affect blood-CSF barrier functionality. Strikingly, the administration of SCFAs in AppNL-G-F AD mice also improved the localization of TJs in the blood-CSF barrier. This was accompanied by a pronounced reduction in β-amyloid (Aβ) burden, which could be achieved by regulating microglial phenotype. Altogether, our results suggest that modulating the microbiota or administering SCFAs might have therapeutic potential in AD via tightening blood-CSF barrier and maintaining microglial activity.",
+  "keyword": [
+    "Gut microbiota",
+    "short-chain fatty acids",
+    "blood-cerebrospinal fluid barrier",
+    "Alzheimer’s disease"
+  ],
+  "acknowledgement": "We thank the VIB BioImaging Core for training, support and access to the instrument park. This work was supported by the Research Foundation-Flanders (FWO), Chinese Scholarship Council (CSC), the Foundation for Alzheimer’s Research Belgium (SAO-FRA) and the Baillet Latour Fund.",
+  "see_also": [],
+  "related_publication": [],
+  "grant": [],
+  "funding_statement": ""
+}

--- a/bia-assign-image/tests/test_assign_image.py
+++ b/bia-assign-image/tests/test_assign_image.py
@@ -98,12 +98,8 @@ def test_bia_specimen(
     created_specimen = specimen.get_specimen(
         dataset.submitted_in_study_uuid,
         expected_image.uuid,
-        [
-            specimen_imaging_preparation_protocol_uuid,
-        ],
-        [
-            bio_sample_uuid,
-        ],
+        specimen_imaging_preparation_protocol_uuid,
+        bio_sample_uuid,
     )
 
     assert expected_specimen == created_specimen

--- a/bia-assign-image/tests/test_data/creation_process/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/af26940e-35c7-470a-8037-0a27d45253b9.json
+++ b/bia-assign-image/tests/test_data/creation_process/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/af26940e-35c7-470a-8037-0a27d45253b9.json
@@ -1,0 +1,26 @@
+{
+  "object_creator": "bia_image_assignment",
+  "uuid": "af26940e-35c7-470a-8037-0a27d45253b9",
+  "version": 0,
+  "model": {
+    "type_name": "CreationProcess",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_image_assignment",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "93de26f0-6d84-42a5-b6fc-fcd67a94f18e"
+      }
+    }
+  ],
+  "subject_specimen_uuid": "48b2db02-a813-4f93-ac73-78574877fd60",
+  "image_acquisition_protocol_uuid": [
+    "caeee34b-eb73-4e39-a071-f0d3a7845bf5"
+  ],
+  "input_image_uuid": [],
+  "protocol_uuid": [
+  ],
+  "annotation_method_uuid": []
+}

--- a/bia-assign-image/tests/test_data/image/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/93de26f0-6d84-42a5-b6fc-fcd67a94f18e.json
+++ b/bia-assign-image/tests/test_data/image/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/93de26f0-6d84-42a5-b6fc-fcd67a94f18e.json
@@ -1,0 +1,38 @@
+{
+  "object_creator": "bia_image_assignment",
+  "uuid": "93de26f0-6d84-42a5-b6fc-fcd67a94f18e",
+  "version": 0,
+  "model": {
+    "type_name": "Image",
+    "version": 2
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_image_assignment",
+      "name": "attributes_from_file_reference_80ef897d-571f-401e-aeab-73c5da842c3b",
+      "value": {
+        "file_list_col1": "col1value",
+        "file_list_col2": "col2value"
+      }
+    },
+    {
+      "provenance": "bia_image_assignment",
+      "name": "file_pattern",
+      "value": {
+        "file_pattern": "S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/file_reference1.tif"
+      }
+    },
+    {
+      "provenance": "bia_image_assignment",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "80ef897d-571f-401e-aeab-73c5da842c3b"
+      }
+    }
+  ],
+  "submission_dataset_uuid": "df381b39-0768-493e-90ed-7c653f012f1f",
+  "creation_process_uuid": "af26940e-35c7-470a-8037-0a27d45253b9",
+  "original_file_reference_uuid": [
+    "80ef897d-571f-401e-aeab-73c5da842c3b"
+  ]
+}

--- a/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image/S-BIAD609/71fb4f2d-6cff-495f-ae21-d1c6ab068de7.json
+++ b/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image/S-BIAD609/71fb4f2d-6cff-495f-ae21-d1c6ab068de7.json
@@ -1,7 +1,7 @@
 {
     "object_creator": "bia_image_assignment",
     "uuid": "71fb4f2d-6cff-495f-ae21-d1c6ab068de7",
-    "version": 0,
+    "version": 1,
     "model": {"type_name": "Image", "version": 2},
     "additional_metadata": [
         {
@@ -26,7 +26,25 @@
             "provenance": "bia_image_assignment",
             "name": "uuid_unique_input",
             "value": {"uuid_unique_input": "6be24196-7921-4e4d-801e-df06878ee56c"}
-        }
+        },
+        {
+      "provenance": "bia_image_assignment",
+      "name": "thumbnail_uri",
+      "value": {
+        "thumbnail_uri": [
+          "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/826f0fe5-ee2d-4d43-a612-4ce659b5426d.png"
+        ]
+      }
+    },
+    {
+      "provenance": "bia_image_assignment",
+      "name": "static_display_uri",
+      "value": {
+        "static_display_uri": [
+          "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/8a93bb61-6fef-4336-94d8-b82d106c9e63.png"
+        ]
+      }
+    }
     ],
     "submission_dataset_uuid": "abf9ca35-01ce-4b46-83cb-071e2967ce07",
     "creation_process_uuid": "59b5759e-fc74-4228-8576-b5b71ff6bda8",

--- a/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image/S-BIAD609/71fb4f2d-6cff-495f-ae21-d1c6ab068de7.json
+++ b/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image/S-BIAD609/71fb4f2d-6cff-495f-ae21-d1c6ab068de7.json
@@ -1,0 +1,34 @@
+{
+    "object_creator": "bia_image_assignment",
+    "uuid": "71fb4f2d-6cff-495f-ae21-d1c6ab068de7",
+    "version": 0,
+    "model": {"type_name": "Image", "version": 2},
+    "additional_metadata": [
+        {
+            "provenance": "bia_image_assignment",
+            "name": "attributes_from_file_reference_6be24196-7921-4e4d-801e-df06878ee56c",
+            "value": {
+                 "attributes": {
+                     "Type": "Raw image",
+                     "Tissue": "Striatum",
+                     "Genotype": "wildtype"
+                 }
+             }
+        },
+        {
+            "provenance": "bia_image_assignment",
+            "name": "file_pattern",
+            "value": {
+                "file_pattern": "EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif"
+            }
+        },
+        {
+            "provenance": "bia_image_assignment",
+            "name": "uuid_unique_input",
+            "value": {"uuid_unique_input": "6be24196-7921-4e4d-801e-df06878ee56c"}
+        }
+    ],
+    "submission_dataset_uuid": "abf9ca35-01ce-4b46-83cb-071e2967ce07",
+    "creation_process_uuid": "59b5759e-fc74-4228-8576-b5b71ff6bda8",
+    "original_file_reference_uuid": ["6be24196-7921-4e4d-801e-df06878ee56c"]
+}

--- a/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image_representation/S-BIAD609/2a8ecffd-6690-494f-acbb-81fb94f2df30.json
+++ b/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image_representation/S-BIAD609/2a8ecffd-6690-494f-acbb-81fb94f2df30.json
@@ -1,0 +1,55 @@
+{
+    "uuid": "2a8ecffd-6690-494f-acbb-81fb94f2df30",
+    "representation_of_uuid": "71fb4f2d-6cff-495f-ae21-d1c6ab068de7",
+    "image_format": ".ome.zarr",
+    "total_size_in_bytes": 0,
+    "size_x": 1125,
+    "size_y": 1125,
+    "size_z": 1,
+    "size_c": 2,
+    "size_t": 1,
+    "version": 0,
+    "file_uri": [
+        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/7e0044da-f64a-472a-924e-0395084ba26f.ome.zarr/0"
+    ],
+    "object_creator": "bia_image_conversion",
+    "model": {"type_name": "ImageRepresentation", "version": 4},
+    "additional_metadata": [
+        {
+            "provenance": "bia_image_conversion",
+            "name": "attributes_from_ome.zarr",
+            "value": {
+                "BigEndian": "true",
+                "DimensionOrder": "XYZCT",
+                "ID": "Pixels:0",
+                "Interleaved": "false",
+                "PhysicalSizeX": "0.266517985166675",
+                "PhysicalSizeXUnit": "\u00b5m",
+                "PhysicalSizeY": "0.266517985166675",
+                "PhysicalSizeYUnit": "\u00b5m",
+                "SignificantBits": "16",
+                "Type": "uint16",
+                "{http://www.openmicroscopy.org/Schemas/OME/2016-06}Channel": [
+                    {
+                        "ID": "Channel:0:0",
+                        "SamplesPerPixel": "1",
+                        "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                    },
+                    {
+                        "ID": "Channel:0:1",
+                        "SamplesPerPixel": "1",
+                        "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                    }
+                ],
+                "{http://www.openmicroscopy.org/Schemas/OME/2016-06}MetadataOnly": null
+            }
+        },
+        {
+            "provenance": "bia_image_conversion",
+            "name": "uuid_unique_input",
+            "value": {
+                "uuid_unique_input": "{'conversion_function': 'map_image_representation_to_2025_04_model'}"
+            }
+        }
+    ]
+}

--- a/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image_representation/S-BIAD609/4d73dd9d-2885-4f92-97a6-69e44be4a7d8.json
+++ b/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image_representation/S-BIAD609/4d73dd9d-2885-4f92-97a6-69e44be4a7d8.json
@@ -1,0 +1,55 @@
+{
+    "uuid": "4d73dd9d-2885-4f92-97a6-69e44be4a7d8",
+    "representation_of_uuid": "71fb4f2d-6cff-495f-ae21-d1c6ab068de7",
+    "image_format": ".ome.zarr",
+    "total_size_in_bytes": 0,
+    "size_x": 1125,
+    "size_y": 1125,
+    "size_z": 1,
+    "size_c": 2,
+    "size_t": 1,
+    "version": 0,
+    "file_uri": [
+        "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/7e0044da-f64a-472a-924e-0395084ba26f.ome.zarr/0"
+    ],
+    "object_creator": "bia_image_conversion",
+    "model": {"type_name": "ImageRepresentation", "version": 4},
+    "additional_metadata": [
+        {
+            "provenance": "bia_image_conversion",
+            "name": "attributes_from_ome.zarr",
+            "value": {
+                "BigEndian": "true",
+                "DimensionOrder": "XYZCT",
+                "ID": "Pixels:0",
+                "Interleaved": "false",
+                "PhysicalSizeX": "0.266517985166675",
+                "PhysicalSizeXUnit": "\u00b5m",
+                "PhysicalSizeY": "0.266517985166675",
+                "PhysicalSizeYUnit": "\u00b5m",
+                "SignificantBits": "16",
+                "Type": "uint16",
+                "{http://www.openmicroscopy.org/Schemas/OME/2016-06}Channel": [
+                    {
+                        "ID": "Channel:0:0",
+                        "SamplesPerPixel": "1",
+                        "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                    },
+                    {
+                        "ID": "Channel:0:1",
+                        "SamplesPerPixel": "1",
+                        "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                    }
+                ],
+                "{http://www.openmicroscopy.org/Schemas/OME/2016-06}MetadataOnly": null
+            }
+        },
+        {
+            "provenance": "bia_image_conversion",
+            "name": "uuid_unique_input",
+            "value": {
+                "uuid_unique_input": "{'conversion_function': 'bioformats2raw';'parameters': 'default'}"
+            }
+        }
+    ]
+}

--- a/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image_representation/S-BIAD609/87f9f5e7-473e-4c81-afbf-1dcd148492f4.json
+++ b/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image_representation/S-BIAD609/87f9f5e7-473e-4c81-afbf-1dcd148492f4.json
@@ -1,0 +1,21 @@
+{
+    "uuid": "87f9f5e7-473e-4c81-afbf-1dcd148492f4",
+    "representation_of_uuid": "71fb4f2d-6cff-495f-ae21-d1c6ab068de7",
+    "image_format": ".tiff",
+    "total_size_in_bytes": 5110968,
+    "version": 0,
+    "file_uri": [
+        "https://www.ebi.ac.uk/biostudies/files/S-BIAD609/EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif"
+    ],
+    "object_creator": "bia_image_assignment",
+    "model": {"type_name": "ImageRepresentation", "version": 4},
+    "additional_metadata": [
+        {
+            "provenance": "bia_image_assignment",
+            "name": "uuid_unique_input",
+            "value": {
+                "uuid_unique_input": "71fb4f2d-6cff-495f-ae21-d1c6ab068de7"
+            }
+        }
+    ]
+}

--- a/bia-assign-image/tests/test_data/migrate_to_2025_04_models/pre_2025_04_models/test-file-reference-mapping.json
+++ b/bia-assign-image/tests/test_data/migrate_to_2025_04_models/pre_2025_04_models/test-file-reference-mapping.json
@@ -1,0 +1,188 @@
+{
+    "56ead10e-7f19-4ab0-9f17-bf5608fb5e78": {
+        "uuid": "56ead10e-7f19-4ab0-9f17-bf5608fb5e78",
+        "version": 0,
+        "model": {
+            "type_name": "Image",
+            "version": 1
+        },
+        "attribute": [
+            {
+                "provenance": "bia_conversion",
+                "name": "attributes_from_file_reference_502b2fd6-44c6-4609-b580-d3b74cf6d1e9",
+                "value": {
+                    "attributes": {
+                        "Type": "Raw image",
+                        "Tissue": "Striatum",
+                        "Genotype": "wildtype"
+                    }
+                }
+            }
+        ],
+        "submission_dataset_uuid": "8732e307-9251-4ac9-8207-ec3fecd9e726",
+        "creation_process_uuid": "c949f64a-48b0-4256-bd6f-b5d62cce0540",
+        "original_file_reference_uuid": [
+            "502b2fd6-44c6-4609-b580-d3b74cf6d1e9"
+        ],
+        "file_reference": [
+            {
+                "uuid": "502b2fd6-44c6-4609-b580-d3b74cf6d1e9",
+                "version": 0,
+                "model": {
+                    "type_name": "FileReference",
+                    "version": 2
+                },
+                "attribute": [
+                    {
+                        "provenance": "bia_ingest",
+                        "name": "attributes_from_biostudies.File",
+                        "value": {
+                            "attributes": {
+                                "Type": "Raw image",
+                                "Tissue": "Striatum",
+                                "Genotype": "wildtype"
+                            }
+                        }
+                    }
+                ],
+                "file_path": "EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif",
+                "format": "file",
+                "size_in_bytes": 5110968,
+                "uri": "https://www.ebi.ac.uk/biostudies/files/S-BIAD609/EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif",
+                "submission_dataset_uuid": "8732e307-9251-4ac9-8207-ec3fecd9e726"
+            }
+        ],
+        "image_representation": [
+            {
+                "uuid": "06631305-8cd7-4ad0-8fb9-7f4bbc2b3a48",
+                "version": 0,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 3
+                },
+                "attribute": [],
+                "image_format": ".png",
+                "use_type": "THUMBNAIL",
+                "file_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/826f0fe5-ee2d-4d43-a612-4ce659b5426d.png"
+                ],
+                "total_size_in_bytes": 0,
+                "physical_size_x": null,
+                "physical_size_y": null,
+                "physical_size_z": null,
+                "size_x": null,
+                "size_y": null,
+                "size_z": null,
+                "size_c": null,
+                "size_t": null,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "56ead10e-7f19-4ab0-9f17-bf5608fb5e78"
+            },
+            {
+                "uuid": "1bebb930-ed36-4edd-a3c2-0859bc5e069d",
+                "version": 0,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 3
+                },
+                "attribute": [
+                    {
+                        "provenance": "bia_conversion",
+                        "name": "attributes_from_ome.zarr",
+                        "value": {
+                            "BigEndian": "true",
+                            "DimensionOrder": "XYZCT",
+                            "ID": "Pixels:0",
+                            "Interleaved": "false",
+                            "PhysicalSizeX": "0.266517985166675",
+                            "PhysicalSizeXUnit": "\u00b5m",
+                            "PhysicalSizeY": "0.266517985166675",
+                            "PhysicalSizeYUnit": "\u00b5m",
+                            "SignificantBits": "16",
+                            "Type": "uint16",
+                            "{http://www.openmicroscopy.org/Schemas/OME/2016-06}Channel": [
+                                {
+                                    "ID": "Channel:0:0",
+                                    "SamplesPerPixel": "1",
+                                    "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                                },
+                                {
+                                    "ID": "Channel:0:1",
+                                    "SamplesPerPixel": "1",
+                                    "{http://www.openmicroscopy.org/Schemas/OME/2016-06}LightPath": null
+                                }
+                            ],
+                            "{http://www.openmicroscopy.org/Schemas/OME/2016-06}MetadataOnly": null
+                        }
+                    }
+                ],
+                "image_format": ".ome.zarr",
+                "use_type": "INTERACTIVE_DISPLAY",
+                "file_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/7e0044da-f64a-472a-924e-0395084ba26f.ome.zarr/0"
+                ],
+                "total_size_in_bytes": 0,
+                "physical_size_x": null,
+                "physical_size_y": null,
+                "physical_size_z": null,
+                "size_x": 1125,
+                "size_y": 1125,
+                "size_z": 1,
+                "size_c": 2,
+                "size_t": 1,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "56ead10e-7f19-4ab0-9f17-bf5608fb5e78"
+            },
+            {
+                "uuid": "3e5339f3-9753-4310-a045-fcd87ca10d4d",
+                "version": 0,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 3
+                },
+                "attribute": [],
+                "image_format": ".png",
+                "use_type": "STATIC_DISPLAY",
+                "file_uri": [
+                    "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/8a93bb61-6fef-4336-94d8-b82d106c9e63.png"
+                ],
+                "total_size_in_bytes": 0,
+                "physical_size_x": null,
+                "physical_size_y": null,
+                "physical_size_z": null,
+                "size_x": null,
+                "size_y": null,
+                "size_z": null,
+                "size_c": null,
+                "size_t": null,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "56ead10e-7f19-4ab0-9f17-bf5608fb5e78"
+            },
+            {
+                "uuid": "d44d480e-6d11-4135-a99b-fd7093a76b2c",
+                "version": 0,
+                "model": {
+                    "type_name": "ImageRepresentation",
+                    "version": 3
+                },
+                "attribute": [],
+                "image_format": ".tiff",
+                "use_type": "UPLOADED_BY_SUBMITTER",
+                "file_uri": [
+                    "https://www.ebi.ac.uk/biostudies/files/S-BIAD609/EMBOJ-2022-111515R-Q _ IF images/Appendix Figure S10/Striatum/Butyrate.tif"
+                ],
+                "total_size_in_bytes": 5110968,
+                "physical_size_x": null,
+                "physical_size_y": null,
+                "physical_size_z": null,
+                "size_x": null,
+                "size_y": null,
+                "size_z": null,
+                "size_c": null,
+                "size_t": null,
+                "image_viewer_setting": [],
+                "representation_of_uuid": "56ead10e-7f19-4ab0-9f17-bf5608fb5e78"
+            }
+        ]
+    }
+}

--- a/bia-assign-image/tests/test_data/specimen/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/48b2db02-a813-4f93-ac73-78574877fd60.json
+++ b/bia-assign-image/tests/test_data/specimen/S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/48b2db02-a813-4f93-ac73-78574877fd60.json
@@ -1,0 +1,24 @@
+{
+  "object_creator": "bia_image_assignment",
+  "uuid": "48b2db02-a813-4f93-ac73-78574877fd60",
+  "version": 0,
+  "model": {
+    "type_name": "Specimen",
+    "version": 3
+  },
+  "imaging_preparation_protocol_uuid": [
+    "caeee34b-eb73-4e39-a071-f0d3a7845bf5"
+  ],
+  "sample_of_uuid": [
+    "231efe62-9369-4009-adc6-3dadb3497105"
+  ],
+  "additional_metadata": [
+    {
+      "provenance": "bia_image_assignment",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "93de26f0-6d84-42a5-b6fc-fcd67a94f18e"
+      }
+    }
+  ]
+}

--- a/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
+++ b/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
@@ -123,34 +123,6 @@ def pre_2025_04_image_dict() -> dict:
 
 @pytest.fixture
 def expected_2025_04_image() -> bia_data_model.Image:
-    # image_dict = {
-    #    "uuid": "b3f9004c-8c9a-4344-bffc-cab4bcf52a10",
-    #    "version": 0,
-    #    "model": {"type_name": "Image", "version": 2},
-    #    "additional_metadata": [
-    #        {
-    #            "provenance": semantic_models.Provenance.bia_image_assignment,
-    #            "name": "attributes_from_file_reference_0797dc78-5993-4add-b0fc-235c52055b97",
-    #            "value": {
-    #                "attributes": [
-    #                    "3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff"
-    #                ]
-    #            },
-    #        },
-    #        {
-    #            "provenance": semantic_models.Provenance.bia_ingest,
-    #            "name": "uuid_unique_input",
-    #            # using "".join(original_file_reference_uuid) as unique string
-    #            "value": {"uuid_unique_input": "0797dc78-5993-4add-b0fc-235c52055b97"},
-    #        },
-    #    ],
-    #    "original_file_reference_uuid": [
-    #        "80ef897d-571f-401e-aeab-73c5da842c3b",
-    #    ],
-    #    "creation_process_uuid": "",
-    #    "submission_dataset_uuid": "df381b39-0768-493e-90ed-7c653f012f1f",
-    #    "object_creator": semantic_models.Provenance.bia_image_assignment,
-    # }
     image_dict = {
         "object_creator": "bia_image_assignment",
         "uuid": "93de26f0-6d84-42a5-b6fc-fcd67a94f18e",
@@ -195,11 +167,6 @@ def test_map_image_representation(
     assert mapped_image_representation == expected_2025_04_image_representation
 
 
-# Test mapping UPLOADED_BY_SUBMITTER
-
-# Test mapping THUMBNAIL AND STATIC_DISPLAY
-
-
 def test_map_image(
     pre_2025_04_image_dict,
     expected_2025_04_image,
@@ -212,7 +179,3 @@ def test_map_image(
         api_target="local",
     )
     assert mapped_image == expected_2025_04_image
-
-
-def test_update_mapped_image_from_pre_2025_04_representations_linking_image():
-    pass

--- a/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
+++ b/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
@@ -175,7 +175,6 @@ def test_map_image(
         pre_2025_04_image_dict,
         accession_id,
         file_reference_uuids_2025_04=expected_2025_04_image.original_file_reference_uuid,
-        dataset_uuid_2025_04=expected_2025_04_image.submission_dataset_uuid,
         api_target="local",
     )
     assert mapped_image == expected_2025_04_image

--- a/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
+++ b/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
@@ -16,14 +16,15 @@ os.environ["PYTHONPATH"] = ";".join(
 )
 from scripts.map_image_related_artefacts_to_2025_04_models import (
     map_image_representation_to_2025_04_model,
+    map_image_to_2025_04_model,
 )
 
-accession_id = "S-BIAD-MAP-TO-2025-04-MODELS-TEST"
+accession_id = "S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST"
 
 
 @pytest.fixture
 def pre_2025_04_image_representation_dict() -> dict:
-    return {
+    model_dict = {
         "uuid": "570a177d-de5d-4bee-bbd1-fd2dcbec9e2a",
         "representation_of_uuid": "e7322131-8e27-455d-b9fc-8add0719af70",
         "use_type": "INTERACTIVE_DISPLAY",
@@ -31,9 +32,6 @@ def pre_2025_04_image_representation_dict() -> dict:
         "attribute": [],
         "total_size_in_bytes": 0,
         "version": 0,
-        "file_uri": [
-            "https://uks3/testbucket-bia/S-BIAD-MAP-TO-2025-04-MODELS-TEST/image_uuid/image_representation_uuid.ome.zarr",
-        ],
         "physical_size_x": 1,
         "physical_size_y": 1,
         "physical_size_z": 1,
@@ -45,23 +43,25 @@ def pre_2025_04_image_representation_dict() -> dict:
         "image_viewer_setting": [],
         "model": {"type_name": "ImageRepresentation", "version": 3},
     }
+    file_uri = [
+        f"https://uks3/testbucket-bia/{accession_id}/{model_dict['representation_of_uuid']}/{model_dict['uuid']}.ome.zarr",
+    ]
+    model_dict["file_uri"] = file_uri
+    return model_dict
 
 
 @pytest.fixture
 def expected_2025_04_image_representation(
+    pre_2025_04_image_representation_dict,
     expected_2025_04_image,
 ) -> bia_data_model.ImageRepresentation:
     image_representation_dict = {
-        "uuid": "8d225268-d47b-4512-8cf3-0ba14a8be541",
+        "uuid": "fee02b2d-2e5c-4994-9588-7763e8c26bee",
         "representation_of_uuid": str(expected_2025_04_image.uuid),
-        "use_type": "INTERACTIVE_DISPLAY",
         "image_format": ".ome.zarr",
         "total_size_in_bytes": 0,
         "version": 0,
         "object_creator": semantic_models.Provenance.bia_image_conversion,
-        "file_uri": [
-            "https://uks3/testbucket-bia/S-BIAD-MAP-TO-2025-04-MODELS-TEST/image_uuid/image_representation_uuid.ome.zarr",
-        ],
         "voxel_physical_size_x": 1,
         "voxel_physical_size_y": 1,
         "voxel_physical_size_z": 1,
@@ -71,23 +71,25 @@ def expected_2025_04_image_representation(
         "size_c": 1,
         "size_t": 1,
         "image_viewer_setting": [],
-        # TODO: confirm with FS if "version" here should be 4
-        "model": {"type_name": "ImageRepresentation", "version": 3},
+        "model": {"type_name": "ImageRepresentation", "version": 4},
         "additional_metadata": [
             {
-                "provenance": semantic_models.Provenance.bia_ingest,
+                "provenance": semantic_models.Provenance.bia_image_conversion,
                 "name": "uuid_unique_input",
-                # using str(use_type)+image_format as unique string
-                "value": {"uuid_unique_input": "INTERACTIVE_DISPLAY.ome.zarr"},
+                "value": {
+                    "uuid_unique_input": "{'conversion_function': 'map_image_representation_to_2025_04_model'}"
+                },
             }
         ],
     }
+    image_representation_dict["file_uri"] = pre_2025_04_image_representation_dict[
+        "file_uri"
+    ]
     return bia_data_model.ImageRepresentation.model_validate(image_representation_dict)
 
 
 @pytest.fixture
-def expected_2025_04_image() -> bia_data_model.Image:
-    # TODO: Compute proper uuids (i.e. based on actual study_uuid for file reference, creation process and dataset)
+def pre_2025_04_image_dict() -> dict:
     image_dict = {
         "uuid": "b3f9004c-8c9a-4344-bffc-cab4bcf52a10",
         "version": 0,
@@ -116,6 +118,67 @@ def expected_2025_04_image() -> bia_data_model.Image:
         "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0",
         "object_creator": semantic_models.Provenance.bia_image_assignment,
     }
+    return image_dict
+
+
+@pytest.fixture
+def expected_2025_04_image() -> bia_data_model.Image:
+    # image_dict = {
+    #    "uuid": "b3f9004c-8c9a-4344-bffc-cab4bcf52a10",
+    #    "version": 0,
+    #    "model": {"type_name": "Image", "version": 2},
+    #    "additional_metadata": [
+    #        {
+    #            "provenance": semantic_models.Provenance.bia_image_assignment,
+    #            "name": "attributes_from_file_reference_0797dc78-5993-4add-b0fc-235c52055b97",
+    #            "value": {
+    #                "attributes": [
+    #                    "3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff"
+    #                ]
+    #            },
+    #        },
+    #        {
+    #            "provenance": semantic_models.Provenance.bia_ingest,
+    #            "name": "uuid_unique_input",
+    #            # using "".join(original_file_reference_uuid) as unique string
+    #            "value": {"uuid_unique_input": "0797dc78-5993-4add-b0fc-235c52055b97"},
+    #        },
+    #    ],
+    #    "original_file_reference_uuid": [
+    #        "80ef897d-571f-401e-aeab-73c5da842c3b",
+    #    ],
+    #    "creation_process_uuid": "",
+    #    "submission_dataset_uuid": "df381b39-0768-493e-90ed-7c653f012f1f",
+    #    "object_creator": semantic_models.Provenance.bia_image_assignment,
+    # }
+    image_dict = {
+        "object_creator": "bia_image_assignment",
+        "uuid": "93de26f0-6d84-42a5-b6fc-fcd67a94f18e",
+        "version": 0,
+        "model": {"type_name": "Image", "version": 2},
+        "additional_metadata": [
+            {
+                "provenance": "bia_image_assignment",
+                "name": "attributes_from_file_reference_80ef897d-571f-401e-aeab-73c5da842c3b",
+                "value": {"file_list_col1": "col1value", "file_list_col2": "col2value"},
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "file_pattern",
+                "value": {
+                    "file_pattern": "S-BIAD-MAP-IMAGE-RELATED-ARTEFACTS-TO-2025-04-MODELS-TEST/file_reference1.tif"
+                },
+            },
+            {
+                "provenance": "bia_image_assignment",
+                "name": "uuid_unique_input",
+                "value": {"uuid_unique_input": "80ef897d-571f-401e-aeab-73c5da842c3b"},
+            },
+        ],
+        "submission_dataset_uuid": "df381b39-0768-493e-90ed-7c653f012f1f",
+        "creation_process_uuid": "af26940e-35c7-470a-8037-0a27d45253b9",
+        "original_file_reference_uuid": ["80ef897d-571f-401e-aeab-73c5da842c3b"],
+    }
     return bia_data_model.Image.model_validate(image_dict)
 
 
@@ -125,6 +188,31 @@ def test_map_image_representation(
     expected_2025_04_image,
 ):
     mapped_image_representation = map_image_representation_to_2025_04_model(
-        pre_2025_04_image_representation_dict, str(expected_2025_04_image.uuid)
+        pre_2025_04_image_representation_dict,
+        str(expected_2025_04_image.uuid),
+        accession_id,
     )
     assert mapped_image_representation == expected_2025_04_image_representation
+
+
+# Test mapping UPLOADED_BY_SUBMITTER
+
+# Test mapping THUMBNAIL AND STATIC_DISPLAY
+
+
+def test_map_image(
+    pre_2025_04_image_dict,
+    expected_2025_04_image,
+):
+    mapped_image = map_image_to_2025_04_model(
+        pre_2025_04_image_dict,
+        accession_id,
+        file_reference_uuids_2025_04=expected_2025_04_image.original_file_reference_uuid,
+        dataset_uuid_2025_04=expected_2025_04_image.submission_dataset_uuid,
+        api_target="local",
+    )
+    assert mapped_image == expected_2025_04_image
+
+
+def test_update_mapped_image_from_pre_2025_04_representations_linking_image():
+    pass

--- a/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
+++ b/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models.py
@@ -1,0 +1,130 @@
+"""Test core functions of script to map image related artefacts to 2025/04 version of models"""
+
+import os
+from pathlib import Path
+import pytest
+from bia_shared_datamodels import bia_data_model, semantic_models
+
+# Modify python path to allow importing script functions
+mapping_script_path = str(Path(__file__).parents[1] / "scripts")
+python_path = os.environ.get("PYTHONPATH", "")
+os.environ["PYTHONPATH"] = ";".join(
+    [
+        mapping_script_path,
+        python_path,
+    ]
+)
+from scripts.map_image_related_artefacts_to_2025_04_models import (
+    map_image_representation_to_2025_04_model,
+)
+
+accession_id = "S-BIAD-MAP-TO-2025-04-MODELS-TEST"
+
+
+@pytest.fixture
+def pre_2025_04_image_representation_dict() -> dict:
+    return {
+        "uuid": "570a177d-de5d-4bee-bbd1-fd2dcbec9e2a",
+        "representation_of_uuid": "e7322131-8e27-455d-b9fc-8add0719af70",
+        "use_type": "INTERACTIVE_DISPLAY",
+        "image_format": ".ome.zarr",
+        "attribute": [],
+        "total_size_in_bytes": 0,
+        "version": 0,
+        "file_uri": [
+            "https://uks3/testbucket-bia/S-BIAD-MAP-TO-2025-04-MODELS-TEST/image_uuid/image_representation_uuid.ome.zarr",
+        ],
+        "physical_size_x": 1,
+        "physical_size_y": 1,
+        "physical_size_z": 1,
+        "size_x": 1,
+        "size_y": 1,
+        "size_z": 1,
+        "size_c": 1,
+        "size_t": 1,
+        "image_viewer_setting": [],
+        "model": {"type_name": "ImageRepresentation", "version": 3},
+    }
+
+
+@pytest.fixture
+def expected_2025_04_image_representation(
+    expected_2025_04_image,
+) -> bia_data_model.ImageRepresentation:
+    image_representation_dict = {
+        "uuid": "8d225268-d47b-4512-8cf3-0ba14a8be541",
+        "representation_of_uuid": str(expected_2025_04_image.uuid),
+        "use_type": "INTERACTIVE_DISPLAY",
+        "image_format": ".ome.zarr",
+        "total_size_in_bytes": 0,
+        "version": 0,
+        "object_creator": semantic_models.Provenance.bia_image_conversion,
+        "file_uri": [
+            "https://uks3/testbucket-bia/S-BIAD-MAP-TO-2025-04-MODELS-TEST/image_uuid/image_representation_uuid.ome.zarr",
+        ],
+        "voxel_physical_size_x": 1,
+        "voxel_physical_size_y": 1,
+        "voxel_physical_size_z": 1,
+        "size_x": 1,
+        "size_y": 1,
+        "size_z": 1,
+        "size_c": 1,
+        "size_t": 1,
+        "image_viewer_setting": [],
+        # TODO: confirm with FS if "version" here should be 4
+        "model": {"type_name": "ImageRepresentation", "version": 3},
+        "additional_metadata": [
+            {
+                "provenance": semantic_models.Provenance.bia_ingest,
+                "name": "uuid_unique_input",
+                # using str(use_type)+image_format as unique string
+                "value": {"uuid_unique_input": "INTERACTIVE_DISPLAY.ome.zarr"},
+            }
+        ],
+    }
+    return bia_data_model.ImageRepresentation.model_validate(image_representation_dict)
+
+
+@pytest.fixture
+def expected_2025_04_image() -> bia_data_model.Image:
+    # TODO: Compute proper uuids (i.e. based on actual study_uuid for file reference, creation process and dataset)
+    image_dict = {
+        "uuid": "b3f9004c-8c9a-4344-bffc-cab4bcf52a10",
+        "version": 0,
+        "model": {"type_name": "Image", "version": 1},
+        "additional_metadata": [
+            {
+                "provenance": semantic_models.Provenance.bia_image_assignment,
+                "name": "attributes_from_file_reference_0797dc78-5993-4add-b0fc-235c52055b97",
+                "value": {
+                    "attributes": [
+                        "3d_multichannel_time_series/image_01_channel_00_slice_001_time0000.tiff"
+                    ]
+                },
+            },
+            {
+                "provenance": semantic_models.Provenance.bia_ingest,
+                "name": "uuid_unique_input",
+                # using "".join(original_file_reference_uuid) as unique string
+                "value": {"uuid_unique_input": "0797dc78-5993-4add-b0fc-235c52055b97"},
+            },
+        ],
+        "original_file_reference_uuid": [
+            "0797dc78-5993-4add-b0fc-235c52055b97",
+        ],
+        "creation_process_uuid": "b5d98aa9-79ce-4106-90b2-d3687eac67f0",
+        "submission_dataset_uuid": "ae32e92d-84f9-4119-82d1-70cb36477bc0",
+        "object_creator": semantic_models.Provenance.bia_image_assignment,
+    }
+    return bia_data_model.Image.model_validate(image_dict)
+
+
+def test_map_image_representation(
+    pre_2025_04_image_representation_dict,
+    expected_2025_04_image_representation,
+    expected_2025_04_image,
+):
+    mapped_image_representation = map_image_representation_to_2025_04_model(
+        pre_2025_04_image_representation_dict, str(expected_2025_04_image.uuid)
+    )
+    assert mapped_image_representation == expected_2025_04_image_representation

--- a/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models_script.py
+++ b/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models_script.py
@@ -74,6 +74,9 @@ def test_map_image_related_artefacts_to_2025_04_models(
         accession_id,
         api_target="local",
     )
+    # The versions may be different depending on no. of
+    # times the test has been run - so don't compare version
+    mapped_artefacts["image"].version = expected_2025_04_image.version
     assert mapped_artefacts["image"] == expected_2025_04_image
     assert (
         mapped_artefacts["representation_of_image_uploaded_by_submitter"]

--- a/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models_script.py
+++ b/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models_script.py
@@ -1,0 +1,78 @@
+"""Test core functions of script to map image related artefacts to 2025/04 version of models"""
+
+import os
+from pathlib import Path
+import json
+import pytest
+from bia_shared_datamodels import bia_data_model, semantic_models
+from .conftest import get_expected_object
+
+# Modify python path to allow importing script functions
+mapping_script_path = str(Path(__file__).parents[1] / "scripts")
+python_path = os.environ.get("PYTHONPATH", "")
+os.environ["PYTHONPATH"] = ";".join(
+    [
+        mapping_script_path,
+        python_path,
+    ]
+)
+from scripts.map_image_related_artefacts_to_2025_04_models import (
+    map_image_related_artefacts_to_2025_04_models,
+)
+
+# Use details from an actual study
+accession_id = "S-BIAD609"
+
+@pytest.fixture
+def base_path() -> Path:
+    return Path(__file__).parent / "test_data" / "migrate_to_2025_04_models"
+
+@pytest.fixture
+def file_reference_mapping(base_path) -> dict:
+    file_reference_mapping_path = base_path / "pre_2025_04_models" / "test-file-reference-mapping.json"
+    file_reference_mappings = json.loads(file_reference_mapping_path.read_text())
+    return list(file_reference_mappings.values())[0]
+
+
+@pytest.fixture
+def expected_2025_04_image(base_path) -> bia_data_model.Image:
+    obj_path = base_path / "2025_04_models"
+    uuid = "71fb4f2d-6cff-495f-ae21-d1c6ab068de7"
+    return get_expected_object(obj_path, "Image", accession_id, uuid)
+
+@pytest.fixture
+def expected_2025_04_representation_of_image_uploaded_by_submitter(
+    base_path
+) -> bia_data_model.ImageRepresentation:
+    obj_path = base_path / "2025_04_models"
+    uuid = "87f9f5e7-473e-4c81-afbf-1dcd148492f4"
+    return get_expected_object(obj_path, "ImageRepresentation", accession_id, uuid)
+
+@pytest.fixture
+def expected_2025_04_representation_of_image_converted_to_ome_zarr(
+    base_path
+) -> bia_data_model.ImageRepresentation:
+    obj_path = base_path / "2025_04_models"
+    uuid = "2a8ecffd-6690-494f-acbb-81fb94f2df30"
+    return get_expected_object(obj_path, "ImageRepresentation", accession_id, uuid)
+
+
+def test_map_image_related_artefacts_to_2025_04_models(
+    file_reference_mapping,
+    expected_2025_04_image,
+    expected_2025_04_representation_of_image_converted_to_ome_zarr,
+    expected_2025_04_representation_of_image_uploaded_by_submitter,
+):
+    mapped_artefacts = map_image_related_artefacts_to_2025_04_models(
+        file_reference_mapping, 
+        accession_id,
+        api_target="local",
+    )
+    assert mapped_artefacts["image"] == expected_2025_04_image
+    assert mapped_artefacts["representation_of_image_uploaded_by_submitter"] == expected_2025_04_representation_of_image_uploaded_by_submitter
+    assert mapped_artefacts["representation_of_image_converted_to_ome_zarr"] == expected_2025_04_representation_of_image_converted_to_ome_zarr
+
+
+    # Test if Dataset details in Image are correct?
+
+    # Test if Creation process details in Image are correct?

--- a/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models_script.py
+++ b/bia-assign-image/tests/test_map_image_related_artefacts_to_2025_04_models_script.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import json
 import pytest
-from bia_shared_datamodels import bia_data_model, semantic_models
+from bia_shared_datamodels import bia_data_model
 from .conftest import get_expected_object
 
 # Modify python path to allow importing script functions
@@ -23,13 +23,17 @@ from scripts.map_image_related_artefacts_to_2025_04_models import (
 # Use details from an actual study
 accession_id = "S-BIAD609"
 
+
 @pytest.fixture
 def base_path() -> Path:
     return Path(__file__).parent / "test_data" / "migrate_to_2025_04_models"
 
+
 @pytest.fixture
 def file_reference_mapping(base_path) -> dict:
-    file_reference_mapping_path = base_path / "pre_2025_04_models" / "test-file-reference-mapping.json"
+    file_reference_mapping_path = (
+        base_path / "pre_2025_04_models" / "test-file-reference-mapping.json"
+    )
     file_reference_mappings = json.loads(file_reference_mapping_path.read_text())
     return list(file_reference_mappings.values())[0]
 
@@ -40,17 +44,19 @@ def expected_2025_04_image(base_path) -> bia_data_model.Image:
     uuid = "71fb4f2d-6cff-495f-ae21-d1c6ab068de7"
     return get_expected_object(obj_path, "Image", accession_id, uuid)
 
+
 @pytest.fixture
 def expected_2025_04_representation_of_image_uploaded_by_submitter(
-    base_path
+    base_path,
 ) -> bia_data_model.ImageRepresentation:
     obj_path = base_path / "2025_04_models"
     uuid = "87f9f5e7-473e-4c81-afbf-1dcd148492f4"
     return get_expected_object(obj_path, "ImageRepresentation", accession_id, uuid)
 
+
 @pytest.fixture
 def expected_2025_04_representation_of_image_converted_to_ome_zarr(
-    base_path
+    base_path,
 ) -> bia_data_model.ImageRepresentation:
     obj_path = base_path / "2025_04_models"
     uuid = "2a8ecffd-6690-494f-acbb-81fb94f2df30"
@@ -64,14 +70,19 @@ def test_map_image_related_artefacts_to_2025_04_models(
     expected_2025_04_representation_of_image_uploaded_by_submitter,
 ):
     mapped_artefacts = map_image_related_artefacts_to_2025_04_models(
-        file_reference_mapping, 
+        file_reference_mapping,
         accession_id,
         api_target="local",
     )
     assert mapped_artefacts["image"] == expected_2025_04_image
-    assert mapped_artefacts["representation_of_image_uploaded_by_submitter"] == expected_2025_04_representation_of_image_uploaded_by_submitter
-    assert mapped_artefacts["representation_of_image_converted_to_ome_zarr"] == expected_2025_04_representation_of_image_converted_to_ome_zarr
-
+    assert (
+        mapped_artefacts["representation_of_image_uploaded_by_submitter"]
+        == expected_2025_04_representation_of_image_uploaded_by_submitter
+    )
+    assert (
+        mapped_artefacts["representation_of_image_converted_to_ome_zarr"]
+        == expected_2025_04_representation_of_image_converted_to_ome_zarr
+    )
 
     # Test if Dataset details in Image are correct?
 


### PR DESCRIPTION
PR with working version of script to map Image related artefacts to 2025/04 models. Clickup ticket: [Update uuid mapping scripts](https://app.clickup.com/t/8698urxje).

Draft PR for [Update uuid mapping scripts](https://app.clickup.com/t/8698urxje) . Need feedback on:
1. unique string for creating Image, ImageRepresentation and FileReference
2. Approach to take for mapping Image
    a.  Assume relevant study has been ingested and call `assign_image` with relevant file reference uuids
    b. Create `Image` from the scratch - means also computing (creating) uuids of dependant artefacts
    c. Other suggestions?
3. What `version` should models be?