### PR TITLE
remove use_type and object version bump

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/bia_data_model.py
@@ -154,7 +154,7 @@ class ObjectCreatorMixin(BaseModel):
 class Study(semantic_models.Study, DocumentMixin, ObjectCreatorMixin):
     author: List[semantic_models.Contributor] = Field(min_length=1)
 
-    model_config = ConfigDict(model_version_latest=2)
+    model_config = ConfigDict(model_version_latest=3)
 
 
 #######################################################################################################
@@ -165,7 +165,7 @@ class Study(semantic_models.Study, DocumentMixin, ObjectCreatorMixin):
 class Dataset(semantic_models.Dataset, DocumentMixin, ObjectCreatorMixin):
     submitted_in_study_uuid: Annotated[UUID, ObjectReference(Study)] = Field()
 
-    model_config = ConfigDict(model_version_latest=1)
+    model_config = ConfigDict(model_version_latest=2)
 
 
 class FileReference(semantic_models.FileReference, DocumentMixin, ObjectCreatorMixin):
@@ -174,7 +174,7 @@ class FileReference(semantic_models.FileReference, DocumentMixin, ObjectCreatorM
         ObjectReference(Dataset),
     ] = Field()
 
-    model_config = ConfigDict(model_version_latest=2)
+    model_config = ConfigDict(model_version_latest=3)
 
 
 #######################################################################################################
@@ -190,7 +190,7 @@ class Image(semantic_models.Image, DocumentMixin, ObjectCreatorMixin):
         List[UUID], ObjectReference(FileReference)
     ] = Field()
 
-    model_config = ConfigDict(model_version_latest=1)
+    model_config = ConfigDict(model_version_latest=2)
 
 
 class ImageRepresentation(
@@ -202,7 +202,7 @@ class ImageRepresentation(
         ObjectReference(Image),
     ] = Field()
 
-    model_config = ConfigDict(model_version_latest=3)
+    model_config = ConfigDict(model_version_latest=4)
 
 
 class AnnotationData(semantic_models.AnnotationData, DocumentMixin, ObjectCreatorMixin):
@@ -212,7 +212,7 @@ class AnnotationData(semantic_models.AnnotationData, DocumentMixin, ObjectCreato
         List[UUID], ObjectReference(FileReference)
     ] = Field()
 
-    model_config = ConfigDict(model_version_latest=1)
+    model_config = ConfigDict(model_version_latest=2)
 
 
 #######################################################################################################
@@ -232,7 +232,7 @@ class Specimen(semantic_models.Specimen, DocumentMixin, ObjectCreatorMixin):
         description="The biosample from which this specimen was created.",
     )
 
-    model_config = ConfigDict(model_version_latest=2)
+    model_config = ConfigDict(model_version_latest=3)
 
 
 class CreationProcess(
@@ -264,17 +264,17 @@ class CreationProcess(
         )
     )
 
-    model_config = ConfigDict(model_version_latest=2)
+    model_config = ConfigDict(model_version_latest=3)
 
 
 class Protocol(semantic_models.Protocol, DocumentMixin, ObjectCreatorMixin):
-    model_config = ConfigDict(model_version_latest=2)
+    model_config = ConfigDict(model_version_latest=3)
 
 
 class ImageAcquisitionProtocol(
     semantic_models.ImageAcquisitionProtocol, DocumentMixin, ObjectCreatorMixin
 ):
-    model_config = ConfigDict(model_version_latest=2)
+    model_config = ConfigDict(model_version_latest=3)
 
 
 class SpecimenImagingPreparationProtocol(
@@ -282,21 +282,22 @@ class SpecimenImagingPreparationProtocol(
     DocumentMixin,
     ObjectCreatorMixin,
 ):
-    model_config = ConfigDict(model_version_latest=2)
+    model_config = ConfigDict(model_version_latest=3)
 
 
 class BioSample(semantic_models.BioSample, DocumentMixin, ObjectCreatorMixin):
-    model_config = ConfigDict(model_version_latest=3)
     growth_protocol_uuid: Annotated[Optional[UUID], ObjectReference(Protocol)] = Field(
         None,
         description="The protocol that was followed in order to create this biosample.",
     )
 
+    model_config = ConfigDict(model_version_latest=4)
+
 
 class AnnotationMethod(
     semantic_models.AnnotationMethod, DocumentMixin, ObjectCreatorMixin
 ):
-    model_config = ConfigDict(model_version_latest=3)
+    model_config = ConfigDict(model_version_latest=4)
 
 
 Specimen.model_rebuild()

--- a/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/mock_objects.py
@@ -47,7 +47,7 @@ def get_study_dict(completeness=Completeness.COMPLETE) -> dict:
                 "Template keyword1",
                 "Template keyword2",
             ],
-            "model": {"type_name": "Study", "version": 2},
+            "model": {"type_name": "Study", "version": 3},
             "additional_metadata": [get_attribute_dict()],
         }
 
@@ -122,7 +122,7 @@ def get_dataset_dict(
                 get_image_correlation_method_dict(),
             ],
             "example_image_uri": ["https://dummy.url.org"],
-            "model": {"type_name": "Dataset", "version": 1},
+            "model": {"type_name": "Dataset", "version": 2},
             "additional_metadata": [get_attribute_dict()],
         }
     return dataset
@@ -144,7 +144,7 @@ def get_file_reference_dict(completeness=Completeness.COMPLETE) -> dict:
     }
     if completeness == Completeness.COMPLETE:
         file_reference |= {
-            "model": {"type_name": "FileReference", "version": 2},
+            "model": {"type_name": "FileReference", "version": 3},
             "additional_metadata": [get_attribute_dict()],
         }
     return file_reference
@@ -167,7 +167,7 @@ def get_image_dict(completeness=Completeness.COMPLETE) -> dict:
     }
     if completeness == Completeness.COMPLETE:
         image |= {
-            "model": {"type_name": "Image", "version": 1},
+            "model": {"type_name": "Image", "version": 2},
             "additional_metadata": [get_attribute_dict()],
             "original_file_reference_uuid": [
                 get_file_reference_dict()["uuid"],
@@ -182,7 +182,6 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
     image_representation = {
         "uuid": uuid4(),
         "representation_of_uuid": get_image_dict()["uuid"],
-        "use_type": "UPLOADED_BY_SUBMITTER",
         "image_format": "Template image format",
         "total_size_in_bytes": 0,
         "file_uri": [],
@@ -205,7 +204,7 @@ def get_image_representation_dict(completeness=Completeness.COMPLETE) -> dict:
             "image_viewer_setting": [
                 get_rendered_view_dict(),
             ],
-            "model": {"type_name": "ImageRepresentation", "version": 3},
+            "model": {"type_name": "ImageRepresentation", "version": 4},
             "additional_metadata": [get_attribute_dict()],
         }
     return image_representation
@@ -251,7 +250,7 @@ def get_annotation_data_dict(completeness=Completeness.COMPLETE) -> dict:
     }
     if completeness == Completeness.COMPLETE:
         annotation_data |= {
-            "model": {"type_name": "AnnotationData", "version": 1},
+            "model": {"type_name": "AnnotationData", "version": 2},
             "additional_metadata": [get_attribute_dict()],
             "original_file_reference_uuid": [
                 get_file_reference_dict()["uuid"],
@@ -274,7 +273,7 @@ def get_creation_process_dict(completeness=Completeness.COMPLETE) -> dict:
     }
     if completeness == Completeness.COMPLETE:
         process |= {
-            "model": {"type_name": "CreationProcess", "version": 2},
+            "model": {"type_name": "CreationProcess", "version": 3},
             "subject_specimen_uuid": get_specimen_dict()["uuid"],
             "image_acquisition_protocol_uuid": [
                 get_image_acquisition_protocol_dict()["uuid"]
@@ -303,7 +302,7 @@ def get_protocol_dict(completeness=Completeness.COMPLETE) -> dict:
     }
     if completeness == Completeness.COMPLETE:
         protocol |= {
-            "model": {"type_name": "Protocol", "version": 2},
+            "model": {"type_name": "Protocol", "version": 3},
             "additional_metadata": [get_attribute_dict()],
         }
 
@@ -331,7 +330,7 @@ def get_image_acquisition_protocol_dict(completeness=Completeness.COMPLETE) -> d
                 "Template imaging method name",
             ],
             "additional_metadata": [get_attribute_dict()],
-            "model": {"type_name": "ImageAcquisitionProtocol", "version": 2},
+            "model": {"type_name": "ImageAcquisitionProtocol", "version": 3},
         }
     return image_acquisition_protocol
 
@@ -357,7 +356,7 @@ def get_annotation_method_dict(completeness=Completeness.COMPLETE) -> dict:
             "method_type": [semantic_models.AnnotationMethodType.class_labels],
             "annotation_source_indicator": semantic_models.AnnotationSourceIndicator.metadata_file,
             "additional_metadata": [get_attribute_dict()],
-            "model": {"type_name": "AnnotationMethod", "version": 3},
+            "model": {"type_name": "AnnotationMethod", "version": 4},
         }
     return annotation_method
 
@@ -409,7 +408,7 @@ def get_specimen_dict(completeness=Completeness.COMPLETE) -> dict:
     }
     if completeness == Completeness.COMPLETE:
         specimen |= {
-            "model": {"type_name": "Specimen", "version": 2},
+            "model": {"type_name": "Specimen", "version": 3},
             "additional_metadata": [get_attribute_dict()],
         }
     return specimen
@@ -437,7 +436,7 @@ def get_specimen_imaging_preparation_protocol_dict(
             "additional_metadata": [get_attribute_dict()],
             "model": {
                 "type_name": "SpecimenImagingPreparationProtocol",
-                "version": 2,
+                "version": 3,
             },
         }
     return specimen_imaging_preparation_protocol
@@ -483,7 +482,7 @@ def get_biosample_dict(completeness=Completeness.COMPLETE) -> dict:
             ],
             "growth_protocol_uuid": get_protocol_dict()["uuid"],
             "additional_metadata": [get_attribute_dict()],
-            "model": {"type_name": "BioSample", "version": 3},
+            "model": {"type_name": "BioSample", "version": 4},
         }
     return biosample
 

--- a/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/semantic_models.py
@@ -189,18 +189,6 @@ class Licence(str, Enum):
 
     CC_BY_NC_ND_40 = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
 
-class ImageRepresentationUseType(str, Enum):
-    """Enumerate use types of ImageRepresentations"""
-
-    # Original format uploaded with the study
-    UPLOADED_BY_SUBMITTER = "UPLOADED_BY_SUBMITTER"
-    # Usually used as representative image for study
-    STATIC_DISPLAY = "STATIC_DISPLAY"
-    # To be used as thumbnail
-    THUMBNAIL = "THUMBNAIL"
-    # Allows remote interactive exploration - usually ome zarr format
-    INTERACTIVE_DISPLAY = "INTERACTIVE_DISPLAY"
-
 
 #######################################################################################################
 # Subgraph 2: Contributors & their affiliations
@@ -323,9 +311,6 @@ class ImageRepresentation(ConfiguredBaseModel, AttributeMixin):
     """
 
     image_format: str = Field(description="""Image format of the combined files.""")
-    use_type: ImageRepresentationUseType = Field(
-        description="""The use case of this particular image representation i.e. thumbnail, interactive display etc."""
-    )
     file_uri: List[str] = Field(
         description="""URI(s) of the file(s) which together make up this image representation."""
     )


### PR DESCRIPTION
2 model changes:

1. remove use type from image rep models - this is because this information will be stored using attribute connections between the image and various image representations.
2. bump model version on all objects due to the addition of required fields - all objects have a new required field, and many objects have gone through somewhat significant change. Previous data would not be compatible, so a model version bump is sensible to signify the change.

Original ticket: https://app.clickup.com/t/8698nhx0n
And ticket i cut just to not forget about the change over the long weekend: https://app.clickup.com/t/8698xywp8