### PR TITLE
Add uuid of im rep converted to zarr to attributes of 2025/04 image

### DIFF
--- a/bia-assign-image/scripts/map_image_related_artefacts_to_2025_04_models.py
+++ b/bia-assign-image/scripts/map_image_related_artefacts_to_2025_04_models.py
@@ -186,8 +186,21 @@ def map_image_related_artefacts_to_2025_04_models(
             }
         )
         image_2025_04.additional_metadata.append(static_display_uri)
+        
+    if rep_of_image_converted_to_ome_zarr_2025_04:
+        recommended_vizarr_representation = attribute_models.Attribute.model_validate(
+            {
+                "provenance": "bia_image_assignment",
+                "name": "recommended_vizarr_representation",
+                "value": {
+                    "recommended_vizarr_representation": rep_of_image_converted_to_ome_zarr_2025_04.uuid,
+                },
+            }
+        )
+        image_2025_04.additional_metadata.append(recommended_vizarr_representation)
 
-    if thumbnail_rep or static_display_rep:
+
+    if thumbnail_rep or static_display_rep or rep_of_image_converted_to_ome_zarr_2025_04:
         # image_2025_04.version += 1
         api_client = get_api_client(api_target)
         store_object_in_api_idempotent(

--- a/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image/S-BIAD609/71fb4f2d-6cff-495f-ae21-d1c6ab068de7.json
+++ b/bia-assign-image/tests/test_data/migrate_to_2025_04_models/2025_04_models/image/S-BIAD609/71fb4f2d-6cff-495f-ae21-d1c6ab068de7.json
@@ -44,6 +44,13 @@
           "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD609/b0ecfe5d-b32d-4ab6-9c3c-a5afeba0a575/8a93bb61-6fef-4336-94d8-b82d106c9e63.png"
         ]
       }
+    },
+    {
+      "provenance": "bia_image_assignment",
+      "name": "recommended_vizarr_representation",
+      "value": {
+        "recommended_vizarr_representation": "2a8ecffd-6690-494f-acbb-81fb94f2df30"
+      }
     }
     ],
     "submission_dataset_uuid": "abf9ca35-01ce-4b46-83cb-071e2967ce07",


### PR DESCRIPTION
Clickup ticket: [https://app.clickup.com/t/86997e8kv](https://app.clickup.com/t/86997e8kv)
Note: attribute for uuid of im rep for zarr has a string value. However, attributes for static_display and thumbnail uris have list. Should I change the later 2 to string values as well - are there instances where we may need more than one value for these?