### PR TITLE
cover licences with dashes

### DIFF
--- a/bia-ingest/bia_ingest/biostudies/common/study.py
+++ b/bia-ingest/bia_ingest/biostudies/common/study.py
@@ -132,6 +132,7 @@ def get_licence(study_attributes: Dict[str, Any]) -> semantic_models.Licence:
     """
     temp = re.sub(r"\s", "_", study_attributes.get("License", "CC0"))
     licence = re.sub(r"\.", "", temp)
+    licence = licence.replace('-','_')
     return semantic_models.Licence[licence]
 
 


### PR DESCRIPTION
Quick fix to ingest ~27 studies that were having issues with 'Uncaught exception: 'CC_BY-SA_30' '

E.g. to test:

poetry run biaingest ingest --dryrun --process-filelist skip S-BIAD867