### PR TITLE
Add search by path name

### DIFF
--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -98,6 +98,7 @@ class Repository:
     async def _add_indices_collection_biaint(self) -> None:
         await self.biaint.create_index([("uuid", 1)], unique=True, name="doc_uuid")
         await self.biaint.create_index([("model", 1)], name="doc_model")
+        await self.biaint.create_index([("file_path", 1)], name="doc_file_ref_path")
 
         await self._add_indices_reverse_links()
 

--- a/api/api/models/repository.py
+++ b/api/api/models/repository.py
@@ -98,7 +98,11 @@ class Repository:
     async def _add_indices_collection_biaint(self) -> None:
         await self.biaint.create_index([("uuid", 1)], unique=True, name="doc_uuid")
         await self.biaint.create_index([("model", 1)], name="doc_model")
-        await self.biaint.create_index([("file_path", 1)], name="doc_file_ref_path")
+        await self.biaint.create_index(
+            [("file_path", 1)],
+            partialFilterExpression=shared_data_models.FileReference.get_model_metadata().model_dump(),
+            name="doc_file_ref_path",
+        )
 
         await self._add_indices_reverse_links()
 

--- a/api/api/search.py
+++ b/api/api/search.py
@@ -48,7 +48,7 @@ async def searchFileReferenceByPathName(
     path_name: Annotated[str, Query(min_length=5, max_length=1000)],
     db: Annotated[Repository, Depends(get_db)],
     pagination: Annotated[Pagination, Depends()],
-    study_uuid: shared_data_models.UUID = None,
+    study_uuid: shared_data_models.UUID,
 ) -> List:
 
     study = await db.get_doc(study_uuid, shared_data_models.Study)

--- a/api/api/search.py
+++ b/api/api/search.py
@@ -47,7 +47,6 @@ async def searchImageRepresentationByFileUri(
 async def searchFileReferenceByPathName(
     path_name: Annotated[str, Query(min_length=5, max_length=1000)],
     db: Annotated[Repository, Depends(get_db)],
-    pagination: Annotated[Pagination, Depends()],
     study_uuid: shared_data_models.UUID,
 ) -> List[shared_data_models.FileReference]:
     study = await db.get_doc(study_uuid, shared_data_models.Study)
@@ -88,7 +87,7 @@ async def searchFileReferenceByPathName(
     ]
     results = await db.aggregate(pipeline)
     if results:
-        results = [x for res in results for x in res["files"]][: pagination.page_size]
+        results = [x for res in results for x in res["files"]]
     return results
 
 

--- a/api/api/search.py
+++ b/api/api/search.py
@@ -48,21 +48,19 @@ async def searchFileReferenceByPathName(
     path_name: Annotated[str, Query(min_length=5, max_length=1000)],
     db: Annotated[Repository, Depends(get_db)],
     pagination: Annotated[Pagination, Depends()],
-    uuid: shared_data_models.UUID = None,
+    study_uuid: shared_data_models.UUID = None,
 ) -> List:
 
-    if not uuid:
-        return await db.get_docs(
-            {"file_path": path_name},
-            shared_data_models.FileReference,
-            pagination=pagination,
-        )
-
-    study = await db.get_doc(uuid, shared_data_models.Study)
+    study = await db.get_doc(study_uuid, shared_data_models.Study)
 
     results = await db.aggregate(
         [
-            {"$match": {"uuid": uuid, "model.type_name": "Study", "model.version": 3}},
+            {
+                "$match": {
+                    "uuid": study_uuid,
+                    "model": shared_data_models.Study.get_model_metadata().model_dump(),
+                }
+            },
             {
                 "$lookup": {
                     "from": "bia_integrator",

--- a/api/api/search.py
+++ b/api/api/search.py
@@ -43,6 +43,19 @@ async def searchImageRepresentationByFileUri(
     )
 
 
+@router.get("/file_reference/by_path_name")
+async def searchFileReferenceByPathName(
+    path_name: Annotated[str, Query(min_length=1, max_length=1000)],
+    db: Annotated[Repository, Depends(get_db)],
+    pagination: Annotated[Pagination, Depends()],
+) -> List[shared_data_models.FileReference]:
+    return await db.get_docs(
+        {"file_path": path_name},  # <-- exact match
+        shared_data_models.FileReference,
+        pagination=pagination,
+    )
+
+
 def make_search_items(t: Type[shared_data_models.DocumentMixin]):
     async def get_items(
         db: Annotated[Repository, Depends(get_db)],

--- a/api/api/search.py
+++ b/api/api/search.py
@@ -55,6 +55,7 @@ async def searchFileReferenceByPathName(
         {
             "$match": {
                 "submitted_in_study_uuid": study_uuid,
+                "model": shared_data_models.Dataset.get_model_metadata().model_dump(),
             }
         },
         {
@@ -64,17 +65,11 @@ async def searchFileReferenceByPathName(
                 "pipeline": [
                     {
                         "$match": {
+                            "model": shared_data_models.FileReference.get_model_metadata().model_dump(),
+                            "file_path": path_name,
                             "$expr": {
-                                "$and": [
-                                    {
-                                        "$eq": [
-                                            "$submission_dataset_uuid",
-                                            "$$dataset_uuid",
-                                        ]
-                                    },
-                                    {"$eq": ["$file_path", path_name]},
-                                ]
-                            }
+                                "$eq": ["$submission_dataset_uuid", "$$dataset_uuid"]
+                            },
                         }
                     },
                     {"$project": {"_id": 0}},

--- a/api/api/tests/test_search_file_reference.py
+++ b/api/api/tests/test_search_file_reference.py
@@ -4,163 +4,67 @@ from api.tests.conftest import get_uuid
 from typing import List
 
 
-@pytest.fixture
-def mock_file_references():
-    return [
-        {
-            "object_creator": "submitter",
-            "uuid": "00f8e870-255d-4102-ba8b-76f105a483c4",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "f5eeec34-cd2c-4db8-93f0-78405dac1a09",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "0284edc4-f2f2-4098-8e22-dd6f284e29ea",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "7c2d6930-ecd8-45a8-b790-0ff4ecca416a",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "0e7c5a61-a4f9-4bb3-b80b-16d6e1a9ede9",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "507e6785-8c89-4f23-ba49-0f90da8e419f",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "121aa82d-85e7-4dd4-80be-9524808cc1e2",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "6271d72c-95fe-45a1-988c-c908d3f53b84",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "14d4fbc2-6cec-471e-9d2e-20bb58cb08c6",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "ef0a2e76-5166-4826-9fa4-dbbe05f08389",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "2a64a7ac-3883-4aa9-a97f-b185372abdb1",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "a5e38575-988e-49ac-a219-d746fd55cea2",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "32809f8d-020c-4f20-bf22-528e7ecddd16",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "e145cc3f-8ea6-450c-b3c1-d1543026470b",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "3512c568-67d3-4c28-9fc3-b11d3b3c1356",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "60c5d631-de65-4b4b-b547-07216b04a650",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "36bce1ff-f0fb-4175-9c0a-02aa133fc355",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "a95972a1-5b0a-4ac8-9c52-27e76329204b",
-        },
-        {
-            "object_creator": "submitter",
-            "uuid": "40fc6124-6754-4a97-b81d-245e362914bb",
-            "version": 0,
-            "model": {"type_name": "FileReference", "version": 3},
-            "additional_metadata": [
-                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
-            ],
-            "file_path": "Dummy file path",
-            "format": "Dummy format",
-            "size_in_bytes": 10,
-            "uri": "https://dummy.uri.co",
-            "submission_dataset_uuid": "686304c9-1a9c-4116-9ee1-51aa5e4f2b83",
-        },
-    ]
-
-
-def test_file_reference_page_size_enforced(
-    api_client: TestClient, mock_file_references: List[dict]
+@pytest.fixture(scope="function")
+def file_references_many(
+    api_client: TestClient, existing_file_reference: dict, existing_dataset: dict
 ):
-    page_size = 2
+    """
+    Creates several FileReference objects that share the same file_path.
+    """
+    file_references = []
+    study_id = existing_dataset["submitted_in_study_uuid"]
+    for _ in range(5):
+        new_ref = existing_file_reference.copy()
+        new_ref["file_path"] = "test file path"
+        new_ref["uuid"] = get_uuid()
+        new_ref["submission_dataset_uuid"] = existing_dataset["uuid"]
+        rsp = api_client.post("private/file_reference", json=new_ref)
+        assert rsp.status_code == 201, rsp.json()
+        file_references.append(new_ref)
+
+    file_references.sort(key=lambda fr: fr["uuid"])
+    return {"file_references": file_references, "study_id": study_id}
+
+
+def test_file_reference_path_name(api_client: TestClient, file_references_many: dict):
+    page_size = 3
     rsp = api_client.get(
         "/v2/search/file_reference/by_path_name",
-        params={"path_name": "Dummy file path", "page_size": page_size},
+        params={"path_name": "test file path", "page_size": page_size},
     )
+
     assert rsp.status_code == 200
     assert len(rsp.json()) == page_size
-    assert rsp.json() == mock_file_references[:2]
+    actual_sorted = sorted(rsp.json(), key=lambda fr: fr["uuid"])
+    expected_sorted = sorted(
+        file_references_many["file_references"][:page_size], key=lambda fr: fr["uuid"]
+    )
+    print(f"Response: {[uu['uuid'] for uu in actual_sorted]}\n")
+    print(f"List: {[uu['uuid'] for uu in expected_sorted]}\n")
+    assert actual_sorted == expected_sorted
+
+
+def test_file_reference_path_name_with_study(
+    api_client: TestClient, file_references_many: dict
+):
+    page_size = 5
+    study_id = file_references_many["study_id"]
+    rsp = api_client.get(
+        "/v2/search/file_reference/by_path_name",
+        params={
+            "path_name": "test file path",
+            "page_size": page_size,
+            "uuid": study_id,
+        },
+    )
+
+    assert rsp.status_code == 200
+    assert len(rsp.json()) == page_size
+    actual_sorted = sorted(rsp.json(), key=lambda fr: fr["uuid"])
+    expected_sorted = sorted(
+        file_references_many["file_references"][:page_size], key=lambda fr: fr["uuid"]
+    )
+    assert actual_sorted == expected_sorted
 
 
 def test_file_reference_bad_page_size_rejected(api_client: TestClient):
@@ -174,13 +78,4 @@ def test_file_reference_bad_page_size_rejected(api_client: TestClient):
 
 def test_file_reference_path_name_required(api_client: TestClient):
     rsp = api_client.get("/v2/search/file_reference/by_path_name")
-    assert rsp.status_code == 422  # Missing required query param
-
-
-def test_file_reference_no_results(api_client: TestClient):
-    rsp = api_client.get(
-        "/v2/search/file_reference/by_path_name",
-        params={"path_name": "Nonexistent path", "page_size": 3},
-    )
-    assert rsp.status_code == 200
-    assert rsp.json() == []
+    assert rsp.status_code == 422

--- a/api/api/tests/test_search_file_reference.py
+++ b/api/api/tests/test_search_file_reference.py
@@ -77,17 +77,24 @@ def test_file_reference_search_bad_page_size_rejected(api_client: TestClient):
         assert rsp.status_code == 422
 
 
-def test_file_reference_search_study_uuid_required(api_client: TestClient):
+def test_file_reference_search_study_uuid_required(
+    api_client: TestClient, existing_dataset: dict
+):
     rsp = api_client.get(
         "/v2/search/file_reference/by_path_name",
-        params={"study_uuid": "8c16740a-6805-4b86-80b6-caa036bf2a8a", "page_size": 1},
+        params={
+            "study_uuid": existing_dataset["submitted_in_study_uuid"],
+            "page_size": 1,
+        },
     )
     assert rsp.status_code == 422
 
 
-def test_file_reference_search_path_name_required(api_client: TestClient):
+def test_file_reference_search_path_name_required(
+    api_client: TestClient, existing_file_reference: dict
+):
     rsp = api_client.get(
         "/v2/search/file_reference/by_path_name",
-        params={"path_name": "Dummy file path", "page_size": 1},
+        params={"path_name": existing_file_reference["file_path"], "page_size": 1},
     )
     assert rsp.status_code == 422

--- a/api/api/tests/test_search_file_reference.py
+++ b/api/api/tests/test_search_file_reference.py
@@ -1,0 +1,186 @@
+import pytest
+from fastapi.testclient import TestClient
+from api.tests.conftest import get_uuid
+from typing import List
+
+
+@pytest.fixture
+def mock_file_references():
+    return [
+        {
+            "object_creator": "submitter",
+            "uuid": "00f8e870-255d-4102-ba8b-76f105a483c4",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "f5eeec34-cd2c-4db8-93f0-78405dac1a09",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "0284edc4-f2f2-4098-8e22-dd6f284e29ea",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "7c2d6930-ecd8-45a8-b790-0ff4ecca416a",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "0e7c5a61-a4f9-4bb3-b80b-16d6e1a9ede9",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "507e6785-8c89-4f23-ba49-0f90da8e419f",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "121aa82d-85e7-4dd4-80be-9524808cc1e2",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "6271d72c-95fe-45a1-988c-c908d3f53b84",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "14d4fbc2-6cec-471e-9d2e-20bb58cb08c6",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "ef0a2e76-5166-4826-9fa4-dbbe05f08389",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "2a64a7ac-3883-4aa9-a97f-b185372abdb1",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "a5e38575-988e-49ac-a219-d746fd55cea2",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "32809f8d-020c-4f20-bf22-528e7ecddd16",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "e145cc3f-8ea6-450c-b3c1-d1543026470b",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "3512c568-67d3-4c28-9fc3-b11d3b3c1356",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "60c5d631-de65-4b4b-b547-07216b04a650",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "36bce1ff-f0fb-4175-9c0a-02aa133fc355",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "a95972a1-5b0a-4ac8-9c52-27e76329204b",
+        },
+        {
+            "object_creator": "submitter",
+            "uuid": "40fc6124-6754-4a97-b81d-245e362914bb",
+            "version": 0,
+            "model": {"type_name": "FileReference", "version": 3},
+            "additional_metadata": [
+                {"provenance": "submitter", "name": "file_list_columns", "value": {}}
+            ],
+            "file_path": "Dummy file path",
+            "format": "Dummy format",
+            "size_in_bytes": 10,
+            "uri": "https://dummy.uri.co",
+            "submission_dataset_uuid": "686304c9-1a9c-4116-9ee1-51aa5e4f2b83",
+        },
+    ]
+
+
+def test_file_reference_page_size_enforced(
+    api_client: TestClient, mock_file_references: List[dict]
+):
+    page_size = 2
+    rsp = api_client.get(
+        "/v2/search/file_reference/by_path_name",
+        params={"path_name": "Dummy file path", "page_size": page_size},
+    )
+    assert rsp.status_code == 200
+    assert len(rsp.json()) == page_size
+    assert rsp.json() == mock_file_references[:2]
+
+
+def test_file_reference_bad_page_size_rejected(api_client: TestClient):
+    for bad in [0, -5]:
+        rsp = api_client.get(
+            "/v2/search/file_reference/by_path_name",
+            params={"path_name": "Dummy file path", "page_size": bad},
+        )
+        assert rsp.status_code == 422
+
+
+def test_file_reference_path_name_required(api_client: TestClient):
+    rsp = api_client.get("/v2/search/file_reference/by_path_name")
+    assert rsp.status_code == 422  # Missing required query param
+
+
+def test_file_reference_no_results(api_client: TestClient):
+    rsp = api_client.get(
+        "/v2/search/file_reference/by_path_name",
+        params={"path_name": "Nonexistent path", "page_size": 3},
+    )
+    assert rsp.status_code == 200
+    assert rsp.json() == []

--- a/api/api/tests/test_search_file_reference.py
+++ b/api/api/tests/test_search_file_reference.py
@@ -12,7 +12,6 @@ def file_references_many(
     Creates several FileReference objects that share the same file_path.
     """
     file_references = [existing_file_reference]
-    study_id = existing_dataset["submitted_in_study_uuid"]
     for _ in range(5):
         new_ref = existing_file_reference.copy()
         new_ref["file_path"] = "test file path"
@@ -23,47 +22,25 @@ def file_references_many(
         file_references.append(new_ref)
 
     file_references.sort(key=lambda fr: fr["uuid"])
-    return {"file_references": file_references, "study_id": study_id}
-
-
-def test_file_reference_path_name(api_client: TestClient, file_references_many: dict):
-    page_size = 3
-    file_path = "test file path"
-    rsp = api_client.get(
-        "/v2/search/file_reference/by_path_name",
-        params={"path_name": file_path, "page_size": page_size},
-    )
-    file_references = [
-        fr
-        for fr in file_references_many["file_references"]
-        if fr["file_path"] == file_path
-    ][:page_size]
-
-    assert rsp.status_code == 200
-    assert len(rsp.json()) == page_size
-    actual_sorted = sorted(rsp.json(), key=lambda fr: fr["uuid"])
-    expected_sorted = sorted(file_references, key=lambda fr: fr["uuid"])
-    assert actual_sorted == expected_sorted
+    return file_references
 
 
 def test_file_reference_path_name_with_study(
-    api_client: TestClient, file_references_many: dict
+    api_client: TestClient, file_references_many: List[dict], existing_dataset: dict
 ):
     page_size = 5
-    study_id = file_references_many["study_id"]
+    study_id = existing_dataset["submitted_in_study_uuid"]
     file_path = "test file path"
     rsp = api_client.get(
         "/v2/search/file_reference/by_path_name",
         params={
             "path_name": file_path,
             "page_size": page_size,
-            "uuid": study_id,
+            "study_uuid": study_id,
         },
     )
     file_references = [
-        fr
-        for fr in file_references_many["file_references"]
-        if fr["file_path"] == file_path
+        fr for fr in file_references_many if fr["file_path"] == file_path
     ][:page_size]
 
     assert rsp.status_code == 200

--- a/api/api/tests/test_search_file_reference.py
+++ b/api/api/tests/test_search_file_reference.py
@@ -46,35 +46,23 @@ def file_references_many(
 def test_file_reference_search_by_path_name_and_study_uuid(
     api_client: TestClient, file_references_many: List[dict], existing_dataset: dict
 ):
-    page_size = 5
     study_id = existing_dataset["submitted_in_study_uuid"]
     file_path = "test file path"
     rsp = api_client.get(
         "/v2/search/file_reference/by_path_name",
         params={
             "path_name": file_path,
-            "page_size": page_size,
             "study_uuid": study_id,
         },
     )
     file_references = [
         fr for fr in file_references_many if fr["file_path"] == file_path
-    ][:page_size]
+    ]
 
     assert rsp.status_code == 200
-    assert len(rsp.json()) == page_size
     actual_sorted = sorted(rsp.json(), key=lambda fr: fr["uuid"])
     expected_sorted = sorted(file_references, key=lambda fr: fr["uuid"])
     assert actual_sorted == expected_sorted
-
-
-def test_file_reference_search_bad_page_size_rejected(api_client: TestClient):
-    for bad in [0, -5]:
-        rsp = api_client.get(
-            "/v2/search/file_reference/by_path_name",
-            params={"path_name": "Dummy file path", "page_size": bad},
-        )
-        assert rsp.status_code == 422
 
 
 def test_file_reference_search_study_uuid_required(
@@ -84,7 +72,6 @@ def test_file_reference_search_study_uuid_required(
         "/v2/search/file_reference/by_path_name",
         params={
             "study_uuid": existing_dataset["submitted_in_study_uuid"],
-            "page_size": 1,
         },
     )
     assert rsp.status_code == 422
@@ -95,6 +82,6 @@ def test_file_reference_search_path_name_required(
 ):
     rsp = api_client.get(
         "/v2/search/file_reference/by_path_name",
-        params={"path_name": existing_file_reference["file_path"], "page_size": 1},
+        params={"path_name": existing_file_reference["file_path"]},
     )
     assert rsp.status_code == 422


### PR DESCRIPTION
https://app.clickup.com/t/8699f4tc5

Task: Add a method to the API that allows an API consumer to search for a FileReference using its exact path_name.

Background: to correctly create links between images in our database (via the API that controls interaction with Mongo), we want to be able to set a particular attribute on the file(s) that comprise that image. We have old curation code that enables this, but to make it work with the more recent version of the API, we'll need to add an API method that allows searching for a FileReference object using one of its attributes (path_name).
