### PR TITLE
test version bump to python 13

### DIFF
--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -52,7 +52,7 @@ jobs:
             bia-ingest,
             bia-assign-image,
             bia-converter,
-            bia-search
+            bia-search,
             ro-crate-ingest,
           ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -37,48 +37,6 @@ jobs:
         run: poetry build
       - name: Run pytest
         run: poetry run pytest
-  ci-test-with-api-python_3_11:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
-        poetry-version: ["1.8"]
-        # Note we do not test on windows or mac. Currently, github mac runners do not support nested virtualization, so we cannot run docker on them (since mac docker virtualises linux)
-        # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#limitations-for-arm64-macos-runners
-        os: [ubuntu-22.04]
-        project:
-          [
-            bia-export,
-            bia-ingest,
-            bia-assign-image,
-            bia-converter,
-            bia-search
-          ]
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: ${{ matrix.project }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v4
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-      - name: Run docker
-        run:  make -C ../ api.up
-      - name: set up poetry
-        run: |
-          poetry env use python
-          poetry install
-      - name: Run pytest
-        run: poetry run pytest
-      # Always cleanup - even for cancelled jobs
-      - name: Docker Compose Down
-        run:  make -C ../ api.down
-        if: ${{ always() }}
   ci-test-with-api-python_3_13:
     strategy:
       fail-fast: false
@@ -90,6 +48,11 @@ jobs:
         os: [ubuntu-22.04]
         project:
           [
+            bia-export,
+            bia-ingest,
+            bia-assign-image,
+            bia-converter,
+            bia-search
             ro-crate-ingest,
           ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/core.yaml
+++ b/.github/workflows/core.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.13"]
         poetry-version: ["1.8"]
         os: [ubuntu-22.04, macos-latest, windows-latest]
         project:
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.13"]
-        poetry-version: ["1.4.2"]
+        poetry-version: ["1.8"]
         # Note we do not test on windows or mac. Currently, github mac runners do not support nested virtualization, so we cannot run docker on them (since mac docker virtualises linux)
         # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#limitations-for-arm64-macos-runners
         os: [ubuntu-22.04]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # Define base image
-FROM python:3.10.0
+FROM python:3.13.0
 
 EXPOSE 8080
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -7,7 +7,7 @@ readme = "Readme.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.12"
+python = "^3.13"
 pydantic = "^2.4.0"
 fastapi = "^0.103.2"
 motor = "^3.1.2"
@@ -22,7 +22,6 @@ ome-types = "^0.4.2"
 # transitive dependency from ome-types
 #   not directly needed except the latest version crashes the api on start
 xsdata = "23.8"
-lxml = "^4.9.3"
 json-log-formatter = "^1.0"
 #@TODO: CHANGEME
 bia-shared-datamodels = { path = "../bia-shared-datamodels", develop = true }
@@ -34,6 +33,7 @@ pydantic-settings = "^2.3"
 #   to check if issue still occurs, comment line below & poetry lock; if it doesn't, delete this
 gevent = "24.10.2"
 aiohttp = "^3.11.13"
+lxml = "^6.0.0"
 
 [tool.poetry.group.dev.dependencies]
 locust = "^2.16.1"

--- a/bia-assign-image/pyproject.toml
+++ b/bia-assign-image/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "bia_assign_image"}]
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.12"
+python = "^3.13"
 bia-shared-datamodels = { path = "../bia-shared-datamodels", develop = true }
 bia-integrator-api = { path = "../clients/python", develop = true }
 bia-test-data = { path = "../bia-test-data", develop = true }

--- a/bia-converter/pyproject.toml
+++ b/bia-converter/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 packages = [{include = "bia_converter"}]
 
 [tool.poetry.dependencies]
-python = ">=3.11,<3.12"
+python = "^3.13"
 rich = "^13.8.1"
 bia-shared-datamodels = { path = "../bia-shared-datamodels", develop = true }
 bia-integrator-api = { path = "../clients/python", develop = true }

--- a/bia-export/pyproject.toml
+++ b/bia-export/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "bia_export"}]
 bia-export = "bia_export.cli:app"
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.12"
+python = "^3.13"
 pydantic = "^2"
 bia-shared-datamodels = { path = "../bia-shared-datamodels", develop = true }
 bia-test-data = { path = "../bia-test-data", develop = true }

--- a/bia-ingest/pyproject.toml
+++ b/bia-ingest/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "bia_ingest"}]
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.12"
+python = "^3.13"
 requests = "^2.31.0"
 bia-shared-datamodels = { path = "../bia-shared-datamodels", develop = true }
 bia-integrator-api = { path = "../clients/python", develop = true }

--- a/bia-search/Dockerfile
+++ b/bia-search/Dockerfile
@@ -1,5 +1,5 @@
 # Define base image
-FROM python:3.10.0
+FROM python:3.13.0
 
 EXPOSE 8080
 

--- a/bia-search/pyproject.toml
+++ b/bia-search/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.12"
+python = "^3.13"
 json-log-formatter = "^1.0"
 pydantic-settings = "^2.3"
 pydantic = "^2.4.0"

--- a/bia-test-data/pyproject.toml
+++ b/bia-test-data/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "bia_test_data"}]
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.12"
+python = "^3.13"
 bia-shared-datamodels = { path = "../bia-shared-datamodels", develop = true }
 bia-integrator-api = { path = "../clients/python", develop = true }
 pydantic-settings = "^2.3.4"


### PR DESCRIPTION
Update all packages and docker containers to use python 3.13

Converter tests fail as they previously did (still need updating to use new models): https://github.com/BioImage-Archive/bia-integrator/actions/runs/15829077006/job/44616838925

Ticket: https://app.clickup.com/t/8699dnvmq