### PR TITLE
add ng view link as CLI command

### DIFF
--- a/bia-converter/bia_converter/cli.py
+++ b/bia-converter/bia_converter/cli.py
@@ -1,13 +1,13 @@
 import sys
 import logging
-from typing import Optional, List
+from typing import Optional
 
 import typer
 from typing_extensions import Annotated
 
 from bia_converter.bia_api_client import api_client
 from bia_converter import convert as convert_module
-from bia_converter.ng_overlay import generate_overlays
+from bia_converter.ng_overlay import generate_overlays, NeuroglancerLayouts
 
 app = typer.Typer()
 
@@ -75,11 +75,11 @@ def generate_neuroglancer_view_link(
         str, typer.Option("--source-image-uuid", help="UUID for the source image")
     ],
     layout: Annotated[
-        str, typer.Option("--layout", help="Neuroglancer layout (e.g., xy, 4panel-alt)")
-    ] = "xy"
+        NeuroglancerLayouts, typer.Option("--layout", help="Neuroglancer layout (e.g., xy, 4panel-alt)")
+    ] = NeuroglancerLayouts.XY
 ):
     logging.basicConfig(level=logging.INFO)
-    generate_overlays(source_image_uuid)
+    generate_overlays(source_image_uuid, layout)
     logger.info(f"Generated neuroglancer view link for {source_image_uuid}")
 
 

--- a/bia-converter/bia_converter/cli.py
+++ b/bia-converter/bia_converter/cli.py
@@ -1,13 +1,13 @@
 import sys
 import logging
-from typing import Optional
+from typing import Optional, List
 
 import typer
 from typing_extensions import Annotated
 
 from bia_converter.bia_api_client import api_client
 from bia_converter import convert as convert_module
-
+from bia_converter.ng_overlay import generate_overlays
 
 app = typer.Typer()
 
@@ -68,6 +68,19 @@ def create_static_display(
     image_rep = api_client.get_image_representation(image_rep_uuid)
     static_display_uri = convert_module.convert_interactive_display_to_static_display(image_rep)
     logger.info(f"Created static display at {static_display_uri}")
+
+@app.command()
+def generate_neuroglancer_view_link(
+    source_image_uuid: Annotated[
+        str, typer.Option("--source-image-uuid", help="UUID for the source image")
+    ],
+    layout: Annotated[
+        str, typer.Option("--layout", help="Neuroglancer layout (e.g., xy, 4panel-alt)")
+    ] = "xy"
+):
+    logging.basicConfig(level=logging.INFO)
+    generate_overlays(source_image_uuid)
+    logger.info(f"Generated neuroglancer view link for {source_image_uuid}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://app.clickup.com/t/869a4uau2
Make create neuroglancer links runnable as a CLI tool in bia-converter

Updates
- get_ome_zar_file_uri: Gets the S3 url for the OME ZAR for an image
- annotation_filter: Study specific, but can be expanded in the future, to exclude certain annotations from the overlays
- update_additional_metadata_source_image_with_ng_view_url: Creates the attribute structure to add to the additional metadata of image object and updates the image object
- source_annotation_image_pairs: Finds the source and annotation image pairs using the api client

---

To test: 

```
source_image_uuid=0e00ab95-0da0-47f2-af67-6fbdc2ab05e2 # example UUID
poetry run bia-converter generate-neuroglancer-view-link --source-image-uuid $source_image_uuid

```