### PR TITLE
propper handling of protocol and annotation method in EMPIAR-> RO crate conversion

### DIFF
--- a/ro-crate-ingest/pyproject.toml
+++ b/ro-crate-ingest/pyproject.toml
@@ -23,6 +23,7 @@ pydantic-settings = "^2.9.1"
 pandas = "^2.3.1"
 pydantic = "^2.11.7"
 aioftp = "^0.26.2"
+pytest-check = "^2.5.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/empiar_proposal_conversion.py
+++ b/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/empiar_proposal_conversion.py
@@ -18,6 +18,7 @@ from ro_crate_ingest.empiar_to_ro_crate.entity_conversion import (
     contributor,
     study,
     file_list,
+    protocol,
 )
 import logging
 
@@ -61,6 +62,9 @@ def convert_empiar_proposal_to_ro_crate(proposal_path: Path, crate_path: Path):
         image_analysis_method.get_image_analysis_methods_by_title(yaml_file)
     )
     graph += roc_image_analysis_methods_map.values()
+
+    roc_protocol = protocol.get_protocols(yaml_file)
+    graph += roc_protocol
 
     roc_dataset_title_map = dataset.get_datasets_by_imageset_title(
         yaml_file=yaml_file,

--- a/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/file_list.py
+++ b/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/file_list.py
@@ -146,9 +146,9 @@ def find_matching_imageset_and_images(
                 bia_type = "http://bia/Image"
                 source_image_label = image.get("input_image_label", None)
                 associated_annotation_method = image.get(
-                    "associated_annotation_title", None
+                    "annotation_method_title", None
                 )
-                associated_protocol = image.get("associated_protocol_title", None)
+                associated_protocol = image.get("protocol_title", None)
                 break
 
         if not label:
@@ -167,10 +167,10 @@ def find_matching_imageset_and_images(
                     ]
 
                     associated_annotation_method = annotation_data.get(
-                        "associated_annotation_title", None
+                        "annotation_method_title", None
                     )
                     associated_protocol = annotation_data.get(
-                        "associated_protocol_title", None
+                        "protocol_title", None
                     )
                     break
 

--- a/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/protocol.py
+++ b/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/protocol.py
@@ -1,0 +1,29 @@
+import logging
+from bia_shared_datamodels import ro_crate_models
+
+logger = logging.getLogger("__main__." + __name__)
+
+
+def get_protocols(
+    rembi_yaml: dict,
+) -> list[ro_crate_models.Protocol]:
+    yaml_list_of_objs = rembi_yaml.get("rembis", {}).get("Protocol", [])
+
+    roc_objects = []
+    for yaml_object in yaml_list_of_objs:
+
+        roc_objects.append(get_protocol(yaml_object))
+
+    return roc_objects
+
+
+def get_protocol(yaml_object: dict) -> ro_crate_models.Protocol:
+
+    model_dict = {
+        "@id": f"_:{yaml_object["title"]}",
+        "@type": ["bia:Protocol"],
+        "title": yaml_object["title"],
+        "protocolDescription": yaml_object["protocol_description"],
+    }
+
+    return ro_crate_models.Protocol(**model_dict)

--- a/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/Reconstructed tomograms for dataset 1 (211206) data/211206/tomograms/file_list.tsv
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/Reconstructed tomograms for dataset 1 (211206) data/211206/tomograms/file_list.tsv
@@ -1,4 +1,4 @@
 file_path	size_in_bytes	type	label	source_image_label	associated_annotation_method	associated_protocol
-data/211206/tomograms/211206.star	71	http://bia/AnnotationData	Coordinates from subtomogram averaging of GEM2 particles for dataset 1 (211206)	['Tomogram TS_016', 'Tomogram TS_019']		
-data/211206/tomograms/TS_016.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_016	Tilt series TS_016		
-data/211206/tomograms/TS_019.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_019	Tilt series TS_019		
+data/211206/tomograms/211206.star	71	http://bia/AnnotationData	Coordinates from subtomogram averaging of GEM2 particles for dataset 1 (211206)	['Tomogram TS_016', 'Tomogram TS_019']	DeePiCt and manual particle picking	
+data/211206/tomograms/TS_016.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_016	Tilt series TS_016		Tomogram reconstruction and sub-tomogram averaging
+data/211206/tomograms/TS_019.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_019	Tilt series TS_019		Tomogram reconstruction and sub-tomogram averaging

--- a/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/Reconstructed tomograms for dataset 2 (220330) data/220330/tomograms/file_list.tsv
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/Reconstructed tomograms for dataset 2 (220330) data/220330/tomograms/file_list.tsv
@@ -1,5 +1,5 @@
 file_path	size_in_bytes	type	label	source_image_label	associated_annotation_method	associated_protocol
-data/220330/tomograms/220330.star	0	http://bia/AnnotationData	Coordinates from subtomogram averaging of GEM2 particles for dataset 2 (220330)	['Tomogram TS_008', 'Tomogram TS_010', 'Tomogram TS_017']		
-data/220330/tomograms/TS_008.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_008	Tilt series TS_008		
-data/220330/tomograms/TS_010.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_010	Tilt series TS_010		
-data/220330/tomograms/TS_017.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_017	Tilt series TS_017		
+data/220330/tomograms/220330.star	0	http://bia/AnnotationData	Coordinates from subtomogram averaging of GEM2 particles for dataset 2 (220330)	['Tomogram TS_008', 'Tomogram TS_010', 'Tomogram TS_017']	DeePiCt and manual particle picking	
+data/220330/tomograms/TS_008.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_008	Tilt series TS_008		Tomogram reconstruction and sub-tomogram averaging
+data/220330/tomograms/TS_010.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_010	Tilt series TS_010		Tomogram reconstruction and sub-tomogram averaging
+data/220330/tomograms/TS_017.mrc_aretomo.mrc	16	http://bia/Image	Tomogram TS_017	Tilt series TS_017		Tomogram reconstruction and sub-tomogram averaging

--- a/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/ro-crate-metadata.json
@@ -616,6 +616,14 @@
             }
         },
         {
+            "@id": "_:Tomogram reconstruction and sub-tomogram averaging",
+            "@type": [
+                "bia:Protocol"
+            ],
+            "title": "Tomogram reconstruction and sub-tomogram averaging",
+            "protocolDescription": "Dose-weighted motion-corrected images were exported for tomographic reconstruction by weighted back-projection in AreTomo and 4-times binned. Averaging was performed in RELION with 1,284 particles, I1 symmetry, using a 60-Å-low-pass-filtered map of the encapsulin scaffold (PDB 6X8M) as a reference."
+        },
+        {
             "@id": "_:CTF estimation and motion correction",
             "@type": [
                 "bia:ImageAnalysisMethod"

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/5832a3b6-7847-4d4a-b7ed-883a6705a30d.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/5832a3b6-7847-4d4a-b7ed-883a6705a30d.json
@@ -20,6 +20,8 @@
   "input_image_uuid": [
     "6265ecb0-1c64-4909-bb89-ee0a08a68c9c"
   ],
-  "protocol_uuid": [],
+  "protocol_uuid": [
+    "7212c1b0-86ed-45c4-830f-eeb9e85b9fa9"
+  ],
   "annotation_method_uuid": []
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/6fd418d5-e4c0-429c-9880-d52ed597000b.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/6fd418d5-e4c0-429c-9880-d52ed597000b.json
@@ -20,6 +20,8 @@
   "input_image_uuid": [
     "b3977436-e4d5-4bc3-8854-b8dcefe3df81"
   ],
-  "protocol_uuid": [],
+  "protocol_uuid": [
+    "7212c1b0-86ed-45c4-830f-eeb9e85b9fa9"
+  ],
   "annotation_method_uuid": []
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/74ae346b-1d71-4fc0-87b5-f521d9838ad9.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/74ae346b-1d71-4fc0-87b5-f521d9838ad9.json
@@ -23,5 +23,7 @@
     "6946bb5b-46a5-4a08-98a8-cd16d16e676a"
   ],
   "protocol_uuid": [],
-  "annotation_method_uuid": []
+  "annotation_method_uuid": [
+    "4aaaad85-4f00-4877-8a7b-cdcf09153f1f"
+  ]
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/82f2aebe-1738-4bca-8a1b-ba7d84d13f39.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/82f2aebe-1738-4bca-8a1b-ba7d84d13f39.json
@@ -20,6 +20,8 @@
   "input_image_uuid": [
     "7d07d617-9a52-49a9-9f5c-5cb75a525c4d"
   ],
-  "protocol_uuid": [],
+  "protocol_uuid": [
+    "7212c1b0-86ed-45c4-830f-eeb9e85b9fa9"
+  ],
   "annotation_method_uuid": []
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/9b40fafc-afa4-4fd6-ab3d-586765664cbb.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/9b40fafc-afa4-4fd6-ab3d-586765664cbb.json
@@ -20,6 +20,8 @@
   "input_image_uuid": [
     "88928f62-5799-498c-83fc-9b8922c046ea"
   ],
-  "protocol_uuid": [],
+  "protocol_uuid": [
+    "7212c1b0-86ed-45c4-830f-eeb9e85b9fa9"
+  ],
   "annotation_method_uuid": []
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/afcc1730-3443-4539-a4a4-8c6450602359.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/afcc1730-3443-4539-a4a4-8c6450602359.json
@@ -20,6 +20,8 @@
   "input_image_uuid": [
     "11e8fd9c-0470-4a91-943d-1ead59865141"
   ],
-  "protocol_uuid": [],
+  "protocol_uuid": [
+    "7212c1b0-86ed-45c4-830f-eeb9e85b9fa9"
+  ],
   "annotation_method_uuid": []
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/f4fb15bf-6091-41bf-aa20-65628d9e8b1b.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/creation_process/EMPIAR-STARFILETEST/f4fb15bf-6091-41bf-aa20-65628d9e8b1b.json
@@ -22,5 +22,7 @@
     "786e454e-c8d8-4446-8ee7-26e651df5ca3"
   ],
   "protocol_uuid": [],
-  "annotation_method_uuid": []
+  "annotation_method_uuid": [
+    "4aaaad85-4f00-4877-8a7b-cdcf09153f1f"
+  ]
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/16387e2b-b6d2-4189-bbda-20edd75983f6.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/16387e2b-b6d2-4189-bbda-20edd75983f6.json
@@ -24,7 +24,7 @@
         "http://schema.org/name": "Tomogram TS_019",
         "http://bia/sourceImageLabel": "Tilt series TS_019",
         "http://bia/associatedAnnotationMethod": "",
-        "http://bia/associatedProtocol": ""
+        "http://bia/associatedProtocol": "Tomogram reconstruction and sub-tomogram averaging"
       }
     }
   ],

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/5c82b4ea-c441-4252-ba06-18657cb12b33.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/5c82b4ea-c441-4252-ba06-18657cb12b33.json
@@ -24,7 +24,7 @@
         "http://schema.org/name": "Tomogram TS_010",
         "http://bia/sourceImageLabel": "Tilt series TS_010",
         "http://bia/associatedAnnotationMethod": "",
-        "http://bia/associatedProtocol": ""
+        "http://bia/associatedProtocol": "Tomogram reconstruction and sub-tomogram averaging"
       }
     }
   ],

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/643e7882-15ba-4a2e-8ec6-25f94193dffb.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/643e7882-15ba-4a2e-8ec6-25f94193dffb.json
@@ -24,7 +24,7 @@
         "http://schema.org/name": "Tomogram TS_016",
         "http://bia/sourceImageLabel": "Tilt series TS_016",
         "http://bia/associatedAnnotationMethod": "",
-        "http://bia/associatedProtocol": ""
+        "http://bia/associatedProtocol": "Tomogram reconstruction and sub-tomogram averaging"
       }
     }
   ],

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/66187fb9-9211-42ac-93ad-32452c83725c.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/66187fb9-9211-42ac-93ad-32452c83725c.json
@@ -23,7 +23,7 @@
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://bia/AnnotationData",
         "http://schema.org/name": "Coordinates from subtomogram averaging of GEM2 particles for dataset 1 (211206)",
         "http://bia/sourceImageLabel": "['Tomogram TS_016', 'Tomogram TS_019']",
-        "http://bia/associatedAnnotationMethod": "",
+        "http://bia/associatedAnnotationMethod": "DeePiCt and manual particle picking",
         "http://bia/associatedProtocol": ""
       }
     }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/901dc49e-44c5-4776-a4c9-e9c3470b22d2.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/901dc49e-44c5-4776-a4c9-e9c3470b22d2.json
@@ -24,7 +24,7 @@
         "http://schema.org/name": "Tomogram TS_017",
         "http://bia/sourceImageLabel": "Tilt series TS_017",
         "http://bia/associatedAnnotationMethod": "",
-        "http://bia/associatedProtocol": ""
+        "http://bia/associatedProtocol": "Tomogram reconstruction and sub-tomogram averaging"
       }
     }
   ],

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/e8087cb4-a452-467c-b07e-a8c2ee252d04.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/e8087cb4-a452-467c-b07e-a8c2ee252d04.json
@@ -23,7 +23,7 @@
         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": "http://bia/AnnotationData",
         "http://schema.org/name": "Coordinates from subtomogram averaging of GEM2 particles for dataset 2 (220330)",
         "http://bia/sourceImageLabel": "['Tomogram TS_008', 'Tomogram TS_010', 'Tomogram TS_017']",
-        "http://bia/associatedAnnotationMethod": "",
+        "http://bia/associatedAnnotationMethod": "DeePiCt and manual particle picking",
         "http://bia/associatedProtocol": ""
       }
     }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/fa8bfeae-ed62-4c99-bd29-130e73e5bc9f.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/fa8bfeae-ed62-4c99-bd29-130e73e5bc9f.json
@@ -24,7 +24,7 @@
         "http://schema.org/name": "Tomogram TS_008",
         "http://bia/sourceImageLabel": "Tilt series TS_008",
         "http://bia/associatedAnnotationMethod": "",
-        "http://bia/associatedProtocol": ""
+        "http://bia/associatedProtocol": "Tomogram reconstruction and sub-tomogram averaging"
       }
     }
   ],

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/protocol/EMPIAR-STARFILETEST/7212c1b0-86ed-45c4-830f-eeb9e85b9fa9.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/protocol/EMPIAR-STARFILETEST/7212c1b0-86ed-45c4-830f-eeb9e85b9fa9.json
@@ -1,0 +1,20 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "7212c1b0-86ed-45c4-830f-eeb9e85b9fa9",
+  "version": 0,
+  "model": {
+    "type_name": "Protocol",
+    "version": 3
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "Tomogram reconstruction and sub-tomogram averaging"
+      }
+    }
+  ],
+  "title": "Tomogram reconstruction and sub-tomogram averaging",
+  "protocol_description": "Dose-weighted motion-corrected images were exported for tomographic reconstruction by weighted back-projection in AreTomo and 4-times binned. Averaging was performed in RELION with 1,284 particles, I1 symmetry, using a 60-Å-low-pass-filtered map of the encapsulin scaffold (PDB 6X8M) as a reference."
+}


### PR DESCRIPTION
fix empiar to ro-crate conversion handling of protocols and annotation methods into the csv and added handling of protocols in the ro-crate-metadata.json

Changed tests to use pytest_check when comparing output: this lets the tests check all the objects and return all the differences, which helps understand what's going on with test failures.

ticket: https://app.clickup.com/t/869aa1xq8