### PR TITLE
Associated source image & update association properties

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/bia_ontology.ttl
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/bia_ontology.ttl
@@ -7,7 +7,7 @@
 @prefix schema: <http://schema.org/> .
 @prefix dc: <http://purl.org/dc/terms/> .
 @prefix csvw: <https://www.w3.org/ns/csvw#> .
-
+@prefix obo: <http://purl.obolibrary.org/obo/> .
 
 bia: a owl:Ontology ;
     schema:name "BioImage Archive Ontology" .
@@ -199,83 +199,74 @@ bia:linkDescription a owl:DatatypeProperty ;
 
 # Classes
 
-bia:Dataset a owl:Class ;
+bia:Dataset a owl:Class;
+    owl:subClassOf obo:IAO_0000030 ;
     rdfs:label "dataset"@en ;
     rdfs:comment "A logical collection of images that were created by following a similar set of protocols."@en .
-
-bia:AssociationProperty a owl:Class ;
-    rdfs:subClassOf rdf:Property ;
-    rdfs:label "association"@en ;
-    rdfs:comment 
-        """The associations proividing information about every element that is a part of the dataset.
-        For each statement `association (property) value`, where `dataset bia:association association`, then for each `dataset schema:hasPart image` there will be a number of additional statements about those images.
-        Depending on the set of properties for all statements of the form `association (property) value` for a given association, a CreationProcesses or Specimen may also be generated to house the statement.
-        In these cases each image will be assumed to have a unique CreationProcess and possible a unique Specimen (depending on the association statements). 
-        See the definitions of the properties in use on the association."""@en .
 
 # Properties
 
 # We recommend using the following properties from other ontologies:
 # - schema:hasPart to capture bia:FileReference or bia:Image are included in a dataset.
 
-bia:associatedAnalysisMethod a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedAnalysisMethod a owl:ObjectProperty;
     rdfs:label "associated analysis method"@en ;
-    rdfs:comment "An analysis method that was applied to (at least some of) the data in this dataset in order to produce results."@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+    rdfs:comment "An analysis method that was applied to (at least some of) the data in order to produce results."@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:ImageAnalysisMethod .
 
-bia:associatedCorrelationMethod a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedCorrelationMethod a owl:ObjectProperty;
     rdfs:label "associated correlation method"@en ;
-    rdfs:comment "A method that was applied to (at least some of) the data in the dataset to corralate data between two or more images."@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+    rdfs:comment "A method that was applied to (at least some of) the data to corralate data between two or more images."@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:ImageCorrelationMethod .
 
-bia:associatedSubject a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedSubject a owl:ObjectProperty ;
     rdfs:label "associated subject"@en ;
     rdfs:comment 
-        """Used to indicate a Specmein as the subject of all Images that are associated with a dataset or file. With datasets, this can be useful for correlated images of the same Specimen."""@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+        """Used to indicate a Specimen as the subject of the creation process(es) associated with this data. With datasets, this can be useful for correlated images of the same Specimen."""@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:Specimen .
 
-bia:associatedBiologicalEntity a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedBiologicalEntity a owl:ObjectProperty ;
     rdfs:label "associated biological entity"@en ;
     rdfs:comment 
-        """Used to indicate a BioSample as the source biological entity that was associated with a dataset or file."""@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+        """Used to indicate a BioSample as the source biological entity that was associated with the subject data."""@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:BioSample .
 
-bia:associatedImagingPreparationProtocol a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedImagingPreparationProtocol a owl:ObjectProperty ;
     rdfs:label "associated imaging preparation protocol"@en ;
     rdfs:comment 
-        """Used to indicate an ImageAcquisitionProtocol as a protocol that was followed in the process of creating all the specimens associated with a dataset or file."""@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+        """Used to indicate an ImageAcquisitionProtocol as a protocol that was followed in the process of creating all the specimens associated with the subject data."""@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:Specimen .
 
-bia:associatedImageAcquisitionProtocol a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedImageAcquisitionProtocol a owl:ObjectProperty ;
     rdfs:label "associated image acquisition protocol"@en ;
     rdfs:comment 
-        """Used to indicate an ImageAcquisitionProtocol as a protocol that was followed in the process of creating all the Images or Annotation Data associated with a dataset or file."""@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+        """Used to indicate an ImageAcquisitionProtocol as a protocol that was followed in the process of creating all the Images or Annotation Data associated with the subject data."""@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:Specimen .
 
-bia:associatedProtocol a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedProtocol a owl:ObjectProperty ;
     rdfs:label "associated protocol"@en ;
     rdfs:comment 
-        """Used to indicate a Protocol that was followed in the process of creating all the Images or Annotation Data associated with a dataset or file."""@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+        """Used to indicate a Protocol that was followed in the process of creating all the Images or Annotation Data associated with the subject data."""@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:Specimen .
 
-bia:associatedAnnotationMethod a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedAnnotationMethod a owl:ObjectProperty ;
     rdfs:label "associated protocol"@en ;
     rdfs:comment 
-        """Used to indicate an Annotation Method as a protocol that was followed in the process of creating all the Images or Annotation Data associated with a dataset or file."""@en;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+        """Used to indicate an Annotation Method as a protocol that was followed in the process of creating all the Images or Annotation Data associated with the subject data."""@en;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:Specimen .
 
-bia:associatedSourceImage a owl:ObjectProperty, bia:AssociationProperty ;
+bia:associatedSourceImage a owl:ObjectProperty ;
     rdfs:label "associated source image"@en ;
-    rdfs:comment """Used to indicate an Image as a source of data for a process that created all the Images or Annotation Data associated with a dataset or file."""@en ;
-    #rdfs:domain [ owl:unionOf ( bia:Dataset bia:FileReference) ];
+    rdfs:comment """Used to indicate an Image as a source of data for a process that created all the Images or Annotation Data associated with the subject data."""@en ;
+    rdfs:domain obo:IAO_0000030 ;
     rdfs:range bia:Image .
 
 bia:associationFileMetadata a owl:ObjectProperty;
@@ -290,7 +281,7 @@ bia:associationFileMetadata a owl:ObjectProperty;
 # Classes
 
 bia:Image a owl:Class ;
-    rdfs:subClassOf schema:CreativeWork ;
+    rdfs:subClassOf schema:CreativeWork ,  obo:IAO_0000030 ;
     rdfs:label "image"@en ;
     rdfs:comment "The abstract notion of an image that can have many representions in different image formats. A BIA image has been created from a unique set of File References."@en .
 
@@ -690,7 +681,7 @@ bia:channelBiologicalEntity a owl:DatatypeProperty ;
 # Classes
 
 bia:FileReference a owl:Class ;
-    rdfs:subClassOf schema:MediaObject ;
+    rdfs:subClassOf schema:MediaObject, obo:IAO_0000030  ;
     rdfs:label "file reference"@en ;
     rdfs:comment "An individual file."@en .
 

--- a/bia-shared-datamodels/test/test_ontology.py
+++ b/bia-shared-datamodels/test/test_ontology.py
@@ -29,9 +29,12 @@ def test_bia_properties_use_defined_terms(
 
     combined_ontology = bia_ontology + related_ontologies
 
-    all_classes = set(combined_ontology.subjects(RDF.type, OWL.Class)) | set(
-        combined_ontology.subjects(RDF.type, RDFS.Class)
+    all_classes = (
+        set(combined_ontology.subjects(RDF.type, OWL.Class))
+        | set(combined_ontology.subjects(RDF.type, RDFS.Class))        
     )
+    # We use IAO's information content entity (IAO_0000030) as the domain for some classes
+    all_classes.add(URIRef("http://purl.obolibrary.org/obo/IAO_0000030"))
 
     all_properties = (
         set(combined_ontology.subjects(RDF.type, OWL.ObjectProperty))


### PR DESCRIPTION
We're using association properties in the file list because it's useful to associate information that should go on specimens and creation processes at multiple levels. I've therefore imported IAO's information content entity: https://www.ebi.ac.uk/ols4/ontologies/iao/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FIAO_0000030?lang=en to use as a superclass of all 3. Data item might be more specific, but the definition is going to be confusing to people who expect images to use image (which is under figure).

I removed the association meta-property definition, since it's not longer correct and a correct one wouldn't be that helpful. All of these are quite generic in their meaning, but that is okay - the more specific properties exist to be used in our data model.

I decided to use this IAO class since it's reasonable for it to be a superclass of all the things we expect as the domain of the association property, and allows me to avoid the use of union classes in the definition - which are immediately a pain to handle programatically.