### PR TITLE
RO-crate validator: valid ro-crate & pydantic validation of ro-crate @graph objects

### DIFF
--- a/ro-crate-ingest/ro_crate_ingest/cli.py
+++ b/ro-crate-ingest/ro_crate_ingest/cli.py
@@ -11,6 +11,7 @@ from ro_crate_ingest.biostudies_to_ro_crate.biostudies_conversion import (
 from ro_crate_ingest.empiar_to_ro_crate.empiar_proposal_conversion import (
     convert_empiar_proposal_to_ro_crate,
 )
+from ro_crate_ingest.validator.validation import bia_roc_validation
 
 ro_crate_ingest = typer.Typer()
 
@@ -98,3 +99,15 @@ def empiar_to_ro_crate(
 
     convert_empiar_proposal_to_ro_crate(proposal_path, crate_path)
 
+
+@ro_crate_ingest.command("validate")
+def validate_ro_crate( crate_path: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--crate-path",
+            "-c",
+            case_sensitive=False,
+            help="Path to the ro-crate root (or ro-crate-metadata.json)",
+        ),
+    ] = None,):
+    bia_roc_validation(crate_path)

--- a/ro-crate-ingest/ro_crate_ingest/ro_crate_defaults.py
+++ b/ro-crate-ingest/ro_crate_ingest/ro_crate_defaults.py
@@ -3,6 +3,10 @@ from pathlib import Path
 import json
 from typing import Optional
 import os
+import bia_shared_datamodels.ro_crate_models as ROCrateModels
+from bia_shared_datamodels.linked_data.pydantic_ld.ROCrateModel import ROCrateModel
+import inspect
+from functools import lru_cache
 
 
 class ROCrateCreativeWork(BaseModel):
@@ -49,10 +53,26 @@ def write_ro_crate_metadata(
         )
 
 
-def create_ro_crate_folder(accession_id: str, crate_path: Optional[Path] = None) -> Path:
+def create_ro_crate_folder(
+    accession_id: str, crate_path: Optional[Path] = None
+) -> Path:
     output_path = crate_path if crate_path else Path(__file__).parents[1]
     ro_crate_dir = output_path / accession_id
     if not os.path.exists(ro_crate_dir):
         os.makedirs(ro_crate_dir)
 
     return ro_crate_dir
+
+
+@lru_cache
+def get_all_ro_crate_classes() -> dict:
+    ro_crate_pydantic_models = {
+        ro_crate_class.model_config["model_type"]: ro_crate_class
+        for name, ro_crate_class in inspect.getmembers(
+            ROCrateModels,
+            lambda member: inspect.isclass(member)
+            and member.__module__ == "bia_shared_datamodels.ro_crate_models"
+            and issubclass(member, ROCrateModel),
+        )
+    }
+    return ro_crate_pydantic_models

--- a/ro-crate-ingest/ro_crate_ingest/validator/exceptions.py
+++ b/ro-crate-ingest/ro_crate_ingest/validator/exceptions.py
@@ -1,0 +1,5 @@
+
+
+
+class ValidationError():
+    pass

--- a/ro-crate-ingest/ro_crate_ingest/validator/generic_validator.py
+++ b/ro-crate-ingest/ro_crate_ingest/validator/generic_validator.py
@@ -1,0 +1,57 @@
+from typing import Any, Optional
+from dataclasses import dataclass
+from enum import Enum
+from abc import ABC, abstractmethod
+
+
+from logging import getLevelName
+
+
+class Severity(str, Enum):
+    """
+    Copying logging levels from the logging module
+    """
+
+    CRITICAL = "CRICITCAL"
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+    INFO = "INFO"
+    # DEBUG = "DEBUG"
+
+
+@dataclass
+class ValidationError:
+    message: str
+    severity: Severity
+    location_description: Optional[str] = None
+
+
+class ValidationResult:
+    issues: list[ValidationError]
+    result: int
+    validated_object: Optional[Any] = None
+
+    def __init__(
+        self, issues: list[ValidationError], validated_object: Optional[Any] = None
+    ):
+        self.issues = issues
+        if len(issues) > 0:
+            self.result = 1
+        else:
+            self.result = 0
+
+        if validated_object:
+            self.validated_object = validated_object
+        else:
+            self.validated_object = None
+
+
+class Validator(ABC):
+    issues: list[ValidationError]
+
+    def __init__(self):
+        self.issues = []
+
+    @abstractmethod
+    def validate(self):
+        pass

--- a/ro-crate-ingest/ro_crate_ingest/validator/graph_entities.py
+++ b/ro-crate-ingest/ro_crate_ingest/validator/graph_entities.py
@@ -1,0 +1,107 @@
+from ro_crate_ingest.ro_crate_defaults import get_all_ro_crate_classes
+from ro_crate_ingest.crate_reader import expand_entity
+from ro_crate_ingest.validator.generic_validator import (
+    ValidationError,
+    ValidationResult,
+    Validator,
+    Severity,
+)
+from bia_shared_datamodels.linked_data.pydantic_ld import ROCrateModel
+import pydantic
+from typing import Optional
+import logging
+
+
+class GraphValidator(Validator):
+
+    class_map: dict
+
+    def __init__(self):
+        self.class_map = get_all_ro_crate_classes()
+        super().__init__()
+
+    def validate(self, graph: list[dict], context) -> ValidationResult:
+
+        roc_object_location_template = "At ro-crate object with @id: {roc_id}"
+
+        ro_crate_object_by_id = {}
+
+        for ro_crate_object in graph:
+
+            if ro_crate_object.get("@id") == "ro-crate-metadata.json":
+                # We don't need to validate the self-reffering entity for the ro-crate-metadata.json.
+                continue
+
+            try:
+                object_types = expand_entity(ro_crate_object, context)["@type"]
+            except KeyError:
+                self.issues.append(
+                    ValidationError(
+                        severity=Severity.ERROR,
+                        location_description=roc_object_location_template.format(
+                            roc_id=ro_crate_object.get("@id")
+                        ),
+                        message=f"Missing @type field. Found: {ro_crate_object.keys()}",
+                    )
+                )
+
+            class_intersection = self._get_class_intersection(object_types)
+
+            if (class_intersection_count := len(class_intersection)) != 1:
+                if class_intersection_count == 0:
+                    self.issues.append(
+                        ValidationError(
+                            severity=Severity.ERROR,
+                            location_description=roc_object_location_template.format(
+                                roc_id=ro_crate_object.get("@id")
+                            ),
+                            message=f"@type of object does not contain any BIA classes. @type contains: {", ".join(ro_crate_object.get("@type"))}",
+                        )
+                    )
+                else:
+                    self.issues.append(
+                        ValidationError(
+                            severity=Severity.ERROR,
+                            location_description=roc_object_location_template.format(
+                                roc_id=ro_crate_object.get("@id")
+                            ),
+                            message=f"@type of object contains multiple BIA classes. @type contains: {", ".join(sorted(class_intersection))}",
+                        )
+                    )
+                continue
+
+            model = self.class_map[class_intersection[0]]
+
+            try:
+                ro_crate_object: ROCrateModel = model(**ro_crate_object)
+            except pydantic.ValidationError as e:
+                self.issues.append(
+                    ValidationError(
+                        severity=Severity.ERROR,
+                        location_description=roc_object_location_template.format(
+                            roc_id=ro_crate_object.get("@id")
+                        ),
+                        message=str(e),
+                    )
+                )
+                continue
+
+            if ro_crate_object.id in ro_crate_object_by_id:
+                self.issues.append(
+                    ValidationError(
+                        severity=Severity.ERROR,
+                        location_description=roc_object_location_template.format(
+                            roc_id=ro_crate_object.id
+                        ),
+                        message=f"Two objects with the same @id: @id should be unique.",
+                    )
+                )
+
+            ro_crate_object_by_id[ro_crate_object.id] = ro_crate_object
+
+        return ValidationResult(
+            issues=self.issues, validated_object=ro_crate_object_by_id
+        )
+
+    def _get_class_intersection(self, object_types: list[str]):
+        return list(set(self.class_map.keys()) & set(object_types))

--- a/ro-crate-ingest/test/test_validator.py
+++ b/ro-crate-ingest/test/test_validator.py
@@ -1,0 +1,94 @@
+from ro_crate_ingest.validator.context_validator import validate_bia_context
+
+from pathlib import Path
+from typer.testing import CliRunner
+from ro_crate_ingest.cli import ro_crate_ingest
+import json
+import pytest
+import logging
+
+runner = CliRunner()
+
+
+def get_test_ro_crate_path(accession_id) -> Path:
+    return Path(__file__).parent / "validator" / "input_ro_crate" / accession_id
+
+
+@pytest.mark.parametrize(
+    "accession_id,expected_result,messages",
+    [
+        (
+            "test_invalid_ro_crate",
+            1,
+            [
+                (
+                    "ERROR",
+                    'The 1 occurrence of the JSON-LD key "field_not_included_in_context" is not allowed in the compacted format because it is not present in the @context of the document',
+                ),
+                (
+                    "ERROR",
+                    "./:\nThe Root Data Entity MUST have a `description` property (as specified by schema.org)",
+                ),
+                (
+                    "ERROR",
+                    "./:\nThe Root Data Entity MUST be linked to either File or Directory instances, nothing else",
+                ),
+                (
+                    "ERROR",
+                    "The RO-Crate does not include the Data Entity 'data2_missing_folder/' as part of its payload",
+                ),
+                (
+                    "ERROR",
+                    "./data1/:\nLess than 1 values on <file://.//data1/>->[ sh:inversePath <http://schema.org/hasPart> ]",
+                ),
+                (
+                    "ERROR",
+                    "./missing_has_part.tiff:\nLess than 1 values on <file://.//missing_has_part.tiff>->[ sh:inversePath <http://schema.org/hasPart> ]",
+                ),
+            ],
+        ),
+        (
+            "test_invalid_ro_crate_objects",
+            1,
+            [
+                (
+                    "ERROR",
+                    "At ro-crate object with @id: data2/:\n@type of object does not contain any BIA classes. @type contains: Dataset",
+                ),
+                (
+                    "ERROR",
+                    "At ro-crate object with @id: data2/groupedImage/:\n@type of object contains multiple BIA classes. @type contains: http://bia/Dataset, http://bia/Image",
+                ),
+                (
+                    "ERROR",
+                    'At ro-crate object with @id: _:SpecimenPreparation:\n1 validation error for SpecimenImagingPreparationProtocol\nprotocolDescription\n  Input should be a valid string [type=string_type, input_value=["ERROR This shouldn\'t be a list"], input_type=list]\n    For further information visit https://errors.pydantic.dev/2.11/v/string_type',
+                ),
+                (
+                    "ERROR",
+                    "At ro-crate object with @id: _:ImageAcquisitionProtocol1:\n1 validation error for ImageAcquisitionProtocol\nprotocolDescription\n  Field required [type=missing, input_value={'@id': '_:ImageAcquisiti...: ['obo:FBbi_00000246']}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/missing",
+                ),
+                (
+                    "ERROR",
+                    "At ro-crate object with @id: _:RepeatedBiosample1:\nTwo objects with the same @id: @id should be unique.",
+                ),
+            ],
+        ),
+    ],
+)
+def test_ro_crate_context_validation_error_messages(
+    accession_id, expected_result, messages, caplog
+):
+
+    caplog.set_level(logging.ERROR)
+
+    crate_path = get_test_ro_crate_path(accession_id)
+
+    arguments = ["validate", "-c", crate_path]
+    result = runner.invoke(ro_crate_ingest, arguments)
+    assert result.exit_code == expected_result
+
+    captured_messages = [
+        (record.levelname, record.message) for record in caplog.records
+    ]
+
+    assert captured_messages == messages


### PR DESCRIPTION
Created validator for ro-crate performing generic ro-crate checks, as well as pydantic model validation of entities in the ro-crate.

Ticket: https://app.clickup.com/t/869abahcx

Validates: 

- Is valid Ro-crate
- Id's work (e.g. are correctly quoted uris or blank nodes)
- Each id appears once only
- Files & Filelists, if referenced, exist?
- Objects are valid bia-ro-crate objects
- Disjoint classes? (only 1 bia class referenced per object type)

Still need to do:
Validation of context (and possible transformation before ro-crate object validation)
Validation of filelists 