### PR TITLE
Image representations

### DIFF
--- a/ro-crate-ingest/pyproject.toml
+++ b/ro-crate-ingest/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.13"
 bia-shared-datamodels = { path = "../bia-shared-datamodels", develop = true }
 bia-integrator-api = { path = "../clients/python", develop = true }
 
-typer = "^0.12.5"
+typer = "^0.17"
 rocrate = "^0"
 linkml = "^1.8.7"
 roc-validator = "^0"

--- a/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/submission_parsing_utils.py
+++ b/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/submission_parsing_utils.py
@@ -18,13 +18,11 @@ def attributes_to_dict(
     for attr in attributes:
         normalised_key = attr.name.lower()
         if normalised_key in attr_dict:
-            if isinstance(attr_dict[normalised_key], list):
-                attr_dict[normalised_key].append(attr.value)
-            else:
+            if not isinstance(attr_dict[attr.name], list):
                 attr_dict[normalised_key] = [
                     attr_dict[normalised_key],
                 ]
-                attr_dict[normalised_key].append(attr.value)
+            attr_dict[normalised_key].append(attr.value)
         else:
             attr_dict[normalised_key] = attr.value
     return attr_dict

--- a/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/submission_parsing_utils.py
+++ b/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/submission_parsing_utils.py
@@ -18,7 +18,7 @@ def attributes_to_dict(
     for attr in attributes:
         normalised_key = attr.name.lower()
         if normalised_key in attr_dict:
-            if not isinstance(attr_dict[attr.name], list):
+            if not isinstance(attr_dict[normalised_key], list):
                 attr_dict[normalised_key] = [
                     attr_dict[normalised_key],
                 ]

--- a/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/file_reference_and_result_dataframe.py
+++ b/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/file_reference_and_result_dataframe.py
@@ -55,7 +55,7 @@ def create_file_reference_and_result_data_row(
     file_ref_url_prefix: str,
     persistence_mode: PersistenceMode,
     image_extensions: list[str],
-) -> APIModels.FileReference:
+) -> dict:
     """
     Creates & persists file references.
     Return the required information needed to create result data (images, annotation data).
@@ -123,7 +123,7 @@ def information_for_result_data_creation(
     size_in_bytes,
     file_format,
     uri,
-) -> Optional[dict]:
+) -> dict:
 
     result_data_id, obj_type = select_result_data_id_and_type(row, image_extensions)
     result_data_label_from_filelist = None

--- a/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/file_reference_and_result_dataframe.py
+++ b/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/file_reference_and_result_dataframe.py
@@ -58,7 +58,7 @@ def create_file_reference_and_result_data_row(
 ) -> APIModels.FileReference:
     """
     Creates & persists file references.
-    Return the required information needed to create result data (images, annotationd data).
+    Return the required information needed to create result data (images, annotation data).
     """
     import pandas as pd
     from numpy import nan
@@ -80,6 +80,8 @@ def create_file_reference_and_result_data_row(
 
     dataset_roc_id = select_dataset(row)
     dataset_uuid = str(create_dataset_uuid(study_uuid, dataset_roc_id)[0])
+    file_format = get_suffix(row["path"])
+    uri = get_file_ref_uri(file_ref_url_prefix, accession_id, row["path"])
 
     model_dict = {
         "uuid": str(uuid),
@@ -87,8 +89,8 @@ def create_file_reference_and_result_data_row(
         "file_path": row["path"],
         "version": 0,
         "size_in_bytes": size_in_bytes,
-        "format": get_suffix(row["path"]),
-        "uri": get_file_ref_uri(file_ref_url_prefix, accession_id, row["path"]),
+        "format": file_format,
+        "uri": uri,
         "object_creator": APIModels.Provenance.BIA_INGEST,
         "additional_metadata": additional_metadata,
     }
@@ -101,12 +103,26 @@ def create_file_reference_and_result_data_row(
     )
 
     return information_for_result_data_creation(
-        row, image_extensions, uuid, dataset_roc_id, dataset_uuid
+        row,
+        image_extensions,
+        uuid,
+        dataset_roc_id,
+        dataset_uuid,
+        size_in_bytes,
+        file_format,
+        uri,
     )
 
 
 def information_for_result_data_creation(
-    row, image_extensions, uuid, dataset_roc_id, dataset_uuid
+    row,
+    image_extensions,
+    uuid,
+    dataset_roc_id,
+    dataset_uuid,
+    size_in_bytes,
+    file_format,
+    uri,
 ) -> Optional[dict]:
 
     result_data_id, obj_type = select_result_data_id_and_type(row, image_extensions)
@@ -130,6 +146,9 @@ def information_for_result_data_creation(
         "result_data_id": result_data_id,
         "result_data_label_from_filelist": result_data_label_from_filelist,
         "association_data_from_filelist": filelist_to_ro_crate_object_reference,
+        "size_in_bytes": size_in_bytes,
+        "file_format": file_format,
+        "uri": uri,
     }
 
 
@@ -141,7 +160,7 @@ def get_suffix(file_path: str) -> str:
 def get_file_ref_uri(file_ref_url_prefix, accession_id, file_path) -> str:
     if file_ref_url_prefix == "empiar":
         accession_no = accession_id.split("-")[1]
-        return f"https://ftp.ebi.ac.uk/empiar/world_availability/{accession_no}/data/{file_path}"
+        return f"https://ftp.ebi.ac.uk/empiar/world_availability/{accession_no}/{file_path}"
     elif file_ref_url_prefix == "biostudies":
         return f"https://www.ebi.ac.uk/biostudies/files/{accession_id}/{file_path}"
     else:

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/410a4130-4120-43e9-a820-37a95da3e0fa.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/410a4130-4120-43e9-a820-37a95da3e0fa.json
@@ -31,6 +31,6 @@
   "file_path": "data/HeLa/Raw SEM images/param.pdf",
   "format": ".pdf",
   "size_in_bytes": 0,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/data/HeLa/Raw SEM images/param.pdf",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/HeLa/Raw SEM images/param.pdf",
   "submission_dataset_uuid": "8745e192-ad53-4a7f-adba-200cdeab3d95"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/7b02bea5-bb5c-4a78-8bc5-ca31d373c228.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/7b02bea5-bb5c-4a78-8bc5-ca31d373c228.json
@@ -31,6 +31,6 @@
   "file_path": "data/HeLa/Raw SEM images/SEM Image - SliceImage - 002.tif",
   "format": ".tif",
   "size_in_bytes": 12,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/data/HeLa/Raw SEM images/SEM Image - SliceImage - 002.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/HeLa/Raw SEM images/SEM Image - SliceImage - 002.tif",
   "submission_dataset_uuid": "8745e192-ad53-4a7f-adba-200cdeab3d95"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/8b0817a3-a5d9-4231-a390-8403652c7c52.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/8b0817a3-a5d9-4231-a390-8403652c7c52.json
@@ -31,6 +31,6 @@
   "file_path": "data/HeLa/Raw SEM images/SEM Image - SliceImage - 001.tif",
   "format": ".tif",
   "size_in_bytes": 12,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/data/HeLa/Raw SEM images/SEM Image - SliceImage - 001.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/HeLa/Raw SEM images/SEM Image - SliceImage - 001.tif",
   "submission_dataset_uuid": "8745e192-ad53-4a7f-adba-200cdeab3d95"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/9b961fcd-418e-4fdb-8ea6-cf2bad89a17e.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-IMAGEPATTERNTEST/9b961fcd-418e-4fdb-8ea6-cf2bad89a17e.json
@@ -31,6 +31,6 @@
   "file_path": "data/HeLa/segmentation/centrioles.tif",
   "format": ".tif",
   "size_in_bytes": 12,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/data/HeLa/segmentation/centrioles.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/HeLa/segmentation/centrioles.tif",
   "submission_dataset_uuid": "8745e192-ad53-4a7f-adba-200cdeab3d95"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/16387e2b-b6d2-4189-bbda-20edd75983f6.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/16387e2b-b6d2-4189-bbda-20edd75983f6.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/tomograms/TS_019.mrc_aretomo.mrc",
   "format": ".mrc",
   "size_in_bytes": 16,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/tomograms/TS_019.mrc_aretomo.mrc",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/tomograms/TS_019.mrc_aretomo.mrc",
   "submission_dataset_uuid": "d672654f-e309-4988-b9f6-9c00986b9892"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/2f918ab8-e07b-4b26-bbbb-0101d34a46c5.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/2f918ab8-e07b-4b26-bbbb-0101d34a46c5.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/data/frames/TS_010_48_002_17.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/data/frames/TS_010_48_002_17.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_010_48_002_17.tif",
   "submission_dataset_uuid": "c5edec32-e491-4b05-8ed9-1ee09f23155d"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/40326777-c4a4-46d4-8b4c-ffc92dde1bf5.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/40326777-c4a4-46d4-8b4c-ffc92dde1bf5.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/alignment/TS_016.mrc/TS_016.mrc.st",
   "format": ".st",
   "size_in_bytes": 27,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/alignment/TS_016.mrc/TS_016.mrc.st",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/alignment/TS_016.mrc/TS_016.mrc.st",
   "submission_dataset_uuid": "0bf4462d-039c-4f5c-a6ed-d91265cd9c2a"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/43a8a925-0843-4d7b-9926-c9352e5ad152.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/43a8a925-0843-4d7b-9926-c9352e5ad152.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/data/frames/TS_017_23_001_12.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/data/frames/TS_017_23_001_12.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_017_23_001_12.tif",
   "submission_dataset_uuid": "c5edec32-e491-4b05-8ed9-1ee09f23155d"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/472aacfd-fa7c-4c55-88fd-462258e62f8a.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/472aacfd-fa7c-4c55-88fd-462258e62f8a.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/data/frames/TS_016_76_001_12.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/data/frames/TS_016_76_001_12.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_016_76_001_12.tif",
   "submission_dataset_uuid": "79ab8f2b-8ed9-4dbd-b2e5-495617623358"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/485a1ea7-19d2-4ce4-b1d2-bc252dda3c9c.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/485a1ea7-19d2-4ce4-b1d2-bc252dda3c9c.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/data/frames/TS_008_42_001_12.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/data/frames/TS_008_42_001_12.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_008_42_001_12.tif",
   "submission_dataset_uuid": "c5edec32-e491-4b05-8ed9-1ee09f23155d"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/4dc2c02c-282c-4340-946c-dfd9ef4a3540.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/4dc2c02c-282c-4340-946c-dfd9ef4a3540.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/data/frames/TS_019_84_002_17.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/data/frames/TS_019_84_002_17.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_019_84_002_17.tif",
   "submission_dataset_uuid": "79ab8f2b-8ed9-4dbd-b2e5-495617623358"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/51b91e70-eb02-47d2-b511-ffcae185e4c0.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/51b91e70-eb02-47d2-b511-ffcae185e4c0.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/data/frames/TS_016_76_002_17.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/data/frames/TS_016_76_002_17.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_016_76_002_17.tif",
   "submission_dataset_uuid": "79ab8f2b-8ed9-4dbd-b2e5-495617623358"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/54cb496d-1b65-4142-8c3c-f1e934c376b6.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/54cb496d-1b65-4142-8c3c-f1e934c376b6.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/alignment/TS_019.mrc/TS_019.mrc.st",
   "format": ".st",
   "size_in_bytes": 27,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/alignment/TS_019.mrc/TS_019.mrc.st",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/alignment/TS_019.mrc/TS_019.mrc.st",
   "submission_dataset_uuid": "0bf4462d-039c-4f5c-a6ed-d91265cd9c2a"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/5c82b4ea-c441-4252-ba06-18657cb12b33.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/5c82b4ea-c441-4252-ba06-18657cb12b33.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/tomograms/TS_010.mrc_aretomo.mrc",
   "format": ".mrc",
   "size_in_bytes": 16,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/tomograms/TS_010.mrc_aretomo.mrc",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/tomograms/TS_010.mrc_aretomo.mrc",
   "submission_dataset_uuid": "f22da05c-650e-4029-8a4e-f9dc45ff39be"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/606ca1be-b643-4dd2-a22f-7fdc7222894e.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/606ca1be-b643-4dd2-a22f-7fdc7222894e.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/data/frames/TS_017_23_002_17.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/data/frames/TS_017_23_002_17.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_017_23_002_17.tif",
   "submission_dataset_uuid": "c5edec32-e491-4b05-8ed9-1ee09f23155d"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/643e7882-15ba-4a2e-8ec6-25f94193dffb.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/643e7882-15ba-4a2e-8ec6-25f94193dffb.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/tomograms/TS_016.mrc_aretomo.mrc",
   "format": ".mrc",
   "size_in_bytes": 16,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/tomograms/TS_016.mrc_aretomo.mrc",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/tomograms/TS_016.mrc_aretomo.mrc",
   "submission_dataset_uuid": "d672654f-e309-4988-b9f6-9c00986b9892"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/66187fb9-9211-42ac-93ad-32452c83725c.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/66187fb9-9211-42ac-93ad-32452c83725c.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/tomograms/211206.star",
   "format": ".star",
   "size_in_bytes": 71,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/tomograms/211206.star",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/tomograms/211206.star",
   "submission_dataset_uuid": "d672654f-e309-4988-b9f6-9c00986b9892"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/7c842bd0-922f-42fd-bb23-33f701c9e901.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/7c842bd0-922f-42fd-bb23-33f701c9e901.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/alignment/TS_008.mrc/TS_008.mrc.st",
   "format": ".st",
   "size_in_bytes": 27,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/alignment/TS_008.mrc/TS_008.mrc.st",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/alignment/TS_008.mrc/TS_008.mrc.st",
   "submission_dataset_uuid": "f20b8e26-9a74-470e-b5b7-b877ffff7754"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/8cf72254-913f-4303-8061-16721c0027d1.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/8cf72254-913f-4303-8061-16721c0027d1.json
@@ -31,6 +31,6 @@
   "file_path": "data/211206/data/frames/TS_019_84_001_12.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/211206/data/frames/TS_019_84_001_12.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_019_84_001_12.tif",
   "submission_dataset_uuid": "79ab8f2b-8ed9-4dbd-b2e5-495617623358"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/901dc49e-44c5-4776-a4c9-e9c3470b22d2.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/901dc49e-44c5-4776-a4c9-e9c3470b22d2.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/tomograms/TS_017.mrc_aretomo.mrc",
   "format": ".mrc",
   "size_in_bytes": 16,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/tomograms/TS_017.mrc_aretomo.mrc",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/tomograms/TS_017.mrc_aretomo.mrc",
   "submission_dataset_uuid": "f22da05c-650e-4029-8a4e-f9dc45ff39be"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/9cfad2ef-abfd-47df-9039-982dfef856dc.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/9cfad2ef-abfd-47df-9039-982dfef856dc.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/alignment/TS_017.mrc/TS_017.mrc.st",
   "format": ".st",
   "size_in_bytes": 27,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/alignment/TS_017.mrc/TS_017.mrc.st",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/alignment/TS_017.mrc/TS_017.mrc.st",
   "submission_dataset_uuid": "f20b8e26-9a74-470e-b5b7-b877ffff7754"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/a68bd061-e8db-42e9-95c5-fab091eb182d.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/a68bd061-e8db-42e9-95c5-fab091eb182d.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/alignment/TS_010.mrc/TS_010.mrc.st",
   "format": ".st",
   "size_in_bytes": 27,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/alignment/TS_010.mrc/TS_010.mrc.st",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/alignment/TS_010.mrc/TS_010.mrc.st",
   "submission_dataset_uuid": "f20b8e26-9a74-470e-b5b7-b877ffff7754"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/c01e2bc5-d4bf-42c2-85b7-a55b5f8debeb.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/c01e2bc5-d4bf-42c2-85b7-a55b5f8debeb.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/data/frames/TS_010_48_001_12.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/data/frames/TS_010_48_001_12.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_010_48_001_12.tif",
   "submission_dataset_uuid": "c5edec32-e491-4b05-8ed9-1ee09f23155d"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/cb417807-328d-4fd7-a7b9-66b69870dd03.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/cb417807-328d-4fd7-a7b9-66b69870dd03.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/data/frames/TS_008_42_002_17.tif",
   "format": ".tif",
   "size_in_bytes": 17,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/data/frames/TS_008_42_002_17.tif",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_008_42_002_17.tif",
   "submission_dataset_uuid": "c5edec32-e491-4b05-8ed9-1ee09f23155d"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/e8087cb4-a452-467c-b07e-a8c2ee252d04.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/e8087cb4-a452-467c-b07e-a8c2ee252d04.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/tomograms/220330.star",
   "format": ".star",
   "size_in_bytes": 0,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/tomograms/220330.star",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/tomograms/220330.star",
   "submission_dataset_uuid": "f22da05c-650e-4029-8a4e-f9dc45ff39be"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/fa8bfeae-ed62-4c99-bd29-130e73e5bc9f.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/file_reference/EMPIAR-STARFILETEST/fa8bfeae-ed62-4c99-bd29-130e73e5bc9f.json
@@ -31,6 +31,6 @@
   "file_path": "data/220330/tomograms/TS_008.mrc_aretomo.mrc",
   "format": ".mrc",
   "size_in_bytes": 16,
-  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/data/220330/tomograms/TS_008.mrc_aretomo.mrc",
+  "uri": "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/tomograms/TS_008.mrc_aretomo.mrc",
   "submission_dataset_uuid": "f22da05c-650e-4029-8a4e-f9dc45ff39be"
 }

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-IMAGEPATTERNTEST/14e74c87-a126-4d8a-a1c8-112da3ea2b92.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-IMAGEPATTERNTEST/14e74c87-a126-4d8a-a1c8-112da3ea2b92.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "14e74c87-a126-4d8a-a1c8-112da3ea2b92",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "60cf34f5-5b11-4aa1-8b30-be09ccb82413"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/HeLa/segmentation/centrioles.tif"
+  ],
+  "total_size_in_bytes": 12,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "60cf34f5-5b11-4aa1-8b30-be09ccb82413"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-IMAGEPATTERNTEST/3102a2da-e1f9-4873-88f2-cadda04da493.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-IMAGEPATTERNTEST/3102a2da-e1f9-4873-88f2-cadda04da493.json
@@ -1,0 +1,34 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "3102a2da-e1f9-4873-88f2-cadda04da493",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "57b2dff5-06bf-42d1-bb75-c62c43bb909b"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/HeLa/Raw SEM images/SEM Image - SliceImage - 001.tif",
+    "https://ftp.ebi.ac.uk/empiar/world_availability/IMAGEPATTERNTEST/data/HeLa/Raw SEM images/SEM Image - SliceImage - 002.tif"
+  ],
+  "total_size_in_bytes": 24,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "57b2dff5-06bf-42d1-bb75-c62c43bb909b"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/028bc4b8-34e0-488e-ba6a-17695ceae3de.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/028bc4b8-34e0-488e-ba6a-17695ceae3de.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "028bc4b8-34e0-488e-ba6a-17695ceae3de",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "87f8921c-39f4-4896-94b6-3e0f5a2eeb7e"
+      }
+    }
+  ],
+  "image_format": ".mrc",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/tomograms/TS_010.mrc_aretomo.mrc"
+  ],
+  "total_size_in_bytes": 16,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "87f8921c-39f4-4896-94b6-3e0f5a2eeb7e"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/17299b29-826b-4a6c-8fcd-220c5255ffa6.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/17299b29-826b-4a6c-8fcd-220c5255ffa6.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "17299b29-826b-4a6c-8fcd-220c5255ffa6",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "6946bb5b-46a5-4a08-98a8-cd16d16e676a"
+      }
+    }
+  ],
+  "image_format": ".mrc",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/tomograms/TS_017.mrc_aretomo.mrc"
+  ],
+  "total_size_in_bytes": 16,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "6946bb5b-46a5-4a08-98a8-cd16d16e676a"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/2985b02f-a611-4606-ae9b-e9977632c822.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/2985b02f-a611-4606-ae9b-e9977632c822.json
@@ -1,0 +1,34 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "2985b02f-a611-4606-ae9b-e9977632c822",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "9665d823-a720-4cfd-86b4-d5cc5000f18f"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_017_23_001_12.tif",
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_017_23_002_17.tif"
+  ],
+  "total_size_in_bytes": 34,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "9665d823-a720-4cfd-86b4-d5cc5000f18f"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/3ad9adb6-f69c-4cf1-b723-cd4d1199e0e1.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/3ad9adb6-f69c-4cf1-b723-cd4d1199e0e1.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "3ad9adb6-f69c-4cf1-b723-cd4d1199e0e1",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "6265ecb0-1c64-4909-bb89-ee0a08a68c9c"
+      }
+    }
+  ],
+  "image_format": ".st",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/alignment/TS_017.mrc/TS_017.mrc.st"
+  ],
+  "total_size_in_bytes": 27,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "6265ecb0-1c64-4909-bb89-ee0a08a68c9c"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/41430d8f-1a73-4234-a056-80643b37bd6b.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/41430d8f-1a73-4234-a056-80643b37bd6b.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "41430d8f-1a73-4234-a056-80643b37bd6b",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "57e3d5a6-0a4a-46ea-ba24-4a1af2c79b5c"
+      }
+    }
+  ],
+  "image_format": ".mrc",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/tomograms/TS_008.mrc_aretomo.mrc"
+  ],
+  "total_size_in_bytes": 16,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "57e3d5a6-0a4a-46ea-ba24-4a1af2c79b5c"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/5e0eb69a-7c75-478f-b388-5e15e0b93425.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/5e0eb69a-7c75-478f-b388-5e15e0b93425.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "5e0eb69a-7c75-478f-b388-5e15e0b93425",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "b3977436-e4d5-4bc3-8854-b8dcefe3df81"
+      }
+    }
+  ],
+  "image_format": ".st",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/alignment/TS_010.mrc/TS_010.mrc.st"
+  ],
+  "total_size_in_bytes": 27,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "b3977436-e4d5-4bc3-8854-b8dcefe3df81"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/5e43e067-64fa-46e4-bf97-5138f0ee6b74.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/5e43e067-64fa-46e4-bf97-5138f0ee6b74.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "5e43e067-64fa-46e4-bf97-5138f0ee6b74",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "ea1a979c-03a4-458f-9640-4c332aef0328"
+      }
+    }
+  ],
+  "image_format": ".mrc",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/tomograms/TS_016.mrc_aretomo.mrc"
+  ],
+  "total_size_in_bytes": 16,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "ea1a979c-03a4-458f-9640-4c332aef0328"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/70eef962-cdb1-4b8a-aa32-2a7afaf7b92d.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/70eef962-cdb1-4b8a-aa32-2a7afaf7b92d.json
@@ -1,0 +1,34 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "70eef962-cdb1-4b8a-aa32-2a7afaf7b92d",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "1d47fe0d-2ebc-4a07-b8ac-d7e3280bad7c"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_016_76_001_12.tif",
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_016_76_002_17.tif"
+  ],
+  "total_size_in_bytes": 34,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "1d47fe0d-2ebc-4a07-b8ac-d7e3280bad7c"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/81a0cb59-dfb4-47a8-a261-9a6aa9915ae4.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/81a0cb59-dfb4-47a8-a261-9a6aa9915ae4.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "81a0cb59-dfb4-47a8-a261-9a6aa9915ae4",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "786e454e-c8d8-4446-8ee7-26e651df5ca3"
+      }
+    }
+  ],
+  "image_format": ".mrc",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/tomograms/TS_019.mrc_aretomo.mrc"
+  ],
+  "total_size_in_bytes": 16,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "786e454e-c8d8-4446-8ee7-26e651df5ca3"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/85f3300b-d6d3-4e98-b14b-8f76f4d9710a.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/85f3300b-d6d3-4e98-b14b-8f76f4d9710a.json
@@ -1,0 +1,34 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "85f3300b-d6d3-4e98-b14b-8f76f4d9710a",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "47fd92aa-4838-4ff4-b2e5-58c2f18e9a5e"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_019_84_001_12.tif",
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/data/frames/TS_019_84_002_17.tif"
+  ],
+  "total_size_in_bytes": 34,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "47fd92aa-4838-4ff4-b2e5-58c2f18e9a5e"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/b122f8b3-44cb-4fc8-8155-607091c279ea.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/b122f8b3-44cb-4fc8-8155-607091c279ea.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "b122f8b3-44cb-4fc8-8155-607091c279ea",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "7d07d617-9a52-49a9-9f5c-5cb75a525c4d"
+      }
+    }
+  ],
+  "image_format": ".st",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/alignment/TS_016.mrc/TS_016.mrc.st"
+  ],
+  "total_size_in_bytes": 27,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "7d07d617-9a52-49a9-9f5c-5cb75a525c4d"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/c38b6910-7cab-4431-a425-f06503b56972.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/c38b6910-7cab-4431-a425-f06503b56972.json
@@ -1,0 +1,34 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "c38b6910-7cab-4431-a425-f06503b56972",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "c0327a9a-6590-421d-b551-015581cbfe37"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_010_48_001_12.tif",
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_010_48_002_17.tif"
+  ],
+  "total_size_in_bytes": 34,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "c0327a9a-6590-421d-b551-015581cbfe37"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/ebe55d52-0293-426d-9e8f-ec6a28181ce4.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/ebe55d52-0293-426d-9e8f-ec6a28181ce4.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "ebe55d52-0293-426d-9e8f-ec6a28181ce4",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "11e8fd9c-0470-4a91-943d-1ead59865141"
+      }
+    }
+  ],
+  "image_format": ".st",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/211206/alignment/TS_019.mrc/TS_019.mrc.st"
+  ],
+  "total_size_in_bytes": 27,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "11e8fd9c-0470-4a91-943d-1ead59865141"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/f5f507be-3111-451d-a1c2-927d1a76ce7f.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/f5f507be-3111-451d-a1c2-927d1a76ce7f.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "f5f507be-3111-451d-a1c2-927d1a76ce7f",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "88928f62-5799-498c-83fc-9b8922c046ea"
+      }
+    }
+  ],
+  "image_format": ".st",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/alignment/TS_008.mrc/TS_008.mrc.st"
+  ],
+  "total_size_in_bytes": 27,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "88928f62-5799-498c-83fc-9b8922c046ea"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/f73fb17d-2c5a-4158-a0f8-82ce738022cf.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/EMPIAR-STARFILETEST/f73fb17d-2c5a-4158-a0f8-82ce738022cf.json
@@ -1,0 +1,34 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "f73fb17d-2c5a-4158-a0f8-82ce738022cf",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "dbc5b328-21a4-478a-a6f9-01c53a90c61b"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_008_42_001_12.tif",
+    "https://ftp.ebi.ac.uk/empiar/world_availability/STARFILETEST/data/220330/data/frames/TS_008_42_002_17.tif"
+  ],
+  "total_size_in_bytes": 34,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "dbc5b328-21a4-478a-a6f9-01c53a90c61b"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/06a71343-38fd-4c6a-8480-1fc687489f37.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/06a71343-38fd-4c6a-8480-1fc687489f37.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "06a71343-38fd-4c6a-8480-1fc687489f37",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "1cd331dc-3fd9-4d32-be9a-f8f5fe5a6c63"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "1cd331dc-3fd9-4d32-be9a-f8f5fe5a6c63"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/0d0883e8-dc53-4f28-9486-83c550b5a6fc.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/0d0883e8-dc53-4f28-9486-83c550b5a6fc.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "0d0883e8-dc53-4f28-9486-83c550b5a6fc",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "23bd5f01-95d3-430d-9505-d8ea2d33f970"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "23bd5f01-95d3-430d-9505-d8ea2d33f970"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/0f9cc303-9da7-4ad5-ab85-40e6960043f8.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/0f9cc303-9da7-4ad5-ab85-40e6960043f8.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "0f9cc303-9da7-4ad5-ab85-40e6960043f8",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "0d6ac7e4-37b9-4bc5-a11f-f2adf6462cf1"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "0d6ac7e4-37b9-4bc5-a11f-f2adf6462cf1"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/1a1dc8bb-b865-49f3-a6dc-de457e9f70f7.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/1a1dc8bb-b865-49f3-a6dc-de457e9f70f7.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "1a1dc8bb-b865-49f3-a6dc-de457e9f70f7",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "089dad76-7b4f-4b61-96ef-830e660d437b"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "089dad76-7b4f-4b61-96ef-830e660d437b"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/26042e87-d39c-4eca-a76b-d5efa05ed509.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/26042e87-d39c-4eca-a76b-d5efa05ed509.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "26042e87-d39c-4eca-a76b-d5efa05ed509",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "6da79457-f871-48bc-bfa1-cbd1e7f846e5"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "6da79457-f871-48bc-bfa1-cbd1e7f846e5"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/2ea77480-0af1-4115-8b40-280e1ac01a69.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/2ea77480-0af1-4115-8b40-280e1ac01a69.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "2ea77480-0af1-4115-8b40-280e1ac01a69",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "81f10e1a-5e49-4ad4-8cac-fa3ccd756033"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "81f10e1a-5e49-4ad4-8cac-fa3ccd756033"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/31fc5939-f548-49c1-94c5-6a32fcc34e8f.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/31fc5939-f548-49c1-94c5-6a32fcc34e8f.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "31fc5939-f548-49c1-94c5-6a32fcc34e8f",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "bbb632e5-33f7-4b43-a9f8-751cbc1cb6e4"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "bbb632e5-33f7-4b43-a9f8-751cbc1cb6e4"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/3821e744-5219-48b1-bde5-6cae786f3a37.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/3821e744-5219-48b1-bde5-6cae786f3a37.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "3821e744-5219-48b1-bde5-6cae786f3a37",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "4abd0a5b-ae65-43c2-a354-c6f1e90a6a95"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "4abd0a5b-ae65-43c2-a354-c6f1e90a6a95"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/40a4081c-0e11-408c-90cf-4616673bfd69.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/40a4081c-0e11-408c-90cf-4616673bfd69.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "40a4081c-0e11-408c-90cf-4616673bfd69",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "e3c57cb1-7f5b-4b96-99c0-4666d94e9a50"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "e3c57cb1-7f5b-4b96-99c0-4666d94e9a50"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/438a28ea-5bc8-4098-93ed-01954d69b1bb.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/438a28ea-5bc8-4098-93ed-01954d69b1bb.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "438a28ea-5bc8-4098-93ed-01954d69b1bb",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "876bdbec-c95f-4c6f-9f29-50085e5ea2f1"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "876bdbec-c95f-4c6f-9f29-50085e5ea2f1"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/4514d0db-99fb-4538-9291-e17af80c4d18.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/4514d0db-99fb-4538-9291-e17af80c4d18.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "4514d0db-99fb-4538-9291-e17af80c4d18",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "2d6f2b53-575c-4fde-b550-f6afceb343f6"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "2d6f2b53-575c-4fde-b550-f6afceb343f6"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/4bd59610-502c-4d26-ad36-bbf533158e43.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/4bd59610-502c-4d26-ad36-bbf533158e43.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "4bd59610-502c-4d26-ad36-bbf533158e43",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "e350b71d-390e-46ac-bb11-f06019a10a04"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "e350b71d-390e-46ac-bb11-f06019a10a04"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/54f07d3a-b5ec-4619-b30d-abe4d119e7e3.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/54f07d3a-b5ec-4619-b30d-abe4d119e7e3.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "54f07d3a-b5ec-4619-b30d-abe4d119e7e3",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "1f7338f1-3ee9-4a0c-a29c-b15c90d9da1d"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "1f7338f1-3ee9-4a0c-a29c-b15c90d9da1d"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/5508f2d4-51e1-4152-87cb-7b3abf7f1900.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/5508f2d4-51e1-4152-87cb-7b3abf7f1900.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "5508f2d4-51e1-4152-87cb-7b3abf7f1900",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "d31a6ef1-76eb-4f7a-a59b-8d74e53de56a"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "d31a6ef1-76eb-4f7a-a59b-8d74e53de56a"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/63c9d7cb-113e-432f-ac08-b7acf904bb03.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/63c9d7cb-113e-432f-ac08-b7acf904bb03.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "63c9d7cb-113e-432f-ac08-b7acf904bb03",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "7fd9ecf1-0732-4dcb-b9fe-a06c89063b29"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "7fd9ecf1-0732-4dcb-b9fe-a06c89063b29"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/6774acc2-7668-4d6d-a508-5d414720a08e.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/6774acc2-7668-4d6d-a508-5d414720a08e.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "6774acc2-7668-4d6d-a508-5d414720a08e",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "6957f6b6-ee8d-4e80-aaf3-f977bea9b923"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "6957f6b6-ee8d-4e80-aaf3-f977bea9b923"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/68fc18c9-97d3-4a72-80a2-e9e505ff381d.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/68fc18c9-97d3-4a72-80a2-e9e505ff381d.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "68fc18c9-97d3-4a72-80a2-e9e505ff381d",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "2080d41b-aa14-4083-91e9-928ea7298f74"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "2080d41b-aa14-4083-91e9-928ea7298f74"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/6d5ced40-5627-4817-8735-ad56ca103886.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/6d5ced40-5627-4817-8735-ad56ca103886.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "6d5ced40-5627-4817-8735-ad56ca103886",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "67adb4f1-6978-48eb-8fda-75526dab2547"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "67adb4f1-6978-48eb-8fda-75526dab2547"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/719eb866-54b6-4e15-86d9-0f45bbbcc79a.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/719eb866-54b6-4e15-86d9-0f45bbbcc79a.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "719eb866-54b6-4e15-86d9-0f45bbbcc79a",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "f4530f44-fc8f-43f1-a6e6-87a46be5550c"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "f4530f44-fc8f-43f1-a6e6-87a46be5550c"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/7495746b-9d94-47d6-ba2e-96c36599a0b1.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/7495746b-9d94-47d6-ba2e-96c36599a0b1.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "7495746b-9d94-47d6-ba2e-96c36599a0b1",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "0c0d9c10-a319-48ac-bde1-be2b5473451d"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "0c0d9c10-a319-48ac-bde1-be2b5473451d"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/85bdf3be-f4bc-4627-8a40-3bca2521cc59.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/85bdf3be-f4bc-4627-8a40-3bca2521cc59.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "85bdf3be-f4bc-4627-8a40-3bca2521cc59",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "00df1365-9962-468d-9c61-d4cbf4c2be03"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "00df1365-9962-468d-9c61-d4cbf4c2be03"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/93155f1a-8183-4b39-ac70-09008fa700ca.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/93155f1a-8183-4b39-ac70-09008fa700ca.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "93155f1a-8183-4b39-ac70-09008fa700ca",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "d8cec1e5-3654-4422-a0ff-cb5d0ca05c3c"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "d8cec1e5-3654-4422-a0ff-cb5d0ca05c3c"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/94f73aa9-dab5-495b-adc5-de3df0338f48.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/94f73aa9-dab5-495b-adc5-de3df0338f48.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "94f73aa9-dab5-495b-adc5-de3df0338f48",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "c491389a-507b-41b7-a016-96f606c4185d"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "c491389a-507b-41b7-a016-96f606c4185d"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/9979ff3d-7027-479e-bcba-6b28394f1598.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/9979ff3d-7027-479e-bcba-6b28394f1598.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "9979ff3d-7027-479e-bcba-6b28394f1598",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "b98fb9c1-ab5f-4aee-8dbe-0e15383b5e99"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "b98fb9c1-ab5f-4aee-8dbe-0e15383b5e99"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/9ad27794-aee5-47e6-98b9-2a633889b65e.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/9ad27794-aee5-47e6-98b9-2a633889b65e.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "9ad27794-aee5-47e6-98b9-2a633889b65e",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "2992e3c9-300e-47d5-a8d6-c257f1af9c18"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "2992e3c9-300e-47d5-a8d6-c257f1af9c18"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b2d78f4d-0ec4-40d3-9b32-04c9df5e3b59.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b2d78f4d-0ec4-40d3-9b32-04c9df5e3b59.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "b2d78f4d-0ec4-40d3-9b32-04c9df5e3b59",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "c94d3f0e-9a2e-4d2f-bdd3-a18f2257a325"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "c94d3f0e-9a2e-4d2f-bdd3-a18f2257a325"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b2e7edea-8c34-4061-9ccb-371f13d77c13.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b2e7edea-8c34-4061-9ccb-371f13d77c13.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "b2e7edea-8c34-4061-9ccb-371f13d77c13",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "68d2c80f-5032-45a0-806e-62573a0f9313"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "68d2c80f-5032-45a0-806e-62573a0f9313"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b607d8bb-9a2f-4a7a-aeac-652b1e15acd6.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b607d8bb-9a2f-4a7a-aeac-652b1e15acd6.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "b607d8bb-9a2f-4a7a-aeac-652b1e15acd6",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "9dbf66da-3c9e-495e-bd02-cbf95dcdd4db"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "9dbf66da-3c9e-495e-bd02-cbf95dcdd4db"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b6ab5f0a-1642-49c9-8d08-a6514c3b784d.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/b6ab5f0a-1642-49c9-8d08-a6514c3b784d.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "b6ab5f0a-1642-49c9-8d08-a6514c3b784d",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "41e5ab21-851d-4cef-b694-409ea26fb43a"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "41e5ab21-851d-4cef-b694-409ea26fb43a"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/c2db2f0e-0dc1-4840-88b8-b2fc503de440.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/c2db2f0e-0dc1-4840-88b8-b2fc503de440.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "c2db2f0e-0dc1-4840-88b8-b2fc503de440",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "f0abcd8f-4042-462c-a303-aa4ba1220d1d"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "f0abcd8f-4042-462c-a303-aa4ba1220d1d"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/d098b1f2-573d-43c3-924e-9157a26afee0.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/d098b1f2-573d-43c3-924e-9157a26afee0.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "d098b1f2-573d-43c3-924e-9157a26afee0",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "0039de1e-0c4a-4d7a-9b7a-6369083a4fb8"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "0039de1e-0c4a-4d7a-9b7a-6369083a4fb8"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/e958c70b-f224-4a02-95b4-cea1ad7d5429.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/e958c70b-f224-4a02-95b4-cea1ad7d5429.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "e958c70b-f224-4a02-95b4-cea1ad7d5429",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "e0ad1d6d-e9fa-4a26-8b2d-9ca4f8865675"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "e0ad1d6d-e9fa-4a26-8b2d-9ca4f8865675"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f044ccff-84c9-4c8f-90d9-4b254c853c2d.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f044ccff-84c9-4c8f-90d9-4b254c853c2d.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "f044ccff-84c9-4c8f-90d9-4b254c853c2d",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "d6bb25eb-49d8-4126-9399-f246b95d0082"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "d6bb25eb-49d8-4126-9399-f246b95d0082"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f1854ea2-5edf-49b1-962a-f397935a72b3.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f1854ea2-5edf-49b1-962a-f397935a72b3.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "f1854ea2-5edf-49b1-962a-f397935a72b3",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "ffcd0337-ef24-4d1a-b521-b75f5b211b96"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "ffcd0337-ef24-4d1a-b521-b75f5b211b96"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f375d2ad-45f9-4394-a1ac-0cde925b5903.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f375d2ad-45f9-4394-a1ac-0cde925b5903.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "f375d2ad-45f9-4394-a1ac-0cde925b5903",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "b34960e8-e69b-43e0-96cf-990e5195cf8a"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "b34960e8-e69b-43e0-96cf-990e5195cf8a"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f416af2d-b0b3-41a9-b43a-99dbd6c3df86.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD1494/f416af2d-b0b3-41a9-b43a-99dbd6c3df86.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "f416af2d-b0b3-41a9-b43a-99dbd6c3df86",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "4e871f31-b7d1-407a-ab43-30d5d12b72ab"
+      }
+    }
+  ],
+  "image_format": ".tif",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 41,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "4e871f31-b7d1-407a-ab43-30d5d12b72ab"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/16a3795a-c3c1-4e0b-9146-ba194253596b.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/16a3795a-c3c1-4e0b-9146-ba194253596b.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "16a3795a-c3c1-4e0b-9146-ba194253596b",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "9c81c870-4871-4dea-8c8d-32b4a8185198"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 8770186,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "9c81c870-4871-4dea-8c8d-32b4a8185198"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/1c61f954-3c4e-44c9-a747-7d3d0dbc538d.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/1c61f954-3c4e-44c9-a747-7d3d0dbc538d.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "1c61f954-3c4e-44c9-a747-7d3d0dbc538d",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "bdfcbce0-21ec-4671-9215-6220268a81de"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 13161534,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "bdfcbce0-21ec-4671-9215-6220268a81de"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/1cda6280-de62-41cc-98c5-70259b4cf62c.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/1cda6280-de62-41cc-98c5-70259b4cf62c.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "1cda6280-de62-41cc-98c5-70259b4cf62c",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "84a17ccc-e22c-4bc5-bdfd-4c8267e7de8a"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 24628037,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "84a17ccc-e22c-4bc5-bdfd-4c8267e7de8a"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/4687b102-bb38-4268-8f51-a717bbbd2094.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/4687b102-bb38-4268-8f51-a717bbbd2094.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "4687b102-bb38-4268-8f51-a717bbbd2094",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "0cd034b1-0816-4f14-83a2-8e1b8bbb28cb"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 958385,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "0cd034b1-0816-4f14-83a2-8e1b8bbb28cb"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/73d1c9a8-6921-4fa1-b2c0-ea76ad74aec2.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/73d1c9a8-6921-4fa1-b2c0-ea76ad74aec2.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "73d1c9a8-6921-4fa1-b2c0-ea76ad74aec2",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "5293ec4b-4a16-4a52-b1d4-328fc8c6538b"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 1728680,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "5293ec4b-4a16-4a52-b1d4-328fc8c6538b"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/a2389386-b7cc-4454-bab9-16c67e4950ed.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/a2389386-b7cc-4454-bab9-16c67e4950ed.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "a2389386-b7cc-4454-bab9-16c67e4950ed",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "74b4e347-7fc4-4b19-ad2e-c41dc2ad808e"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 2959273,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "74b4e347-7fc4-4b19-ad2e-c41dc2ad808e"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/cf1614c8-1fd9-424c-b0d4-12c1df5c6abe.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/cf1614c8-1fd9-424c-b0d4-12c1df5c6abe.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "cf1614c8-1fd9-424c-b0d4-12c1df5c6abe",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "283b0bf0-33d0-4293-8dc1-6e112a3c9dea"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 1056777,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "283b0bf0-33d0-4293-8dc1-6e112a3c9dea"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/fe461334-2c60-480b-9601-871bdb2f756e.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIAD843/fe461334-2c60-480b-9601-871bdb2f756e.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "fe461334-2c60-480b-9601-871bdb2f756e",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "6992c787-7d38-4292-a446-c5a1bb0ea2cf"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 7933589,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "6992c787-7d38-4292-a446-c5a1bb0ea2cf"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/2ca29e9d-b39a-4ace-8e93-cf27f3b32f0f.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/2ca29e9d-b39a-4ace-8e93-cf27f3b32f0f.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "2ca29e9d-b39a-4ace-8e93-cf27f3b32f0f",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "12584e28-9f98-4b8f-ac16-45141209f296"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 8770186,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "12584e28-9f98-4b8f-ac16-45141209f296"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/4bb8daa6-452d-4bc8-994f-b65dd216c32a.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/4bb8daa6-452d-4bc8-994f-b65dd216c32a.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "4bb8daa6-452d-4bc8-994f-b65dd216c32a",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "11c32e5b-437a-496a-895d-8b496096aa1e"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 7933589,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "11c32e5b-437a-496a-895d-8b496096aa1e"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/5124232a-40d6-4856-adb7-45156faf102b.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/5124232a-40d6-4856-adb7-45156faf102b.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "5124232a-40d6-4856-adb7-45156faf102b",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "c76ab251-6ef7-4037-82ac-cd692b39eea6"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 1056777,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "c76ab251-6ef7-4037-82ac-cd692b39eea6"
+}

--- a/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/aa4bd974-40a9-4070-b09f-2154ac247608.json
+++ b/ro-crate-ingest/test/ro_crate_to_bia/output_data/image_representation/S-BIADWITHFILELIST/aa4bd974-40a9-4070-b09f-2154ac247608.json
@@ -1,0 +1,33 @@
+{
+  "object_creator": "bia_ingest",
+  "uuid": "aa4bd974-40a9-4070-b09f-2154ac247608",
+  "version": 0,
+  "model": {
+    "type_name": "ImageRepresentation",
+    "version": 4
+  },
+  "additional_metadata": [
+    {
+      "provenance": "bia_ingest",
+      "name": "uuid_unique_input",
+      "value": {
+        "uuid_unique_input": "1164f334-9d2c-4815-a810-0a5ee8018234"
+      }
+    }
+  ],
+  "image_format": ".zip",
+  "file_uri": [
+    "None?"
+  ],
+  "total_size_in_bytes": 958385,
+  "voxel_physical_size_x": null,
+  "voxel_physical_size_y": null,
+  "voxel_physical_size_z": null,
+  "size_x": null,
+  "size_y": null,
+  "size_z": null,
+  "size_c": null,
+  "size_t": null,
+  "image_viewer_setting": [],
+  "representation_of_uuid": "1164f334-9d2c-4815-a810-0a5ee8018234"
+}


### PR DESCRIPTION
As part of: https://app.clickup.com/t/869aevx29 identified a couple of issues with ro-crate ingest:

1. Was not creating image representations for images - the various values required to create one now get pass through the dataframe, and the ids for them get created during dependency id creation. The image representations get created after each image (following api dependency ordering)
2. Was creating file ref uris for empiar submissions with data/data/
3. Fixed a couple of incorrect type references/typos/unused function variables.
4. Removed labels from Annotation data as it's not a field - i suspect we might want to update the models to cover this so i have left the logic commented out with a todo