### PR TITLE
fixed version of bcyrpt to 4.3 to avoid issue with passlib

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,6 +15,7 @@ requests = "^2.29.0"
 uvicorn = "^0.22.0"
 httpx = "^0.24.0"
 python-dotenv = "^1.0.0"
+bcrypt = "^4.3.0"
 passlib = {extras = ["bcrypt"], version = "^1.7.4"}
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 python-multipart = "^0.0.6"


### PR DESCRIPTION
Setting bcrypt version to 4.3 to avoid compatibility issues between passlib and bcrypt that causes api user creation to fail.