### PR TITLE
Fix minor bug in name of annotation method in dataset.py 

### DIFF
--- a/ro-crate-ingest/override_data/biostudies/S-BIADTEST_ANNOTATION_METHOD/S-BIADTEST_ANNOTATION_METHOD_override.json
+++ b/ro-crate-ingest/override_data/biostudies/S-BIADTEST_ANNOTATION_METHOD/S-BIADTEST_ANNOTATION_METHOD_override.json
@@ -1,0 +1,254 @@
+{
+  "accno": "S-BIADTEST_ANNOTATION_METHOD",
+  "attributes": [
+    {
+      "name": "Title",
+      "value": "BIADTEST ANNOTATION METHOD TEST"
+    },
+    {
+      "name": "ReleaseDate",
+      "value": "2023-08-14"
+    },
+    {
+      "name": "AttachTo",
+      "value": "BioImages"
+    }
+  ],
+  "section": {
+    "type": "Study",
+    "attributes": [
+      {
+        "name": "Description",
+        "value": "Description 1"
+      },
+      {
+        "name": "Keyword",
+        "value": "Keyword1"
+      },
+      {
+        "name": "Keyword",
+        "value": "Keyword2"
+      },
+      {
+        "name": "Keyword",
+        "value": "Keyword3"
+      }
+    ],
+    "links": [
+      {
+        "url": "https://www.ebi.ac.uk/bioimage-archive/",
+        "attributes": [
+          {
+            "name": "Description",
+            "value": "BIA website"
+          }
+        ]
+      },
+      {
+        "url": "https://www.ebi.ac.uk/bioimage-archive/galleries/galleries.html",
+        "attributes": [
+          {
+            "name": "Description",
+            "value": "Pretty pictures"
+          }
+        ]
+      }
+    ],
+    "subsections": [
+      {
+        "type": "author",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "User with affiliaition and orcid"
+          },
+          {
+            "name": "E-mail",
+            "value": "user1@ebi.ac.uk"
+          },
+          {
+            "name": "Role",
+            "value": "data acquisition, data curator"
+          },
+          {
+            "name": "ORCID",
+            "value": "0009-0007-4223-1439"
+          },
+          {
+            "name": "affiliation",
+            "value": "o1",
+            "reference": true
+          }
+        ]
+      },
+      {
+        "accno": "o1",
+        "type": "organization",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "Organization with no rorid"
+          },
+          {
+            "name": "Address",
+            "value": "Hinxton, UK"
+          }
+        ]
+      },
+      {
+        "accno": "Biosample-1",
+        "type": "Biosample",
+        "attributes": [
+          {
+            "name": "Title",
+            "value": "Biosample 1 Title"
+          },
+          {
+            "name": "Biological entity",
+            "value": "Specific part of fly."
+          },
+          {
+            "name": "Description",
+            "value": "Description of how it was obtained etc."
+          }
+        ],
+        "subsections": [
+          {
+            "accno": "Organism-1",
+            "type": "Organism",
+            "attributes": [
+              {
+                "name": "Scientific name",
+                "value": "Drosophila melanogaster"
+              },
+              {
+                "name": "Common name",
+                "value": "fruit fly"
+              },
+              {
+                "name": "NCBI taxon ID",
+                "value": "NCBI:txid7227"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "accno": "Specimen-1",
+        "type": "Specimen",
+        "attributes": [
+          {
+            "name": "Title",
+            "value": "Specimen 1 Title"
+          },
+          {
+            "name": "Sample Preparation Protocol",
+            "value": "Followed step 1, 2 and 3"
+          }
+        ]
+      },
+      {
+        "accno": "Image Acquisition-1",
+        "type": "Image Acquisition",
+        "attributes": [
+          {
+            "name": "Title",
+            "value": "Image Acquisition 1 Title"
+          },
+          {
+            "name": "Imaging Instrument",
+            "value": "Microscope and/or telescope (but looking the other way)."
+          },
+          {
+            "name": "Image Acquisition Parameters",
+            "value": "Voxel size 0.0430x0.0430x0.5002 micron^3"
+          }
+        ],
+        "subsections": [
+          {
+            "accno": "Imaging Method-1",
+            "type": "Imaging Method",
+            "attributes": [
+              {
+                "name": "Ontology Value",
+                "value": "Confocal microscopy"
+              },
+              {
+                "name": "Ontology Name",
+                "value": "Biological Imaging Methods Ontology (FBbi)"
+              },
+              {
+                "name": "Ontology Term ID",
+                "value": "http://purl.obolibrary.org/obo/FBbi_00000251"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "accno": "Study Component-1",
+        "type": "Study Component",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "Confocal fluorescence images"
+          },
+          {
+            "name": "Description",
+            "value": "Study component description 1"
+          },
+          {
+            "name": "File List",
+            "value": "file_list_test_1.json"
+          }
+        ],
+        "subsections": [
+          {
+            "type": "Associations",
+            "attributes": [
+              {
+                "name": "Biosample",
+                "value": "Biosample 1 Title"
+              },
+              {
+                "name": "Specimen",
+                "value": "Specimen 1 Title"
+              },
+              {
+                "name": "Image acquisition",
+                "value": "Image Acquisition 1 Title"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "accno": "Annotation-1",
+        "type": "Annotations",
+        "attributes": [
+          {
+            "name": "Title",
+            "value": "Instance-level mitochondria annotations for volume EM"
+          },
+          {
+            "name": "Annotation Overview",
+            "value": "This is a general description of the annotation dataset was annotated."
+          },
+          {
+            "name": "Annotation Type",
+            "value": "segmentation_mask"
+          },
+          {
+            "name": "Annotation Method",
+            "value": "This is a description that is specific to the details of how the images in this Annotation Dataset were annotated."
+          },
+          {
+            "name": "File List",
+            "value": "annotation_file_list.json"
+          }
+        ]
+      }
+    ]
+  },
+  "type": "submission"
+}

--- a/ro-crate-ingest/override_data/biostudies/S-BIADTEST_ANNOTATION_METHOD/annotation_file_list.json
+++ b/ro-crate-ingest/override_data/biostudies/S-BIADTEST_ANNOTATION_METHOD/annotation_file_list.json
@@ -1,0 +1,40 @@
+[
+  {
+    "path": "folder1/annotation/file1.ome.zarr.zip",
+    "size": 24628037,
+    "attributes": [
+      {
+        "name": "Genotype/Line",
+        "value": "; ubiCAAX-GFP/+ ; neuPH-RFP/+"
+      },
+      {
+        "name": "Channel 1",
+        "value": "CAAX"
+      },
+      {
+        "name": "sourceImage",
+        "value": "folder1/file1.ome.zarr.zip"
+      }
+    ],
+    "type": "file"
+  },
+  {
+    "path": "folder1/annotation/file2.ome.zarr.zip",
+    "size": 13161534,
+    "attributes": [
+      {
+        "name": "Genotype/Line",
+        "value": "; ubiCAAX-GFP/+ ; neuPH-RFP/+"
+      },
+      {
+        "name": "Channel 1",
+        "value": "CAAX"
+      },
+      {
+        "name": "sourceImage",
+        "value": "folder1/file2.ome.zarr.zip"
+      }
+    ],
+    "type": "file"
+  }
+]

--- a/ro-crate-ingest/override_data/biostudies/S-BIADTEST_ANNOTATION_METHOD/file_list_test_1.json
+++ b/ro-crate-ingest/override_data/biostudies/S-BIADTEST_ANNOTATION_METHOD/file_list_test_1.json
@@ -1,0 +1,32 @@
+[
+  {
+    "path": "folder1/file1.ome.zarr.zip",
+    "size": 24628037,
+    "attributes": [
+      {
+        "name": "Genotype/Line",
+        "value": "; ubiCAAX-GFP/+ ; neuPH-RFP/+"
+      },
+      {
+        "name": "Channel 1",
+        "value": "CAAX"
+      }
+    ],
+    "type": "file"
+  },
+  {
+    "path": "folder1/file2.ome.zarr.zip",
+    "size": 13161534,
+    "attributes": [
+      {
+        "name": "Genotype/Line",
+        "value": "; ubiCAAX-GFP/+ ; neuPH-RFP/+"
+      },
+      {
+        "name": "Channel 1",
+        "value": "CAAX"
+      }
+    ],
+    "type": "file"
+  }
+]

--- a/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/filelist_api.py
+++ b/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/filelist_api.py
@@ -38,6 +38,7 @@ def load_filelist(accession_id: str, flist_fname: str):
     # Note, this is not necessarily the same override list as the load_submission in submission_api.py
     overrides = {
         "S-BIADTEST_AUTHOR_AFFILIATION": "A test submission that covers different author and affiliations options.",
+        "S-BIADTEST_ANNOTATION_METHOD": "A test submission that includes an annotation method.",
         "S-BIADTEST_COMPLEX_BIOSAMPLE": "A test submission that covers different biosample, taxon, and REMBI study component associations.",
         "S-BIADTEST_PROTOCOL_STUDY": "A test submission based on S-BIAD34 that covers the early protocol style studies.",
         "S-BIADTEST_COMBINE_FILELIST": "A test submission to verify filelists are combined as expected",

--- a/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/submission_api.py
+++ b/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/biostudies/submission_api.py
@@ -148,6 +148,7 @@ def load_submission(accession_id: str) -> Submission:
     # Note this is a dictionary to include reasons why the override was made
     overrides = {
         "S-BIADTEST_AUTHOR_AFFILIATION": "A test submission that covers different author and affiliations options.",
+        "S-BIADTEST_ANNOTATION_METHOD": "A test submission that includes an annotation method.",
         "S-BIADTEST_COMPLEX_BIOSAMPLE": "A test submission that covers different biosample, taxon, and REMBI study component associations.",
         "S-BIADTEST_PROTOCOL_STUDY": "A test submission based on S-BIAD34 that covers the early protocol style studies.",
         "S-BIADTEST_COMBINE_FILELIST": "A test submission to verify filelists are combined as expected",

--- a/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/entity_conversion/dataset.py
+++ b/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/entity_conversion/dataset.py
@@ -93,7 +93,11 @@ def get_dataset_from_annotation_component(
         "name": attr_dict["title"],
         "description": attr_dict.get("annotation overview", None),
         "associatedAnnotationMethod": [
-            {"@id": association_map[ro_crate_models.AnnotationData][attr_dict["title"]]}
+            {
+                "@id": association_map[ro_crate_models.AnnotationMethod][
+                    attr_dict["title"]
+                ]
+            }
         ],
     }
     return ro_crate_models.Dataset(**model_dict)

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_ANNOTATION_METHOD/combined_file_list.tsv
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_ANNOTATION_METHOD/combined_file_list.tsv
@@ -1,0 +1,5 @@
+path	size	type	dataset	Genotype/Line	Channel 1	sourceImage
+folder1/file1.ome.zarr.zip	24628037	file	#Study%20Component-1	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX	
+folder1/file2.ome.zarr.zip	13161534	file	#Study%20Component-1	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX	
+folder1/annotation/file1.ome.zarr.zip	24628037	file	#Annotation-1	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX	folder1/file1.ome.zarr.zip
+folder1/annotation/file2.ome.zarr.zip	13161534	file	#Annotation-1	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX	folder1/file2.ome.zarr.zip

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_ANNOTATION_METHOD/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_ANNOTATION_METHOD/ro-crate-metadata.json
@@ -1,0 +1,532 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "accessionId": {
+                "@id": "schema:identifier"
+            },
+            "acknowledgement": {
+                "@id": "bia:acknowledgement"
+            },
+            "address": {
+                "@id": "schema:address"
+            },
+            "affiliation": {
+                "@id": "schema:memberOf"
+            },
+            "annotationCoverage": {
+                "@id": "bia:annotationCoverage"
+            },
+            "annotationCriteria": {
+                "@id": "bia:annotationCriteria"
+            },
+            "annotationMethod": {
+                "@id": "bia:annotationMethod"
+            },
+            "annotationSourceIndicator": {
+                "@id": "bia:annotationSourceIndicator"
+            },
+            "associatedAnnotationMethod": {
+                "@id": "bia:associatedAnnotationMethod"
+            },
+            "associatedBiologicalEntity": {
+                "@id": "bia:associatedBiologicalEntity"
+            },
+            "associatedCreationProcess": {
+                "@id": "bia:associatedCreationProcess"
+            },
+            "associatedImageAcquisitionProtocol": {
+                "@id": "bia:associatedImageAcquisitionProtocol"
+            },
+            "associatedImageAnalysisMethod": {
+                "@id": "bia:associatedAnalysisMethod"
+            },
+            "associatedImageCorrelationMethod": {
+                "@id": "bia:associatedCorrelationMethod"
+            },
+            "associatedProtocol": {
+                "@id": "bia:associatedProtocol"
+            },
+            "associatedSourceImage": {
+                "@id": "bia:associatedSourceImage"
+            },
+            "associatedSpecimen": {
+                "@id": "bia:associatedSubject"
+            },
+            "associatedSpecimenImagingPreparationProtocol": {
+                "@id": "bia:associatedImagingPreparationProtocol"
+            },
+            "authorNames": {
+                "@id": "bia:authorNames"
+            },
+            "bia": "http://bia/",
+            "biologicalEntity": {
+                "@id": "bia:sampleOf"
+            },
+            "biologicalEntityDescription": {
+                "@id": "bia:biologicalEntityDescription"
+            },
+            "channelBiologicalEntity": {
+                "@id": "bia:channelBiologicalEntity"
+            },
+            "channelContentDescription": {
+                "@id": "bia:channelContentDescription"
+            },
+            "channelLabel": {
+                "@id": "dc:identifier"
+            },
+            "column": {
+                "@id": "csvw:column"
+            },
+            "columnName": {
+                "@id": "csvw:name"
+            },
+            "commonName": {
+                "@id": "http://rs.tdwg.org/dwc/terms/vernacularName"
+            },
+            "contactEmail": {
+                "@id": "schema:email"
+            },
+            "contributor": {
+                "@id": "schema:author"
+            },
+            "csvw": "http://www.w3.org/ns/csvw#",
+            "datePublished": {
+                "@id": "schema:datePublished"
+            },
+            "dc": "http://purl.org/dc/terms/",
+            "description": {
+                "@id": "schema:description"
+            },
+            "displayName": {
+                "@id": "schema:name"
+            },
+            "experimentalVariableDescription": {
+                "@id": "bia:experimentalVariableDescription"
+            },
+            "extrinsicVariableDescription": {
+                "@id": "bia:extrinsicVariableDescription"
+            },
+            "fbbiId": {
+                "@id": "bia:fbbiId"
+            },
+            "featuresAnalysed": {
+                "@id": "bia:featuresAnalysed"
+            },
+            "fiducialsUsed": {
+                "@id": "bia:fiducialsUsed"
+            },
+            "growthProtocol": {
+                "@id": "bia:growthProtocol"
+            },
+            "hasPart": {
+                "@id": "schema:hasPart"
+            },
+            "imageAcquisitionProtocol": {
+                "@id": "bia:imageAcquisitionProtocol"
+            },
+            "imagingInstrumentDescription": {
+                "@id": "bia:imagingInstrumentDescription"
+            },
+            "imagingMethodName": {
+                "@id": "bia:imagingMethodName"
+            },
+            "imagingPreparationProtocol": {
+                "@id": "bia:imagingPreparationProtocol"
+            },
+            "inputImage": {
+                "@id": "bia:inputImage"
+            },
+            "intrinsicVariableDescription": {
+                "@id": "bia:intrinsicVariableDescription"
+            },
+            "keyword": {
+                "@id": "schema:keywords"
+            },
+            "label": {
+                "@id": "schema:name"
+            },
+            "license": {
+                "@id": "schema:license"
+            },
+            "link": {
+                "@id": "schema:url"
+            },
+            "linkDescription": {
+                "@id": "schema:description"
+            },
+            "methodType": {
+                "@id": "bia:annotationMethodType"
+            },
+            "name": {
+                "@id": "schema:name"
+            },
+            "organismClassification": {
+                "@id": "schema:taxonomicRange"
+            },
+            "propertyUrl": {
+                "@id": "csvw:propertyUrl"
+            },
+            "protocol": {
+                "@id": "bia:protocol"
+            },
+            "protocolDescription": {
+                "@id": "schema:description"
+            },
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "relatedPublication": {
+                "@id": "bia:relatedPublication"
+            },
+            "resultOf": {
+                "@id": "bia:resultOf"
+            },
+            "role": {
+                "@id": "bia:role"
+            },
+            "schema": "http://schema.org/",
+            "scientificName": {
+                "@id": "http://rs.tdwg.org/dwc/terms/scientificName"
+            },
+            "seeAlso": {
+                "@id": "rdfs:seeAlso"
+            },
+            "signalChannelInformation": {
+                "@id": "bia:signalChannelInformation"
+            },
+            "signalContrastMechanismDescription": {
+                "@id": "bia:signalContrastMechanismDescription"
+            },
+            "spatialInformation": {
+                "@id": "bia:spatialInformation"
+            },
+            "subject": {
+                "@id": "bia:subject"
+            },
+            "tableSchema": {
+                "@id": "csvw:tableSchema"
+            },
+            "title": {
+                "@id": "schema:name"
+            },
+            "transformationDescription": {
+                "@id": "bia:transformationDescription"
+            },
+            "transformationMatrix": {
+                "@id": "bia:transformationMatrix"
+            },
+            "website": {
+                "@id": "bia:website"
+            }
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": [
+                "Dataset",
+                "bia:Study"
+            ],
+            "name": "BIADTEST ANNOTATION METHOD TEST",
+            "contributor": [
+                {
+                    "@id": "https://orcid.org/0009-0007-4223-1439"
+                }
+            ],
+            "description": "Description 1",
+            "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "datePublished": "2023-08-14",
+            "keyword": [],
+            "acknowledgement": null,
+            "hasPart": [
+                {
+                    "@id": "#Study%20Component-1"
+                },
+                {
+                    "@id": "#Annotation-1"
+                },
+                {
+                    "@id": "combined_file_list.tsv"
+                }
+            ],
+            "accessionId": "S-BIADTEST_ANNOTATION_METHOD",
+            "seeAlso": [
+                {
+                    "@id": "https://www.ebi.ac.uk/bioimage-archive/"
+                },
+                {
+                    "@id": "https://www.ebi.ac.uk/bioimage-archive/galleries/galleries.html"
+                }
+            ],
+            "relatedPublication": []
+        },
+        {
+            "@id": "https://www.ebi.ac.uk/bioimage-archive/galleries/galleries.html",
+            "@type": "bia:ExternalReference",
+            "description": "Pretty pictures",
+            "additionalType": null
+        },
+        {
+            "@id": "https://www.ebi.ac.uk/bioimage-archive/",
+            "@type": "bia:ExternalReference",
+            "description": "BIA website",
+            "additionalType": null
+        },
+        {
+            "@id": "https://orcid.org/0009-0007-4223-1439",
+            "@type": [
+                "Person",
+                "bia:Contributor"
+            ],
+            "displayName": "User with affiliaition and orcid",
+            "address": null,
+            "website": null,
+            "affiliation": [
+                {
+                    "@id": "#o1"
+                }
+            ],
+            "role": [
+                "data acquisition",
+                "data curator"
+            ],
+            "contactEmail": "user1@ebi.ac.uk"
+        },
+        {
+            "@id": "#o1",
+            "@type": [
+                "Organisation",
+                "bia:Affiliation"
+            ],
+            "displayName": "Organization with no rorid",
+            "address": "Hinxton, UK",
+            "website": null
+        },
+        {
+            "@id": "combined_file_list.tsv",
+            "@type": [
+                "File",
+                "bia:FileList",
+                "csvw:Table"
+            ],
+            "tableSchema": {
+                "@id": "_:ts0"
+            }
+        },
+        {
+            "@id": "_:ts0",
+            "@type": [
+                "csvw:Schema"
+            ],
+            "column": [
+                {
+                    "@id": "_:col0"
+                },
+                {
+                    "@id": "_:col1"
+                },
+                {
+                    "@id": "_:col2"
+                },
+                {
+                    "@id": "_:col3"
+                },
+                {
+                    "@id": "_:col4"
+                },
+                {
+                    "@id": "_:col5"
+                },
+                {
+                    "@id": "_:col6"
+                }
+            ]
+        },
+        {
+            "@id": "_:col6",
+            "@type": [
+                "csvw:Column"
+            ],
+            "columnName": "sourceImage",
+            "propertyUrl": "http://bia/sourceImagePath"
+        },
+        {
+            "@id": "_:col5",
+            "@type": [
+                "csvw:Column"
+            ],
+            "columnName": "Channel 1",
+            "propertyUrl": null
+        },
+        {
+            "@id": "_:col4",
+            "@type": [
+                "csvw:Column"
+            ],
+            "columnName": "Genotype/Line",
+            "propertyUrl": null
+        },
+        {
+            "@id": "_:col3",
+            "@type": [
+                "csvw:Column"
+            ],
+            "columnName": "dataset",
+            "propertyUrl": "http://schema.org/isPartOf"
+        },
+        {
+            "@id": "_:col2",
+            "@type": [
+                "csvw:Column"
+            ],
+            "columnName": "type",
+            "propertyUrl": null
+        },
+        {
+            "@id": "_:col1",
+            "@type": [
+                "csvw:Column"
+            ],
+            "columnName": "size",
+            "propertyUrl": "http://bia/sizeInBytes"
+        },
+        {
+            "@id": "_:col0",
+            "@type": [
+                "csvw:Column"
+            ],
+            "columnName": "path",
+            "propertyUrl": "http://bia/filePath"
+        },
+        {
+            "@id": "#Study%20Component-1",
+            "@type": [
+                "Dataset",
+                "bia:Dataset"
+            ],
+            "name": "Confocal fluorescence images",
+            "description": "Study component description 1",
+            "associatedBiologicalEntity": [
+                {
+                    "@id": "#Biosample-1"
+                }
+            ],
+            "associatedSpecimenImagingPreparationProtocol": [
+                {
+                    "@id": "#Specimen-1"
+                }
+            ],
+            "associatedSpecimen": null,
+            "associatedCreationProcess": null,
+            "associatedSourceImage": [],
+            "associatedImageAcquisitionProtocol": [
+                {
+                    "@id": "#Image%20Acquisition-1"
+                }
+            ],
+            "associatedAnnotationMethod": [],
+            "associatedImageAnalysisMethod": [],
+            "associatedImageCorrelationMethod": [],
+            "associatedProtocol": [],
+            "hasPart": []
+        },
+        {
+            "@id": "#Annotation-1",
+            "@type": [
+                "Dataset",
+                "bia:Dataset"
+            ],
+            "name": "Instance-level mitochondria annotations for volume EM",
+            "description": "This is a general description of the annotation dataset was annotated.",
+            "associatedBiologicalEntity": [],
+            "associatedSpecimenImagingPreparationProtocol": [],
+            "associatedSpecimen": null,
+            "associatedCreationProcess": null,
+            "associatedSourceImage": [],
+            "associatedImageAcquisitionProtocol": [],
+            "associatedAnnotationMethod": [
+                {
+                    "@id": "#Annotation-1"
+                }
+            ],
+            "associatedImageAnalysisMethod": [],
+            "associatedImageCorrelationMethod": [],
+            "associatedProtocol": [],
+            "hasPart": []
+        },
+        {
+            "@id": "#Image%20Acquisition-1",
+            "@type": [
+                "bia:ImageAcquisitionProtocol"
+            ],
+            "title": "Image Acquisition 1 Title",
+            "protocolDescription": "Voxel size 0.0430x0.0430x0.5002 micron^3",
+            "imagingInstrumentDescription": "Microscope and/or telescope (but looking the other way).",
+            "imagingMethodName": [
+                "Confocal microscopy"
+            ],
+            "fbbiId": [
+                "http://purl.obolibrary.org/obo/FBbi_00000251"
+            ]
+        },
+        {
+            "@id": "#Annotation-1",
+            "@type": [
+                "bia:AnnotationMethod"
+            ],
+            "title": "Instance-level mitochondria annotations for volume EM",
+            "protocolDescription": "This is a description that is specific to the details of how the images in this Annotation Dataset were annotated.",
+            "annotationCriteria": null,
+            "annotationCoverage": null,
+            "transformationDescription": null,
+            "spatialInformation": null,
+            "methodType": [
+                "segmentation_mask"
+            ],
+            "annotationSourceIndicator": null
+        },
+        {
+            "@id": "#Specimen-1",
+            "@type": [
+                "bia:SpecimenImagingPreparationProtocol"
+            ],
+            "title": "Specimen 1 Title",
+            "protocolDescription": "Followed step 1, 2 and 3",
+            "signalChannelInformation": []
+        },
+        {
+            "@id": "NCBI:txid7227",
+            "@type": [
+                "bia:Taxon"
+            ],
+            "commonName": "fruit fly",
+            "scientificName": "Drosophila melanogaster"
+        },
+        {
+            "@id": "#Biosample-1",
+            "@type": [
+                "bia:BioSample"
+            ],
+            "title": "Biosample 1 Title",
+            "biologicalEntityDescription": "Specific part of fly.",
+            "experimentalVariableDescription": [],
+            "extrinsicVariableDescription": [],
+            "intrinsicVariableDescription": [],
+            "organismClassification": [
+                {
+                    "@id": "NCBI:txid7227"
+                }
+            ],
+            "growthProtocol": null
+        }
+    ]
+}

--- a/ro-crate-ingest/test/test_biostudies_to_ro_crate.py
+++ b/ro-crate-ingest/test/test_biostudies_to_ro_crate.py
@@ -42,6 +42,7 @@ def expected_path_to_created_path(expected_path: str, output_dir: Path) -> Path:
 @pytest.mark.parametrize(
     "accession_id",
     [
+        "S-BIADTEST_ANNOTATION_METHOD",
         "S-BIADTEST_AUTHOR_AFFILIATION",
         "S-BIADTEST_COMPLEX_BIOSAMPLE",
         "S-BIADTEST_PROTOCOL_STUDY",


### PR DESCRIPTION
Fixed minor bug in referring to annotation method in [PR 548](https://github.com/BioImage-Archive/bia-integrator/pull/548). The main issue is a one-line typo in `dataset.py`, but added tests for annotation method as it may be useful in future.