### PR TITLE
Processing of related publications from empiar to ro-crate and into API models

### DIFF
--- a/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/bia_ontology.ttl
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/bia_ontology.ttl
@@ -23,7 +23,7 @@ bia:Study a owl:Class ;
 
 bia:Publication a owl:Class ;
     rdfs:label "publication"@en ;
-    rdfs:subclassOf schema:CreativeWork ;
+    rdfs:subClassOf schema:CreativeWork ;
     rdfs:comment "A published paper or written work."@en .
 
 # Properties
@@ -54,16 +54,17 @@ bia:authorNames a owl:DatatypeProperty ;
     rdfs:domain bia:Publication ;
     rdfs:range xsd:string .
 
-bia:seeAlso a owl:ObjectProperty ;
-    rdfs:label "see also"@en ;
-    rdfs:comment "A link to an external resource alongside a description of the connection between the subject item and the link."@en ;
-    rdfs:range bia:ExternalReference .
+bia:publicationYear a owl:DatatypeProperty ;
+    rdfs:label "publication year"@en ;
+    rdfs:comment "The year in which the publication was first published."@en ;
+    rdfs:domain bia:Publication ;
+    rdfs:range xsd:integer .
 
-bia:relatedPublication a owl:ObjectProperty ;
-    rdfs:label "related publication"@en ;
-    rdfs:comment """A publication that is of some relevance to the subject."""@en ;
-    rdfs:subPropertyOf schema:citation ;
-    rdfs:range bia:Publication .
+bia:pubmedId a owl:DatatypeProperty ;
+    rdfs:label "pubmed id"@en ;
+    rdfs:comment "The identifier of the publication in the PubMed database."@en ;
+    rdfs:domain bia:Publication ;
+    rdfs:range xsd:string .
 
 bia:fundingStatement a owl:DatatypeProperty ;
     rdfs:label "funding statement"@en ;
@@ -79,6 +80,17 @@ bia:acknowledgement a owl:DatatypeProperty;
     rdfs:domain bia:Study ;
     rdfs:range rdf:langString .
 
+
+bia:seeAlso a owl:ObjectProperty ;
+    rdfs:label "see also"@en ;
+    rdfs:comment "A link to an external resource alongside a description of the connection between the subject item and the link."@en ;
+    rdfs:range bia:ExternalReference .
+
+bia:relatedPublication a owl:ObjectProperty ;
+    rdfs:label "related publication"@en ;
+    rdfs:comment """A publication that is of some relevance to the subject."""@en ;
+    rdfs:subPropertyOf schema:citation ;
+    rdfs:range bia:Publication .
 
 bia:exemplarImage a owl:ObjectProperty;
     rdfs:label "exemplar image"@en ;

--- a/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/bia_ro_crate_context.jsonld
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/bia_ro_crate_context.jsonld
@@ -99,6 +99,9 @@
     "displayName": {
       "@id": "schema:name"
     },
+    "doi": {
+      "@id": "schema:identifier"
+    },
     "experimentalVariableDescription": {
       "@id": "bia:experimentalVariableDescription"
     },
@@ -170,6 +173,12 @@
     },
     "protocolDescription": {
       "@id": "schema:description"
+    },
+    "publicationYear": {
+      "@id": "bia:publicationYear"
+    },
+    "pubmedId": {
+      "@id": "bia:pubmedId"
     },
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "relatedPublication": {

--- a/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/ontology_terms.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/linked_data/ontology_terms.py
@@ -129,6 +129,8 @@ class BIA(DefinedNamespace):
     inputImage: URIRef
     intrinsicVariableDescription: URIRef
     protocol: URIRef
+    publicationYear: URIRef
+    pubmedId: URIRef
     relatedPublication: URIRef
     resultOf: URIRef
     role: URIRef

--- a/bia-shared-datamodels/src/bia_shared_datamodels/ro_crate_models.py
+++ b/bia-shared-datamodels/src/bia_shared_datamodels/ro_crate_models.py
@@ -47,7 +47,10 @@ class Study(ROCrateModel):
     ] = Field()
     accessionId: Annotated[str, FieldContext(SCHEMA.identifier)] = Field()
     seeAlso: Annotated[list[ObjectReference], FieldContext(RDFS.seeAlso)] = Field(default_factory=list)
-    relatedPublication: Annotated[list[str], FieldContext(BIA.relatedPublication)] = Field(default_factory=list)
+    relatedPublication: Annotated[
+        list[ObjectReference],
+        FieldContext(BIA.relatedPublication, is_id_field=True),
+    ] = Field(default_factory=list)
 
     model_config = ConfigDict(model_type=BIA.Study)
 
@@ -60,8 +63,11 @@ class Study(ROCrateModel):
 
 
 class Publication(ROCrateModel):
-    title: Annotated[str, FieldContext(SCHEMA.name)] = Field()
-    authorNames: Annotated[str, FieldContext(BIA.authorNames)] = Field()
+    title: Annotated[Optional[str], FieldContext(SCHEMA.name)] = Field(default=None)
+    authorNames: Annotated[Optional[str], FieldContext(BIA.authorNames)] = Field(default=None)
+    publicationYear: Annotated[Optional[int], FieldContext(BIA.publicationYear)] = Field(default=None)
+    pubmedId: Annotated[Optional[str], FieldContext(BIA.pubmedId)] = Field(default=None)
+    doi: Annotated[Optional[str], FieldContext(SCHEMA.identifier)] = Field(default=None)
 
     model_config = ConfigDict(model_type=BIA.Publication)
 

--- a/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/empiar_proposal_conversion.py
+++ b/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/empiar_proposal_conversion.py
@@ -19,6 +19,7 @@ from ro_crate_ingest.empiar_to_ro_crate.entity_conversion import (
     study,
     file_list,
     protocol,
+    publication
 )
 import logging
 from ro_crate_ingest.empiar_to_ro_crate.empiar.proposal import Proposal
@@ -89,12 +90,15 @@ def convert_empiar_proposal_to_ro_crate(proposal_path: Path, crate_path: Path | 
     roc_contributors = contributor.get_contributors(empiar_api_entry)
     graph += roc_contributors
 
+    roc_publications = publication.get_publications(proposal)
+    graph += roc_publications
+
     roc_study = study.get_study(
         accession_id=accession_id,
         empiar_api_entry=empiar_api_entry,
         contributors=roc_contributors,
         datasets=roc_dataset_title_map.values(),
-        proposal=proposal, 
+        publications=roc_publications,
     )
     graph.append(roc_study)
 

--- a/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/publication.py
+++ b/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/publication.py
@@ -1,0 +1,52 @@
+import re
+from urllib.parse import quote
+
+from bia_shared_datamodels.ro_crate_models import Publication
+
+from ro_crate_ingest.empiar_to_ro_crate.empiar.proposal import Proposal
+
+DOI_PATTERN = re.compile(r'^10\.\d{4,}/')
+
+
+def get_publications(
+    proposal: Proposal
+) -> list[Publication]:
+    
+    publication_bnode_int = 0
+    publications = []
+    yaml_publication_dois = proposal.paper_doi
+    for publication_doi in yaml_publication_dois:
+        publication, publication_bnode_int = get_publication(
+            publication_doi, publication_bnode_int
+        )
+        publications.append(publication)
+    
+    return publications
+
+
+def get_publication(
+    publication_doi: str, publication_bnode_int: int
+) -> tuple[Publication, int]:
+
+    publication_id, publication_bnode_int = get_publication_id(
+        publication_doi, publication_bnode_int
+    )
+
+    model_dict = {
+        "@id": publication_id,
+        "@type": ["ScholarlyArticle", "bia:Publication"],
+        "doi": publication_doi.removeprefix("https://doi.org/"),
+    }
+
+    return Publication(**model_dict), publication_bnode_int
+
+
+def get_publication_id(
+    publication_doi: str, publication_bnode_int: int
+) -> tuple[str, int]:
+    
+    if publication_doi.startswith("https://doi.org/"):
+        publication_doi = publication_doi.removeprefix("https://doi.org/")
+    if not DOI_PATTERN.match(publication_doi):
+        raise ValueError(f"Expected a DOI, got: {publication_doi}")
+    return f"https://doi.org/{quote(publication_doi)}", publication_bnode_int

--- a/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/publication.py
+++ b/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/publication.py
@@ -9,15 +9,14 @@ DOI_PATTERN = re.compile(r'^10\.\d{4,}/')
 
 
 def get_publications(
-    proposal: Proposal
+    proposal: Proposal,
 ) -> list[Publication]:
     
-    publication_bnode_int = 0
     publications = []
     yaml_publication_dois = proposal.paper_doi
     for publication_doi in yaml_publication_dois:
-        publication, publication_bnode_int = get_publication(
-            publication_doi, publication_bnode_int
+        publication = get_publication(
+            publication_doi
         )
         publications.append(publication)
     
@@ -25,11 +24,11 @@ def get_publications(
 
 
 def get_publication(
-    publication_doi: str, publication_bnode_int: int
-) -> tuple[Publication, int]:
+    publication_doi: str,
+) -> Publication:
 
-    publication_id, publication_bnode_int = get_publication_id(
-        publication_doi, publication_bnode_int
+    publication_id = get_publication_id(
+        publication_doi,
     )
 
     model_dict = {
@@ -38,15 +37,16 @@ def get_publication(
         "doi": publication_doi.removeprefix("https://doi.org/"),
     }
 
-    return Publication(**model_dict), publication_bnode_int
+    return Publication(**model_dict)
 
 
 def get_publication_id(
-    publication_doi: str, publication_bnode_int: int
-) -> tuple[str, int]:
+    publication_doi: str,
+) -> str:
     
     if publication_doi.startswith("https://doi.org/"):
         publication_doi = publication_doi.removeprefix("https://doi.org/")
     if not DOI_PATTERN.match(publication_doi):
         raise ValueError(f"Expected a DOI, got: {publication_doi}")
-    return f"https://doi.org/{quote(publication_doi)}", publication_bnode_int
+    
+    return f"https://doi.org/{quote(publication_doi)}"

--- a/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/study.py
+++ b/ro-crate-ingest/ro_crate_ingest/empiar_to_ro_crate/entity_conversion/study.py
@@ -1,7 +1,6 @@
 from bia_shared_datamodels import ro_crate_models
 from collections.abc import Iterable
 from ro_crate_ingest.empiar_to_ro_crate.empiar.entry_api_models import Entry
-from ro_crate_ingest.empiar_to_ro_crate.empiar.proposal import Proposal
 
 
 def get_study(
@@ -9,7 +8,7 @@ def get_study(
     empiar_api_entry: Entry,
     contributors: list[ro_crate_models.Contributor],
     datasets: Iterable[ro_crate_models.Dataset], 
-    proposal: Proposal | None = None, 
+    publications: list[ro_crate_models.Publication],
 ) -> ro_crate_models.Study:
 
     has_part_items = [{"@id": "file_list.tsv"}] 
@@ -27,7 +26,7 @@ def get_study(
         "keyword": [],
         "contributor": [{"@id": c.id} for c in contributors],
         "hasPart": has_part_items, 
-        "relatedPublication": proposal.paper_doi if proposal else [],
+        "relatedPublication": [{"@id": p.id} for p in publications]
     }
 
     return ro_crate_models.Study(**study_dict)

--- a/ro-crate-ingest/ro_crate_ingest/minimal_ro_crate/minimal_ro_crate_creation.py
+++ b/ro-crate-ingest/ro_crate_ingest/minimal_ro_crate/minimal_ro_crate_creation.py
@@ -56,6 +56,7 @@ def make_minimal_ro_crate(
         empiar_api_entry=empiar_api_entry,
         contributors=roc_contributors,
         datasets=roc_dataset_title_map.values(),
+        publications=[],
     )
     graph.append(roc_study)
 

--- a/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/study.py
+++ b/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/study.py
@@ -43,6 +43,14 @@ def convert_study(
     external_references = []
     # TODO add logic and to models to handle external links
 
+    publications = []
+    for publication in ro_crate_study.relatedPublication:
+        publications.append(
+            convert_publication(
+                crate_objects_by_id[publication.id]
+            )
+        )
+
     study = {
         "accession_id": ro_crate_study.accessionId,
         "uuid": str(uuid_creation.create_study_uuid(ro_crate_study.accessionId)),
@@ -63,7 +71,7 @@ def convert_study(
                 value={"uuid_unique_input": ro_crate_study.accessionId},
             ).model_dump()
         ],
-        "related_publication": ro_crate_study.relatedPublication,
+        "related_publication": publications,
         "grant": [],
         "funding_statement": None,
     }
@@ -132,3 +140,18 @@ def convert_external_reference(
     }
 
     return APIModels.ExternalReference(**external_reference_dictionary)
+
+
+def convert_publication(
+    publication: ROCrateModels.Publication
+) -> APIModels.Publication:
+    
+    publication_dict = {
+        "title": publication.title, 
+        "authors_name": publication.authorNames, 
+        "publication_year": publication.publicationYear,
+        "pubmed_id": publication.pubmedId,
+        "doi": publication.doi,
+    }
+
+    return APIModels.Publication(**publication_dict)

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_ANNOTATION_METHOD/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_ANNOTATION_METHOD/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -408,6 +417,30 @@
             "propertyUrl": "http://bia/filePath"
         },
         {
+            "@id": "#Annotation-1",
+            "@type": [
+                "Dataset",
+                "bia:Dataset"
+            ],
+            "name": "Instance-level mitochondria annotations for volume EM",
+            "description": "This is a general description of the annotation dataset was annotated.",
+            "associatedBiologicalEntity": [],
+            "associatedSpecimenImagingPreparationProtocol": [],
+            "associatedSpecimen": null,
+            "associatedCreationProcess": null,
+            "associatedSourceImage": [],
+            "associatedImageAcquisitionProtocol": [],
+            "associatedAnnotationMethod": [
+                {
+                    "@id": "#Annotation-1"
+                }
+            ],
+            "associatedImageAnalysisMethod": [],
+            "associatedImageCorrelationMethod": [],
+            "associatedProtocol": [],
+            "hasPart": []
+        },
+        {
             "@id": "#Study%20Component-1",
             "@type": [
                 "Dataset",
@@ -434,30 +467,6 @@
                 }
             ],
             "associatedAnnotationMethod": [],
-            "associatedImageAnalysisMethod": [],
-            "associatedImageCorrelationMethod": [],
-            "associatedProtocol": [],
-            "hasPart": []
-        },
-        {
-            "@id": "#Annotation-1",
-            "@type": [
-                "Dataset",
-                "bia:Dataset"
-            ],
-            "name": "Instance-level mitochondria annotations for volume EM",
-            "description": "This is a general description of the annotation dataset was annotated.",
-            "associatedBiologicalEntity": [],
-            "associatedSpecimenImagingPreparationProtocol": [],
-            "associatedSpecimen": null,
-            "associatedCreationProcess": null,
-            "associatedSourceImage": [],
-            "associatedImageAcquisitionProtocol": [],
-            "associatedAnnotationMethod": [
-                {
-                    "@id": "#Annotation-1"
-                }
-            ],
             "associatedImageAnalysisMethod": [],
             "associatedImageCorrelationMethod": [],
             "associatedProtocol": [],
@@ -504,14 +513,6 @@
             "signalChannelInformation": []
         },
         {
-            "@id": "NCBI:txid7227",
-            "@type": [
-                "bia:Taxon"
-            ],
-            "commonName": "fruit fly",
-            "scientificName": "Drosophila melanogaster"
-        },
-        {
             "@id": "#Biosample-1",
             "@type": [
                 "bia:BioSample"
@@ -527,6 +528,14 @@
                 }
             ],
             "growthProtocol": null
+        },
+        {
+            "@id": "NCBI:txid7227",
+            "@type": [
+                "bia:Taxon"
+            ],
+            "commonName": "fruit fly",
+            "scientificName": "Drosophila melanogaster"
         }
     ]
 }

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_AUTHOR_AFFILIATION/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_AUTHOR_AFFILIATION/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -538,14 +547,6 @@
             "signalChannelInformation": []
         },
         {
-            "@id": "NCBI:txid7227",
-            "@type": [
-                "bia:Taxon"
-            ],
-            "commonName": "fruit fly",
-            "scientificName": "Drosophila melanogaster"
-        },
-        {
             "@id": "#Biosample-1",
             "@type": [
                 "bia:BioSample"
@@ -561,6 +562,14 @@
                 }
             ],
             "growthProtocol": null
+        },
+        {
+            "@id": "NCBI:txid7227",
+            "@type": [
+                "bia:Taxon"
+            ],
+            "commonName": "fruit fly",
+            "scientificName": "Drosophila melanogaster"
         }
     ]
 }

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMBINE_FILELIST/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMBINE_FILELIST/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -516,14 +525,6 @@
             "signalChannelInformation": []
         },
         {
-            "@id": "NCBI:txid7227",
-            "@type": [
-                "bia:Taxon"
-            ],
-            "commonName": "fruit fly",
-            "scientificName": "Drosophila melanogaster"
-        },
-        {
             "@id": "#Biosample-1%203af9100c-56dd-4419-9bde-f0c43157918f",
             "@type": [
                 "bia:BioSample"
@@ -558,6 +559,14 @@
                 }
             ],
             "growthProtocol": null
+        },
+        {
+            "@id": "NCBI:txid7227",
+            "@type": [
+                "bia:Taxon"
+            ],
+            "commonName": "fruit fly",
+            "scientificName": "Drosophila melanogaster"
         },
         {
             "@id": "#_Specimen-2",

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMPLEX_BIOSAMPLE/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMPLEX_BIOSAMPLE/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -535,30 +544,6 @@
             "signalChannelInformation": []
         },
         {
-            "@id": "#tx1",
-            "@type": [
-                "bia:Taxon"
-            ],
-            "commonName": "zebra fish",
-            "scientificName": "Danio  rerio"
-        },
-        {
-            "@id": "#tx0",
-            "@type": [
-                "bia:Taxon"
-            ],
-            "commonName": "Homo sapiens",
-            "scientificName": "Human"
-        },
-        {
-            "@id": "NCBI:txid7227",
-            "@type": [
-                "bia:Taxon"
-            ],
-            "commonName": "fruit fly",
-            "scientificName": "Drosophila melanogaster"
-        },
-        {
             "@id": "#Biosample-4",
             "@type": [
                 "bia:BioSample"
@@ -574,6 +559,14 @@
                 }
             ],
             "growthProtocol": null
+        },
+        {
+            "@id": "#tx1",
+            "@type": [
+                "bia:Taxon"
+            ],
+            "commonName": "zebra fish",
+            "scientificName": "Danio  rerio"
         },
         {
             "@id": "#Biosample-3",
@@ -610,6 +603,14 @@
             "growthProtocol": null
         },
         {
+            "@id": "#tx0",
+            "@type": [
+                "bia:Taxon"
+            ],
+            "commonName": "Homo sapiens",
+            "scientificName": "Human"
+        },
+        {
             "@id": "#Biosample-1%209094eed1-c332-4f45-add1-dc6e153ceb56",
             "@type": [
                 "bia:BioSample"
@@ -644,6 +645,14 @@
                 }
             ],
             "growthProtocol": null
+        },
+        {
+            "@id": "NCBI:txid7227",
+            "@type": [
+                "bia:Taxon"
+            ],
+            "commonName": "fruit fly",
+            "scientificName": "Drosophila melanogaster"
         },
         {
             "@id": "#_Specimen-2",

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_PROTOCOL_STUDY/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_PROTOCOL_STUDY/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BSST_PAGETAB_FILES/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BSST_PAGETAB_FILES/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {

--- a/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-IMAGELABELTEST/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-IMAGELABELTEST/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -264,8 +273,22 @@
             "accessionId": "EMPIAR-IMAGELABELTEST",
             "seeAlso": [],
             "relatedPublication": [
-                "https://doi.org/10.1038/s41592-022-01746-2"
+                {
+                    "@id": "https://doi.org/10.1038/s41592-022-01746-2"
+                }
             ]
+        },
+        {
+            "@id": "https://doi.org/10.1038/s41592-022-01746-2",
+            "@type": [
+                "ScholarlyArticle",
+                "bia:Publication"
+            ],
+            "title": null,
+            "authorNames": null,
+            "publicationYear": null,
+            "pubmedId": null,
+            "doi": "10.1038/s41592-022-01746-2"
         },
         {
             "@id": "#c0",

--- a/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-IMAGEPATTERNTEST/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-IMAGEPATTERNTEST/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -258,8 +267,22 @@
             "accessionId": "EMPIAR-IMAGEPATTERNTEST",
             "seeAlso": [],
             "relatedPublication": [
-                "https://doi.org/10.7554/eLife.83623"
+                {
+                    "@id": "https://doi.org/10.7554/eLife.83623"
+                }
             ]
+        },
+        {
+            "@id": "https://doi.org/10.7554/eLife.83623",
+            "@type": [
+                "ScholarlyArticle",
+                "bia:Publication"
+            ],
+            "title": null,
+            "authorNames": null,
+            "publicationYear": null,
+            "pubmedId": null,
+            "doi": "10.7554/eLife.83623"
         },
         {
             "@id": "#c0",

--- a/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-SPECIMENTEST/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-SPECIMENTEST/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -258,8 +267,22 @@
             "accessionId": "EMPIAR-SPECIMENTEST",
             "seeAlso": [],
             "relatedPublication": [
-                "https://doi.org/10.1016/j.molcel.2024.06.024"
+                {
+                    "@id": "https://doi.org/10.1016/j.molcel.2024.06.024"
+                }
             ]
+        },
+        {
+            "@id": "https://doi.org/10.1016/j.molcel.2024.06.024",
+            "@type": [
+                "ScholarlyArticle",
+                "bia:Publication"
+            ],
+            "title": null,
+            "authorNames": null,
+            "publicationYear": null,
+            "pubmedId": null,
+            "doi": "10.1016/j.molcel.2024.06.024"
         },
         {
             "@id": "#c0",

--- a/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/output_data/EMPIAR-STARFILETEST/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {
@@ -273,8 +282,22 @@
             "accessionId": "EMPIAR-STARFILETEST",
             "seeAlso": [],
             "relatedPublication": [
-                "https://doi.org/10.1038/s41592-023-02053-0"
+                {
+                    "@id": "https://doi.org/10.1038/s41592-023-02053-0"
+                }
             ]
+        },
+        {
+            "@id": "https://doi.org/10.1038/s41592-023-02053-0",
+            "@type": [
+                "ScholarlyArticle",
+                "bia:Publication"
+            ],
+            "title": null,
+            "authorNames": null,
+            "publicationYear": null,
+            "pubmedId": null,
+            "doi": "10.1038/s41592-023-02053-0"
         },
         {
             "@id": "https://orcid.org/9999-0001-2222-3333",

--- a/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_imagelabeltest.yaml
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_imagelabeltest.yaml
@@ -1,5 +1,5 @@
-accession_id: EMPIAR-IMAGELABELTEST
-paper_doi: https://doi.org/10.1038/s41592-022-01746-2
+accession_id: "EMPIAR-IMAGELABELTEST"
+paper_doi: "https://doi.org/10.1038/s41592-022-01746-2"
 rembis:
   ImageAcquisitionProtocol:
     - title: "Cryo-electron tomography"

--- a/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_imagepatterntest.yaml
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_imagepatterntest.yaml
@@ -1,5 +1,5 @@
-accession_id: EMPIAR-IMAGEPATTERNTEST
-paper_doi: https://doi.org/10.7554/eLife.83623
+accession_id: "EMPIAR-IMAGEPATTERNTEST"
+paper_doi: "https://doi.org/10.7554/eLife.83623"
 rembis:
   ImageAcquisitionProtocol:
     - title: "Cryo-serial pFIB/SEM"

--- a/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_specimentest.yaml
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_specimentest.yaml
@@ -1,5 +1,5 @@
-accession_id: EMPIAR-SPECIMENTEST
-paper_doi: https://doi.org/10.1016/j.molcel.2024.06.024
+accession_id: "EMPIAR-SPECIMENTEST"
+paper_doi: "https://doi.org/10.1016/j.molcel.2024.06.024"
 rembis:
   BioSample:
     - title: "S. cerevisiae"

--- a/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_starfiletest.yaml
+++ b/ro-crate-ingest/test/empiar_to_ro_crate/proposal/empiar_starfiletest.yaml
@@ -1,5 +1,5 @@
-accession_id: EMPIAR-STARFILETEST
-paper_doi: https://doi.org/10.1038/s41592-023-02053-0
+accession_id: "EMPIAR-STARFILETEST"
+paper_doi: "https://doi.org/10.1038/s41592-023-02053-0"
 rembis:
   ImageAcquisitionProtocol:
     - title: "Cryo-electron tomography"

--- a/ro-crate-ingest/test/minimal_ro_crate/output_data/EMPIAR-IMAGEPATTERNTEST/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/minimal_ro_crate/output_data/EMPIAR-IMAGEPATTERNTEST/ro-crate-metadata.json
@@ -101,6 +101,9 @@
             "displayName": {
                 "@id": "schema:name"
             },
+            "doi": {
+                "@id": "schema:identifier"
+            },
             "experimentalVariableDescription": {
                 "@id": "bia:experimentalVariableDescription"
             },
@@ -172,6 +175,12 @@
             },
             "protocolDescription": {
                 "@id": "schema:description"
+            },
+            "publicationYear": {
+                "@id": "bia:publicationYear"
+            },
+            "pubmedId": {
+                "@id": "bia:pubmedId"
             },
             "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
             "relatedPublication": {


### PR DESCRIPTION
Impromptu, no ticket. Continuing from [PR#534](https://github.com/BioImage-Archive/bia-integrator/pull/534/changes#diff-06656828c7e181d4365c196c8368b2fcee604e59f336fbcfa7e935171090e9f4), added: 

- Publication node to RO-Crate 
- Related processing code from empiar and in minimal RO-Crate
- Processing code in RO-Crate to API
- Adjusted test outputs
