### PR TITLE
Fix biosample title and multiple entity bugs

### DIFF
--- a/bia-ro-crate/bia_ro_crate/models/linked_data/pydantic_ld/ROCrateModel.py
+++ b/bia-ro-crate/bia_ro_crate/models/linked_data/pydantic_ld/ROCrateModel.py
@@ -66,6 +66,3 @@ class ROCrateModel(LDModel):
 
     def __hash__(self):
         return hash(self.id)
-
-    def __eq__(self, other):
-        return self.type == other.type and self.id == other.id

--- a/bia-ro-crate/bia_ro_crate/models/linked_data/pydantic_ld/ROCrateModel.py
+++ b/bia-ro-crate/bia_ro_crate/models/linked_data/pydantic_ld/ROCrateModel.py
@@ -63,3 +63,9 @@ class ROCrateModel(LDModel):
         graph.parse(data=json_ld_string, format="json-ld", publicID=f"{base_file_uri}")
 
         return graph
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.type == other.type and self.id == other.id

--- a/ro-crate-ingest/override_data/biostudies/S-BIADTEST_COMPLEX_BIOSAMPLE/S-BIADTEST_COMPLEX_BIOSAMPLE_override.json
+++ b/ro-crate-ingest/override_data/biostudies/S-BIADTEST_COMPLEX_BIOSAMPLE/S-BIADTEST_COMPLEX_BIOSAMPLE_override.json
@@ -252,8 +252,8 @@
             "value": "Another specimen without growth protocol"
           },
           {
-            "name": "Sample Preparation Protocol for specimen 3",
-            "value": "Followed step 1, 2 and 3"
+            "name": "Sample Preparation Protocol",
+            "value": "For specimen 3 - followed step 1, 2 and 3"
           }
         ]
       },

--- a/ro-crate-ingest/override_data/biostudies/S-BIADTEST_COMPLEX_BIOSAMPLE/S-BIADTEST_COMPLEX_BIOSAMPLE_override.json
+++ b/ro-crate-ingest/override_data/biostudies/S-BIADTEST_COMPLEX_BIOSAMPLE/S-BIADTEST_COMPLEX_BIOSAMPLE_override.json
@@ -244,6 +244,20 @@
         ]
       },
       {
+        "accno": "Specimen-3",
+        "type": "Specimen",
+        "attributes": [
+          {
+            "name": "Title",
+            "value": "Another specimen without growth protocol"
+          },
+          {
+            "name": "Sample Preparation Protocol for specimen 3",
+            "value": "Followed step 1, 2 and 3"
+          }
+        ]
+      },
+      {
         "accno": "Image Acquisition-1",
         "type": "Image Acquisition",
         "attributes": [
@@ -417,6 +431,61 @@
               {
                 "name": "Specimen",
                 "value": "Specimen without growth protocol"
+              },
+              {
+                "name": "Image acquisition",
+                "value": "Image Acquisition 1 Title"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "accno": "Study Component-4",
+        "type": "Study Component",
+        "attributes": [
+          {
+            "name": "Name",
+            "value": "Component 4"
+          },
+          {
+            "name": "Description",
+            "value": "Has 2 associations with the two specimens pointing to same biosample - to test multiple entity bug."
+          },
+          {
+            "name": "File List",
+            "value": "file_list_test_4.json"
+          }
+        ],
+        "subsections": [
+          {
+            "type": "Associations",
+            "attributes": [
+              {
+                "name": "Biosample",
+                "value": "Biosample with organism attribute"
+              },
+              {
+                "name": "Specimen",
+                "value": "Specimen without growth protocol"
+              },
+              {
+                "name": "Image acquisition",
+                "value": "Image Acquisition 1 Title"
+              }
+            ]
+          },
+          {
+            "type": "Associations",
+            "attributes": [
+              {
+                "name": "Biosample",
+                "value": "Biosample with organism attribute"
+              },
+              {
+                "name": "Specimen",
+                "value": "Another specimen without growth protocol"
+
               },
               {
                 "name": "Image acquisition",

--- a/ro-crate-ingest/override_data/biostudies/S-BIADTEST_COMPLEX_BIOSAMPLE/file_list_test_4.json
+++ b/ro-crate-ingest/override_data/biostudies/S-BIADTEST_COMPLEX_BIOSAMPLE/file_list_test_4.json
@@ -1,0 +1,32 @@
+[
+  {
+    "path": "folder4/file1.ome.zarr.zip",
+    "size": 24628037,
+    "attributes": [
+      {
+        "name": "Genotype/Line",
+        "value": "; ubiCAAX-GFP/+ ; neuPH-RFP/+"
+      },
+      {
+        "name": "Channel 1",
+        "value": "CAAX"
+      }
+    ],
+    "type": "file"
+  },
+  {
+    "path": "folder4/file2.ome.zarr.zip",
+    "size": 13161534,
+    "attributes": [
+      {
+        "name": "Genotype/Line",
+        "value": "; ubiCAAX-GFP/+ ; neuPH-RFP/+"
+      },
+      {
+        "name": "Channel 1",
+        "value": "CAAX"
+      }
+    ],
+    "type": "file"
+  }
+]

--- a/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/entity_conversion/dataset.py
+++ b/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/entity_conversion/dataset.py
@@ -192,9 +192,9 @@ def get_association_fields(
         )
 
         if roc_bio_sample_id:
-            association_ro_crate_fields["associatedBiologicalEntity"].append(
-                {"@id": roc_bio_sample_id}
-            )
+            id = {"@id": roc_bio_sample_id}
+            if id not in association_ro_crate_fields["associatedBiologicalEntity"]:
+                association_ro_crate_fields["associatedBiologicalEntity"].append(id)
 
     return association_ro_crate_fields
 

--- a/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/entity_conversion/rembi_mifa_mapping/base_mapper.py
+++ b/ro-crate-ingest/ro_crate_ingest/biostudies_to_ro_crate/entity_conversion/rembi_mifa_mapping/base_mapper.py
@@ -26,7 +26,20 @@ class Mapper(ABC):
         raise NotImplementedError
 
     def get_mapped_objects(
-        self, submission: Submission, association_map: dict[type, dict[str, str]]
+        self,
+        submission: Submission,
+        association_map: dict[type, dict[str, str]],
+        unique: bool = True,
     ) -> list[ROCrateModel]:
         self.map(submission, association_map)
-        return self.mapped_object
+
+        if unique:
+            try:
+                return list(set(self.mapped_object))
+            # Account for objects that cannot be hashed (e.g. Taxon)
+            except TypeError as e:
+                raise (e)
+                logging.debug(f"Cannot create set -> {e}. Not checking for uniqueness")
+                return self.mapped_object
+        else:
+            return self.mapped_object

--- a/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/bio_sample.py
+++ b/ro-crate-ingest/ro_crate_ingest/ro_crate_to_api/entity_conversion/bio_sample.py
@@ -34,7 +34,6 @@ def convert_bio_sample(
     crate_objects_by_id: dict[str, ROCrateModel],
     study_uuid: str,
 ) -> APIModels.BioSample:
-
     taxons = []
     for taxon_reference in ro_crate_bio_sample.organismClassification:
         taxons.append(convert_taxon(crate_objects_by_id[taxon_reference.id]))
@@ -49,7 +48,7 @@ def convert_bio_sample(
 
     bio_sample = {
         "uuid": str(uuid),
-        "title": ro_crate_bio_sample.id,
+        "title": ro_crate_bio_sample.title,
         "version": 0,
         "organism_classification": taxons,
         "biological_entity_description": ro_crate_bio_sample.biologicalEntityDescription,

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMPLEX_BIOSAMPLE/combined_file_list.tsv
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMPLEX_BIOSAMPLE/combined_file_list.tsv
@@ -5,3 +5,5 @@ folder2/file1.ome.zarr.zip	24628037	file	#Study%20Component-2	; ubiCAAX-GFP/+ ; 
 folder2/file2.ome.zarr.zip	13161534	file	#Study%20Component-2	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX
 folder3/file1.ome.zarr.zip	24628037	file	#Study%20Component-3	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX
 folder3/file2.ome.zarr.zip	13161534	file	#Study%20Component-3	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX
+folder4/file1.ome.zarr.zip	24628037	file	#Study%20Component-4	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX
+folder4/file2.ome.zarr.zip	13161534	file	#Study%20Component-4	; ubiCAAX-GFP/+ ; neuPH-RFP/+	CAAX

--- a/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMPLEX_BIOSAMPLE/ro-crate-metadata.json
+++ b/ro-crate-ingest/test/biostudies_to_ro_crate/output_data/S-BIADTEST_COMPLEX_BIOSAMPLE/ro-crate-metadata.json
@@ -267,6 +267,9 @@
                     "@id": "#Study%20Component-3"
                 },
                 {
+                    "@id": "#Study%20Component-4"
+                },
+                {
                     "@id": "combined_file_list.tsv"
                 }
             ],
@@ -409,6 +412,41 @@
             "propertyUrl": "http://bia/filePath"
         },
         {
+            "@id": "#Study%20Component-4",
+            "@type": [
+                "Dataset",
+                "bia:Dataset"
+            ],
+            "name": "Component 4",
+            "description": "Has 2 associations with the two specimens pointing to same biosample - to test multiple entity bug.",
+            "associatedBiologicalEntity": [
+                {
+                    "@id": "#Biosample-2"
+                }
+            ],
+            "associatedSpecimenImagingPreparationProtocol": [
+                {
+                    "@id": "#Specimen-1"
+                },
+                {
+                    "@id": "#Specimen-3"
+                }
+            ],
+            "associatedSpecimen": null,
+            "associatedCreationProcess": null,
+            "associatedSourceImage": [],
+            "associatedImageAcquisitionProtocol": [
+                {
+                    "@id": "#Image%20Acquisition-1"
+                }
+            ],
+            "associatedAnnotationMethod": [],
+            "associatedImageAnalysisMethod": [],
+            "associatedImageCorrelationMethod": [],
+            "associatedProtocol": [],
+            "hasPart": []
+        },
+        {
             "@id": "#Study%20Component-3",
             "@type": [
                 "Dataset",
@@ -524,6 +562,15 @@
             "fbbiId": [
                 "http://purl.obolibrary.org/obo/FBbi_00000251"
             ]
+        },
+        {
+            "@id": "#Specimen-3",
+            "@type": [
+                "bia:SpecimenImagingPreparationProtocol"
+            ],
+            "title": "Another specimen without growth protocol",
+            "protocolDescription": "For specimen 3 - followed step 1, 2 and 3",
+            "signalChannelInformation": []
         },
         {
             "@id": "#Specimen-2",


### PR DESCRIPTION
Fix minor bug correcting title of biosample in roc->api. Fix bug to prevent creation of duplicate objects in roc. Clickup tickets: [https://app.clickup.com/t/869cu9zp8](https://app.clickup.com/t/869cu9zp8) and [https://app.clickup.com/t/869cn3gzu](https://app.clickup.com/t/869cn3gzu).

This PR supercedes [PR552](https://github.com/BioImage-Archive/bia-integrator/pull/552) that was shelved due to comments during review.